### PR TITLE
Correct typographical error in DTED Level 2 RPF

### DIFF
--- a/src/gov/nasa/worldwind/formats/rpf/RPFDataSeries.java
+++ b/src/gov/nasa/worldwind/formats/rpf/RPFDataSeries.java
@@ -95,7 +95,7 @@ public enum RPFDataSeries
     DATA_SERIES_I5("I5", "---", ".5m", "Imagery, .5 (half) meter resolution", "CIB", 0.5),
     DATA_SERIES_IV("IV", "---", "Various>10m", "Imagery, greater than 10 meter resolution", "CIB", -1),
     DATA_SERIES_D1("D1", "---", "100m", "Elevation Data from DTED level 1", "CDTED", 100.0),
-    DATA_SERIES_D2("D1", "---", "30m", "Elevation Data from DTED level 2", "CDTED", 30.0),
+    DATA_SERIES_D2("D2", "---", "30m", "Elevation Data from DTED level 2", "CDTED", 30.0),
     /* [Chart.php] */
     DATA_SERIES_TF("TF", "---", "1:250000", "Transit Fly (UK)", "CADRG", 250000),
     ;


### PR DESCRIPTION
### Description of the Change
Migrated the original pull-request from @rhstone (see pull-request: https://github.com/NASAWorldWind/WorldWindJava/pull/98 and the corresponding issue: https://github.com/NASAWorldWind/WorldWindJava/issues/99). According to the original [forum-post](https://forum.worldwindcentral.com/forum/world-wind-java-forums/development-help/156945-bug-in-rpfdataseries):

> There seems to be duplicate entries in enum RPFDataSeries for DATA_SERIES_D1 and DATA_SERIES_D1. Both have "D1" as and entry for the series code. We are having a problem with world wind displaying the wrong altitude with two different DTED levels. I'm using version 1586.0.0.1. Does anyone know if this is this a known bug? If so, has this been fixed in subsequent versions?

### Why Should This Be In Core?
This fixes a bug where WorldWind displays the wrong altitude for two different DTED levels. Looks like a small oversight in the original code.

### Benefits
Correct altitude values are displayed for DTED levels.

### Potential Drawbacks
None

### Applicable Issues
None