### PR TITLE
Add null checks to ColladaMeshShape.java

### DIFF
--- a/src/gov/nasa/worldwind/ogc/collada/impl/ColladaMeshShape.java
+++ b/src/gov/nasa/worldwind/ogc/collada/impl/ColladaMeshShape.java
@@ -1192,6 +1192,9 @@ public class ColladaMeshShape extends AbstractGeneralShape
      */
     protected String getTextureSource(ColladaAbstractGeometry geometry)
     {
+        if (this.bindMaterial == null)
+            return null;
+        
         ColladaTechniqueCommon techniqueCommon = this.bindMaterial.getTechniqueCommon();
         if (techniqueCommon == null)
             return null;
@@ -1297,7 +1300,10 @@ public class ColladaMeshShape extends AbstractGeneralShape
      *         available.
      */
     protected ColladaEffect getEffect(ColladaAbstractGeometry geometry)
-    {
+    {   
+        if (this.bindMaterial == null)
+            return null;
+            
         ColladaTechniqueCommon techniqueCommon = this.bindMaterial.getTechniqueCommon();
         if (techniqueCommon == null)
             return null;


### PR DESCRIPTION
### Description of the Change
Additional null-checks to ColladaMeshShape to allow for Collada models without textures to be loaded.

### Why Should This Be In Core?
This is a simple oversight that should have been included in the initial class. The null-check is already present in the getInstanceMaterial() method. Adding it to getTextureSource() and getEffect() allows for Collada models without textures to be loaded.

### Benefits
Collada models without textures can now be imported from Cinema 4D.

### Potential Drawbacks
None

### Applicable Issues
None