### PR TITLE
Fix issue if no positions in PhaseLine determineLabelPositions method.

### DIFF
--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/PhaseLine.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/PhaseLine.java
@@ -186,7 +186,11 @@ public class PhaseLine extends AbstractMilStd2525TacticalGraphic
     @Override
     protected void determineLabelPositions(DrawContext dc)
     {
-        Iterator<? extends Position> iterator = this.path.getPositions().iterator();
+		Iterable<? extends Position> positions = this.path.getPositions();
+        if (positions == null)
+            return;
+	
+        Iterator<? extends Position> iterator = positions.iterator();
 
         // Find the first and last positions on the path
         Position first = iterator.next();


### PR DESCRIPTION
### Description of the Change
The MilStd2525GraphicFactory class can create graphics without positions. As a result of this there is a bug in the PhaseLine class where a NPE is thrown.

### Why Should This Be In Core?
The null-pointer check is an oversight that should have been in the original class.

### Benefits
General stability of MilStd2525-related classes.

### Potential Drawbacks
None

### Applicable Issues
None