### PR TITLE
Correct test for DTED file extension

### DIFF
--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallDTED.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallDTED.java
@@ -148,9 +148,9 @@ public class InstallDTED extends ApplicationTemplate
                 {
                     this.findDTEDFiles(file, files);
                 }
-                else if (file.getName().endsWith("dt0")
-                    || file.getName().endsWith("dt1")
-                    || file.getName().endsWith("dt2"))
+                else if (file.getName().toLowerCase().endsWith("dt0")
+                    || file.getName().toLowerCase().endsWith("dt1")
+                    || file.getName().toLowerCase().endsWith("dt2"))
                 {
                     files.add(file);
                 }


### PR DESCRIPTION
### Description of the Change
Original pull-request of @gbburkhardt (see: https://github.com/NASAWorldWind/WorldWindJava/pull/137) with a fix in the InstallDTED class to allow for DTED files with upper or lowercase file extensions to be used.

### Why Should This Be In Core?
This is a simple oversight that should have been included in the original class.

### Benefits
Allow for DTED files with upper or lowercase file extensions to be used in the installDTED example class.

### Potential Drawbacks
None

### Applicable Issues
None