### PR TITLE
Fixed AVKey misspelling.

### DIFF
--- a/src/gov/nasa/worldwind/avlist/AVKey.java
+++ b/src/gov/nasa/worldwind/avlist/AVKey.java
@@ -417,7 +417,7 @@ public interface AVKey // TODO: Eliminate unused constants, if any
     final String SIZE_FIT_TEXT = "gov.nasa.worldwind.avkey.SizeFitText";
     final String SIZE_FIXED = "gov.nasa.worldwind.avkey.SizeFixed";
     final String SPATIAL_REFERENCE_WKT = "gov.nasa.worldwind.avkey.SpatialReference.WKT";
-    final String SOUTH = "gov.nasa.worldwdind.avkey.South";
+    final String SOUTH = "gov.nasa.worldwind.avkey.South";
     final String START = "gov.nasa.worldwind.avkey.Start";
     final String STEREO_FOCUS_ANGLE = "gov.nasa.worldwind.StereoFocusAngle";
     final String STEREO_INTEROCULAR_DISTANCE = "gov.nasa.worldwind.StereoFInterocularDistance";


### PR DESCRIPTION
### Description of the Change
Migrated original pull-request of @andrewmcloud (see: https://github.com/NASAWorldWind/WorldWindJava/pull/130) here.

### Why Should This Be In Core?
Fixes spelling error that have been missed.

### Benefits
Code-base with less spelling errors, I guess?

### Potential Drawbacks
None

### Applicable Issues
None