### PR TITLE
Fixed JavaDoc errors and warnings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,7 @@
         <javadoc destdir="${worldwind.doc.dir}/javadoc"
                  overview="${worldwind.src.dir}/overview.html"
                  encoding="UTF-8"
-                 windowtitle="NASA WorldWind" doctitle="NASA WorldWind" header="NASA WorldWind"
+                 windowtitle="WorldWindJava API" doctitle="NASA WorldWind Java-Community Edition" header="NASA WorldWind-CE"
                  splitindex="true" protected="true" nodeprecated="true" version="false" author="false" use="true"
                  maxmemory="1024m">
             <packageset dir="${worldwind.src.dir}" defaultexcludes="yes">

--- a/src/gov/nasa/worldwind/AbstractSceneController.java
+++ b/src/gov/nasa/worldwind/AbstractSceneController.java
@@ -1073,7 +1073,7 @@ public abstract class AbstractSceneController extends WWObjectImpl implements Sc
      * gov.nasa.worldwind.render.SurfaceObject#render(gov.nasa.worldwind.render.DrawContext)} in ordered rendering mode.
      * This does nothing if the ordered surface renderable queue is empty, or if it does not contain any
      * SurfaceObjects.
-     * <p/>
+     * <p>
      * This method is called during the preRender phase, and is therefore free to modify the framebuffer contents to
      * create the composite representation.
      *

--- a/src/gov/nasa/worldwind/BasicFactory.java
+++ b/src/gov/nasa/worldwind/BasicFactory.java
@@ -94,7 +94,7 @@ public class BasicFactory implements Factory
      * <li>{@link gov.nasa.worldwind.ogc.wcs.wcs100.WCS100Capabilities}</li>
      * <li>{@link String} holding a file name, a name of a resource on the classpath, or a string representation of a
      * URL</li></ul>
-     * <p/>
+     * <p>
      *
      * @param configSource the configuration source. See above for supported types.
      * @param params       key-value parameters to override or supplement the information provided in the specified

--- a/src/gov/nasa/worldwind/BasicModel.java
+++ b/src/gov/nasa/worldwind/BasicModel.java
@@ -244,7 +244,7 @@ public class BasicModel extends WWObjectImpl implements Model
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * This implementation forwards the message each layer in the model.
      *
      * @param msg The message that was received.

--- a/src/gov/nasa/worldwind/Configuration.java
+++ b/src/gov/nasa/worldwind/Configuration.java
@@ -22,35 +22,35 @@ import java.util.logging.Level;
  * contents. Configurations files contain the names of classes to create at run-time, the initial model definition,
  * including the globe, elevation model and layers, and various control quantities such as cache sizes and data
  * retrieval timeouts.
- * <p/>
+ * <p>
  * The Configuration class is a singleton, but its instance is not exposed publicly. It is addressed only via static
  * methods of the class. It is constructed upon first use of any of its static methods.
- * <p/>
+ * <p>
  * When the Configuration class is first instantiated it reads the XML document <code>config/worldwind.xml</code> and
  * registers all the information there. The information can subsequently be retrieved via the class' various
  * <code>getValue</code> methods. Many WorldWind start-up objects query this information to determine the classes to
  * create. For example, the first WorldWind object created by an application is typically a {@link
  * gov.nasa.worldwind.awt.WorldWindowGLCanvas}. During construction that class causes WorldWind's internal classes to
  * be constructed, using the names of those classes drawn from the Configuration singleton, this class.
- * <p/>
+ * <p>
  * The default WorldWind configuration document is <code>config/worldwind.xml</code>. This can be changed by setting
  * the Java property <code>gov.nasa.worldwind.config.file</code> to a different file name or a valid URL prior to
  * creating any WorldWind object or invoking any static methods of WorldWind classes, including the Configuration
  * class. When an application specifies a different configuration location it typically does so in its main method prior
  * to using WorldWind. If a file is specified its location must be on the classpath. (The contents of application and
  * WorldWind jar files are typically on the classpath, in which case the configuration file may be in the jar file.)
- * <p/>
+ * <p>
  * Additionally, an application may set another Java property, <code>gov.nasa.worldwind.app.config.document</code>, to a
  * file name or URL whose contents contain configuration values to override those of the primary configuration document.
  * WorldWind overrides only those values in this application document, it leaves all others to the value specified in
  * the primary document. Applications usually specify an override document in order to specify the initial layers in the
  * model.
- * <p/>
+ * <p>
  * See <code>config/worldwind.xml</code> for documentation on setting configuration values.
- * <p/>
+ * <p>
  * Configuration values can also be set programatically via {@link Configuration#setValue(String, Object)}, but they are
  * not retroactive so affect only Configuration queries made subsequent to setting the value.
- * <p/>
+ * <p>
  * <em>Note:</em> Prior to September of 2009, configuration properties were read from the file
  * <code>config/worldwind.properties</code>. An alternate file could be specified via the
  * <code>gov.nasa.worldwind.config.file</code> Java property. These mechanisms remain available but are deprecated.
@@ -381,7 +381,7 @@ public class Configuration // Singleton
 
     /**
      * Return as a Boolean the value associated with a specified key.
-     * <p/>
+     * <p>
      * Valid values for true are '1' or anything that starts with 't' or 'T'. ie. 'true', 'True', 't' Valid values for
      * false are '0' or anything that starts with 'f' or 'F'. ie. 'false', 'False', 'f'
      *
@@ -399,7 +399,7 @@ public class Configuration // Singleton
 
     /**
      * Return as a Boolean the value associated with a specified key.
-     * <p/>
+     * <p>
      * Valid values for true are '1' or anything that starts with 't' or 'T'. ie. 'true', 'True', 't' Valid values for
      * false are '0' or anything that starts with 'f' or 'F'. ie. 'false', 'False', 'f'
      *
@@ -502,10 +502,12 @@ public class Configuration // Singleton
      * Returns the path to the current user's application data directory. The path returned depends on the operating
      * system on which the Java Virtual Machine is running. The following table provides the path for all supported
      * operating systems:
-     * <p/>
-     * <table> <tr><th>Operating System</th><th>Path</th></tr> <tr><td>Mac OS X</td><td>~/Library/Application
-     * Support</td></tr> <tr><td>Windows</td><td>~\\Application Data</td></tr> <tr><td>Linux, Unix,
-     * Solaris</td><td>~/</td></tr> </table>
+     * <table><caption>Returned Paths</caption>
+     * <tr><th>Operating System</th><th>Path</th></tr> 
+     * <tr><td>Mac OS X</td><td>~/Library/Application Support</td></tr> 
+     * <tr><td>Windows</td><td>~\\Application Data</td></tr> 
+     * <tr><td>Linux, Unix, Solaris</td><td>~/</td></tr> 
+     * </table>
      *
      * @return the absolute path to the current user's application data directory.
      */
@@ -647,9 +649,11 @@ public class Configuration // Singleton
      * Returns the highest OpenGL profile available on the current graphics device that is compatible with WorldWind.
      * The returned profile favors hardware acceleration over software acceleration. With JOGL version 2.0, this returns
      * the highest available profile from the following list:
-     * <p/>
-     * <ul> <li>OpenGL compatibility profile 4.x</li> <li>OpenGL compatibility profile 3.x</li> <li>OpenGL profile 1.x
-     * up to 3.0</li> </ul>
+     * <ul> 
+     * <li>OpenGL compatibility profile 4.x</li> 
+     * <li>OpenGL compatibility profile 3.x</li> 
+     * <li>OpenGL profile 1.x up to 3.0</li> 
+     * </ul>
      *
      * @return the highest compatible OpenGL profile.
      */

--- a/src/gov/nasa/worldwind/Exportable.java
+++ b/src/gov/nasa/worldwind/Exportable.java
@@ -12,13 +12,13 @@ import java.io.IOException;
  * Exportable marks an object that can be exported in different data formats. Implementing classes may support one or
  * more export formats. Formats are identified by MIME type. Call {@link #isExportFormatSupported(String)} to determine
  * if an object supports export in a certain format.
- * <p/>
+ * <p>
  * Example of use:
- * <p/>
+ * 
  * <pre>
  * // Export a PointPlacemark in KML format
  * PointPlacemark placemark;
- * <p/>
+ * 
  * StringWriter kml = new StringWriter();
  * placemark.export(KMLConstants.KML_MIME_TYPE, kml);
  * </pre>

--- a/src/gov/nasa/worldwind/SceneController.java
+++ b/src/gov/nasa/worldwind/SceneController.java
@@ -109,7 +109,7 @@ public interface SceneController extends WWObject, Disposable
      * Specifies the current pick point in AWT screen coordinates, or <code>null</code> to indicate that there is no
      * pick point. Each frame, this scene controller determines which objects are drawn at the pick point and places
      * them in a PickedObjectList. This list can be accessed by calling {@link #getPickedObjectList()}.
-     * <p/>
+     * <p>
      * If the pick point is <code>null</code>, this scene controller ignores the pick point and the list of objects
      * returned by getPickedObjectList is empty.
      *
@@ -130,7 +130,7 @@ public interface SceneController extends WWObject, Disposable
      * Specifies the current pick rectangle in AWT screen coordinates, or <code>null</code> to indicate that there is no
      * pick rectangle. Each frame, this scene controller determines which objects intersect the pick rectangle and
      * places them in a PickedObjectList. This list can be accessed by calling {@link #getObjectsInPickRectangle()}.
-     * <p/>
+     * <p>
      * If the pick rectangle is <code>null</code>, this scene controller ignores the pick rectangle and the list of
      * objects returned by getObjectsInPickRectangle is empty.
      *

--- a/src/gov/nasa/worldwind/StereoOptionSceneController.java
+++ b/src/gov/nasa/worldwind/StereoOptionSceneController.java
@@ -15,18 +15,17 @@ import com.jogamp.opengl.*;
 /**
  * TODO: This file needs to be updated to implement "correct" stereo, as described at:
  * http://www.orthostereo.com/geometryopengl.html
- * <p/>
- * <p/>
+ * <p>
  * This scene controller draws in stereo, either red-blue anaglyph or device supported if the display device provides
  * stereo directly. It can also draw without applying stereo. To select stereo, prior to calling this class' constructor
  * set the Java VM property <code>gov.nasa.worldwind.stereo.mode</code> to "device" for device supported stereo (if
  * provided by the device) or "redblue" for red-blue anaglyph stereo. If the property is not set or is any other value,
  * this class does not draw in stereo.
- * <p/>
+ * <p>
  * The {@link WorldWindow} instance must support stereo in order to use device-supported stereo. A stereo
  * <code>WorldWindow</code> is selected by specifying the Java VM property described above prior to creating it. See
  * {@link gov.nasa.worldwind.awt.WorldWindowGLCanvas} for further details.
- * <p/>
+ * <p>
  * Note: The logic and much of the code here was contributed by Xander Enzmann of Mitre Corporation.
  *
  * @author tag
@@ -114,7 +113,7 @@ public class StereoOptionSceneController extends BasicSceneController implements
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * If the display device is providing stereo -- {@link #isHardwareStereo()} is <code>true</code> -- this method
      * returns true even if the stereo mode is {@link AVKey#STEREO_MODE_NONE}. In this case, individual stereo images
      * are drawn for left and right eyes in order to prevent a blurred scene.
@@ -158,7 +157,7 @@ public class StereoOptionSceneController extends BasicSceneController implements
 
     /**
      * Implement no stereo ("Mono") while using a stereo device.
-     * <p/>
+     * <p>
      * Note that this method draws the image twice, once to each of the left and right eye buffers, even when stereo is
      * not in effect. This is to prevent the stereo device from drawing blurred scenes.
      *

--- a/src/gov/nasa/worldwind/StereoSceneController.java
+++ b/src/gov/nasa/worldwind/StereoSceneController.java
@@ -10,7 +10,7 @@ import gov.nasa.worldwind.geom.Angle;
 
 /**
  * An interface for scene controllers that provide stereo.
- * <p/>
+ * <p>
  * Note: The {@link WorldWindow} instance must support stereo display in order to use device-supported stereo. See
  * {@link gov.nasa.worldwind.awt.WorldWindowGLCanvas} to learn how to select a stereo device.
  *
@@ -24,10 +24,10 @@ public interface StereoSceneController extends SceneController
      * gov.nasa.worldwind.avlist.AVKey#STEREO_MODE_DEVICE} to request device supported stereo, {@link
      * gov.nasa.worldwind.avlist.AVKey#STEREO_MODE_RED_BLUE} to request red-blue anaglyph stereo implemented in
      * software, or {@link gov.nasa.worldwind.avlist.AVKey#STEREO_MODE_NONE} (the default) to request no stereo effect.
-     * <p/>
+     * <p>
      * If <code>STEREO_MODE_DEVICE</code> is requested but the display device does not support stereo, stereo is not
      * applied.
-     * <p/>
+     * <p>
      * See the implementing class to determine how it detects the initial stereo mode.
      *
      * @param mode the technique used to provide the stereo effect. If null, the mode is set to {@link

--- a/src/gov/nasa/worldwind/View.java
+++ b/src/gov/nasa/worldwind/View.java
@@ -18,19 +18,21 @@ import gov.nasa.worldwind.view.ViewPropertyLimits;
  * follows the OpenGL convention of a right-handed coordinate system with the origin at the eye point and looking down
  * the negative Z axis. <code>View</code> also provides a transformation from eye coordinates to screen coordinates,
  * following the OpenGL convention of an origin in the lower left hand screen corner.
- * <p/>
+ * <p>
  * Most of the accessor and computation methods on <code>View</code> will use viewing state computed in the last call to
  * {@link #apply(gov.nasa.worldwind.render.DrawContext) apply}.
- * <p/>
- * The following methods return state values <i>updated in the most recent call to apply</i>. <code> <ul>
- * <li>getEyePosition</li> <li>getEyePoint</li> <li>getUpVector</li> <li>getForwardVector</li>
- * <li>getModelviewMatrix</li> <li>getViewport</li> <li>getFrustum</li> <li>getFrustumInModelCoordinates</li>
- * <li>getProjectionMatrix</li> </code> </ul>
- * <p/>
+ * <p>
+ * The following methods return state values <i>updated in the most recent call to apply</i>.<ul>
+ * <li><code>getEyePosition</code></li> <li><code>getEyePoint</code></li> 
+ * <li><code>getUpVector</code></li> <li><code>getForwardVector</code></li> 
+ * <li><code>getModelviewMatrix</code></li> <li><code>getViewport</code></li> 
+ * <li><code>getFrustum</code></li> <li><code>getFrustumInModelCoordinates</code></li> 
+ * <li><code>getProjectionMatrix</code></li> </ul> 
+ * <p>
  * The following methods return computed values using state that was updated in the most recent call to
- * <code>apply</code>. <code> <ul> <li>project</li> <li>unproject</li> <li>computeRayFromScreenPoint</li>
+ * <code>apply</code>. <ul> 
+ * <li>project</li> <li>unproject</li> <li>computeRayFromScreenPoint</li>
  * <li>computePositionFromScreenPoint</li> <li>computePixelSizeAtDistance</li> <li>computeHorizonDistance</li> </ul>
- * </code>
  *
  * @author Paul Collins
  * @version $Id: View.java 1171 2013-02-11 21:45:02Z dcollins $
@@ -47,7 +49,7 @@ public interface View extends WWObject, Restorable
     /**
      * Returns the current geographic coordinates of this view's eye position, as computed for the most recent model
      * traversal.
-     * <p/>
+     * <p>
      * Note: The value returned is not necessarily the value specified to {@link #setEyePosition(gov.nasa.worldwind.geom.Position)}
      * but is the eye position corresponding to this view's most recently applied state.
      *
@@ -68,7 +70,7 @@ public interface View extends WWObject, Restorable
     /**
      * Returns the current geographic coordinates of this view's eye position, as determined from this view's current
      * parameters.
-     * <p/>
+     * <p>
      * Note: The value returned is not necessarily the value specified to {@link #setEyePosition(gov.nasa.worldwind.geom.Position)}
      * but is the eye position corresponding to this view's current parameters.
      *

--- a/src/gov/nasa/worldwind/WorldWind.java
+++ b/src/gov/nasa/worldwind/WorldWind.java
@@ -96,13 +96,13 @@ public final class WorldWind
     /**
      * Reinitialize WorldWind to its initial ready state. Shut down and restart all WorldWind services and clear all
      * WorldWind memory caches. Cache memory will be released at the next JVM garbage collection.
-     * <p/>
+     * <p>
      * Call this method to reduce WorldWind's current resource usage to its initial, empty state.
-     * <p/>
+     * <p>
      * The state of any open {@link WorldWindow} objects is indeterminate subsequent to invocation of this method. The
      * core WorldWindow objects attempt to shut themselves down cleanly during the call, but their resulting window
      * state is undefined.
-     * <p/>
+     * <p>
      * WorldWind can continue to be used after calling this method.
      */
     public static synchronized void shutDown()
@@ -232,7 +232,7 @@ public final class WorldWind
      * @return the new component
      *
      * @throws IllegalStateException    if no name could be found which corresponds to <code>classNameKey</code>
-     * @throws IllegalArgumentException if <code>classNameKey<code> is null
+     * @throws IllegalArgumentException if <code>classNameKey</code> is null
      * @throws WWRuntimeException       if the component could not be created
      */
     public static Object createConfigurationComponent(String classNameKey)

--- a/src/gov/nasa/worldwind/WorldWindow.java
+++ b/src/gov/nasa/worldwind/WorldWindow.java
@@ -185,7 +185,7 @@ public interface WorldWindow extends AVList
 
     /**
      * Returns the GPU Resource used by this WorldWindow. This method is for internal use only.
-     * <p/>
+     * <p>
      * Note: Applications do not need to interact with the GPU resource cache. It is self managed. Modifying it in any
      * way will cause significant problems such as excessive memory usage or application crashes. The only reason to use
      * the GPU resource cache is to request management of GPU resources within implementations of shapes or layers. And

--- a/src/gov/nasa/worldwind/WorldWindowGLAutoDrawable.java
+++ b/src/gov/nasa/worldwind/WorldWindowGLAutoDrawable.java
@@ -255,14 +255,16 @@ public class WorldWindowGLAutoDrawable extends WorldWindowImpl implements WorldW
 
     /**
      * See {@link GLEventListener#init(GLAutoDrawable)}.
-     * <p/>
+     * <p>
      * GLEventListener's dispose method indicates that the GL context has been released, and provides the listener an
      * opportunity to clean up any resources. Dispose does not imply that the component's lifecycle has ended or that
      * the application is closing. There are three cases in which dispose may be called:
-     * <p/>
-     * <ul> <li>The WorldWindow is removed from its parent component.</li> <li>The WorldWindow's parent frame is
-     * closed.</li> <li>The application calls either GLCanvas.dispose or GLJPanel.dispose.</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>The WorldWindow is removed from its parent component.</li> 
+     * <li>The WorldWindow's parent frame is closed.</li> 
+     * <li>The application calls either GLCanvas.dispose or GLJPanel.dispose.</li> 
+     * </ul>
+     * <p>
      * This implementation is left empty. In the case when a WorldWindow or a WorldWind application has reached its end
      * of life, its resources should be released by calling {@link gov.nasa.worldwind.WorldWindow#shutdown()} or {@link
      * gov.nasa.worldwind.WorldWind#shutDown()}, respectively. In the case when a WorldWindow is removed from its parent
@@ -530,7 +532,7 @@ public class WorldWindowGLAutoDrawable extends WorldWindowImpl implements WorldW
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Forward the message event to the Model for distribution to the layers.
      *
      * @param msg Message event.

--- a/src/gov/nasa/worldwind/animation/AnimationSupport.java
+++ b/src/gov/nasa/worldwind/animation/AnimationSupport.java
@@ -80,7 +80,7 @@ public class AnimationSupport
      * Calculate the angular ratio between two angles
      * @param x The numerator
      * @param y The denominator
-     * @return The angular ratio of <code>x/y></code>
+     * @return The angular ratio of {@code x/y> }
      */
     public static double angularRatio(Angle x, Angle y)
     {

--- a/src/gov/nasa/worldwind/avlist/AVListImpl.java
+++ b/src/gov/nasa/worldwind/avlist/AVListImpl.java
@@ -16,7 +16,7 @@ import java.util.logging.Level;
  * An implementation class for the {@link AVList} interface. Classes implementing <code>AVList</code> can subclass or
  * aggregate this class to provide default <code>AVList</code> functionality. This class maintains a hash table of
  * attribute-value pairs.
- * <p/>
+ * <p>
  * This class implements a notification mechanism for attribute-value changes. The mechanism provides a means for
  * objects to observe attribute changes or queries for certain keys without explicitly monitoring all keys. See {@link
  * java.beans.PropertyChangeSupport}.

--- a/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
@@ -24,14 +24,14 @@ import java.util.*;
  * <code>WorldWindowGLCanvas</code> is a heavyweight AWT component for displaying WorldWind {@link Model}s (globe and
  * layers). It's a self-contained component intended to serve as an application's <code>WorldWindow</code>. Construction
  * options exist to specify a specific graphics device and to share graphics resources with another graphics device.
- * <p/>
+ * <p>
  * Heavyweight AWT components such as instances of this class can be used in conjunction with lightweight Swing
  * components. A discussion of doing so is in the <em>Heavyweight and Lightweight Issues</em> section of the <a
  * href="http://download.java.net/media/jogl/doc/userguide/">"JOGL User's Guide"</a>. All that's typically necessary is
  * to invoke the following methods of the indicated Swing classes: {@link javax.swing.ToolTipManager#setLightWeightPopupEnabled(boolean)},
  * {@link javax.swing.JPopupMenu#setLightWeightPopupEnabled(boolean)} and {@link javax.swing.JPopupMenu#setLightWeightPopupEnabled(boolean)}.
  * These methods should be invoked within a <code>static</code> block within an application's main class.
- * <p/>
+ * <p>
  * This class is capable of supporting stereo devices. To cause a stereo device to be selected and used, specify the
  * Java VM property "gov.nasa.worldwind.stereo.mode=device" prior to creating an instance of this class. A stereo
  * capable {@link SceneController} such as {@link gov.nasa.worldwind.StereoSceneController} must also be specified in
@@ -39,7 +39,7 @@ import java.util.*;
  * stereo from being used by subsequently opened {@code WorldWindowGLCanvas}es, set the property to a an empty string,
  * "". If a stereo device cannot be selected and used, this falls back to a non-stereo device that supports WorldWind's
  * minimum requirements.
- * <p/>
+ * <p>
  * Under certain conditions, JOGL replaces the <code>GLContext</code> associated with instances of this class. This then
  * necessitates that all resources such as textures that have been stored on the graphic devices must be regenerated for
  * the new context. WorldWind does this automatically by clearing the associated {@link GpuResourceCache}. Objects
@@ -88,8 +88,8 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
      *
      * @param shareWith a <code>WorldWindow</code> with which to share graphics resources.
      *
-     * @see GLCanvas#GLCanvas(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
-     *      com.jogamp.opengl.GLContext, java.awt.GraphicsDevice)
+     * @see "GLCanvas(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
+     *      com.jogamp.opengl.GLContext, java.awt.GraphicsDevice)"
      */
     public WorldWindowGLCanvas(WorldWindow shareWith)
     {
@@ -128,8 +128,8 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
      * @param device    the <code>GraphicsDevice</code> on which to create the window. May be null, in which case the
      *                  default screen device of the local {@link GraphicsEnvironment} is used.
      *
-     * @see GLCanvas#GLCanvas(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
-     *      com.jogamp.opengl.GLContext, java.awt.GraphicsDevice)
+     * @see "GLCanvas(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
+     *      com.jogamp.opengl.GLContext, java.awt.GraphicsDevice)"
      */
     public WorldWindowGLCanvas(WorldWindow shareWith, java.awt.GraphicsDevice device)
     {
@@ -172,8 +172,8 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
      * @param chooser      a chooser object that customizes the specified capabilities. May be null, in which case a
      *                     default chooser is used.
      *
-     * @see GLCanvas#GLCanvas(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
-     *      com.jogamp.opengl.GLContext, java.awt.GraphicsDevice)
+     * @see "GLCanvas(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
+     *      com.jogamp.opengl.GLContext, java.awt.GraphicsDevice)"
      */
     public WorldWindowGLCanvas(WorldWindow shareWith, java.awt.GraphicsDevice device,
         GLCapabilities capabilities, GLCapabilitiesChooser chooser)

--- a/src/gov/nasa/worldwind/awt/WorldWindowGLJPanel.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLJPanel.java
@@ -23,14 +23,14 @@ import java.util.*;
  * <code>WorldWindowGLCanvas</code> is a lightweight Swing component for displaying WorldWind {@link Model}s (globe and
  * layers). It's a self-contained component intended to serve as an application's <code>WorldWindow</code>. Construction
  * options exist to specify a specific graphics device and to share graphics resources with another graphics device.
- * <p/>
+ * <p>
  * Note: The Java SDK for OpenGL (JOGL) support for the underlying {@link GLJPanel} that this class uses has
  * historically been problematic. It works well on some devices but not on others, and its performance varies much more
  * among devices than that of its heavyweight counterpart, {@link WorldWindowGLCanvas}. It's therefore best to use the
  * heavyweight component if possible. You can find detailed information on this issue in the <em>Heavyweight and
  * Lightweight Issues</em> section of the <a href="http://download.java.net/media/jogl/doc/userguide/">"JOGL User's
  * Guide"</a>
- * <p/>
+ * <p>
  * This class is capable of supporting stereo devices. To cause a stereo device to be selected and used, specify the
  * Java VM property "gov.nasa.worldwind.stereo.mode=device" prior to creating an instance of this class. A stereo
  * capable {@link SceneController} such as {@link gov.nasa.worldwind.StereoSceneController} must also be specified in
@@ -38,7 +38,7 @@ import java.util.*;
  * stereo from being used by subsequently opened {@code WorldWindowGLCanvas}es, set the property to a an empty string,
  * "". If a stereo device cannot be selected and used, this falls back to a non-stereo device that supports WorldWind's
  * minimum requirements.
- * <p/>
+ * <p>
  * Under certain conditions, JOGL replaces the <code>GLContext</code> associated with instances of this class. This then
  * necessitates that all resources such as textures that have been stored on the graphic devices must be regenerated for
  * the new context. WorldWind does this automatically by clearing the associated {@link GpuResourceCache}. Objects
@@ -87,8 +87,8 @@ public class WorldWindowGLJPanel extends GLJPanel implements WorldWindow, Proper
      *
      * @param shareWith a <code>WorldWindow</code> with which to share graphics resources.
      *
-     * @see GLJPanel#GLJPanel(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
-     *      com.jogamp.opengl.GLContext)
+     * @see "GLJPanel(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
+     *      com.jogamp.opengl.GLContext)"
      */
     public WorldWindowGLJPanel(WorldWindow shareWith)
     {
@@ -130,8 +130,8 @@ public class WorldWindowGLJPanel extends GLJPanel implements WorldWindow, Proper
      * @param chooser      a chooser object that customizes the specified capabilities. May be null, in which case a
      *                     default chooser is used.
      *
-     * @see GLJPanel#GLJPanel(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
-     *      com.jogamp.opengl.GLContext)
+     * @see "GLJPanel(com.jogamp.opengl.GLCapabilitiesImmutable, com.jogamp.opengl.GLCapabilitiesChooser,
+     *      com.jogamp.opengl.GLContext)"
      */
     public WorldWindowGLJPanel(WorldWindow shareWith, GLCapabilities capabilities,
         GLCapabilitiesChooser chooser)

--- a/src/gov/nasa/worldwind/cache/BasicDataFileStore.java
+++ b/src/gov/nasa/worldwind/cache/BasicDataFileStore.java
@@ -52,13 +52,19 @@ public class BasicDataFileStore extends AbstractFileStore
      * requested that does not have a format suffix, <code>requestFile</code> appends a suffix appropriate for the
      * content type returned by the server. Subsequent calls to <code>requestFile</code> use the content types in this
      * list to find the content type matching the cached file.
-     * <p/>
+     * <p>
      * This is initialized to the following list of default content types typically used in WorldWind applications:
-     * <p/>
-     * <ul> <li>application/vnd.google-earth.kml+xml</li> <li>application/vnd.google-earth.kmz</li>
-     * <li>model/collada+xml</li> <li>image/dds</li> <li>image/gif</li> <li>image/jpeg</li> <li>image/jpg</li>
-     * <li>image/png</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>application/vnd.google-earth.kml+xml</li> 
+     * <li>application/vnd.google-earth.kmz</li>
+     * <li>model/collada+xml</li> 
+     * <li>image/dds</li> 
+     * <li>image/gif</li> 
+     * <li>image/jpeg</li> 
+     * <li>image/jpg</li>
+     * <li>image/png</li> 
+     * </ul>
+     * <p>
      * This list may be overridden by specifying a comma-delimited list of content types in the WorldWind configuration
      * parameter <code>gov.nasa.worldwind.avkey.CacheContentTypes</code>.
      */
@@ -412,7 +418,7 @@ public class BasicDataFileStore extends AbstractFileStore
 
     /**
      * Returns the length of the resource referred to by a jar URL. Can be used to test whether the resource exists.
-     * <p/>
+     * <p>
      * Note: This method causes the URL to open a connection and retrieve content length.
      *
      * @param jarUrl the jar URL.
@@ -595,13 +601,13 @@ public class BasicDataFileStore extends AbstractFileStore
     /**
      * Makes a path to the file in the cache from the file's generic URL and content type. If the URL has a non-empty
      * query string, then this returns a path name formatted as follows:
-     * <p/>
+     * <p>
      * <code>host/hashCode/path_query.suffix</code>
-     * <p/>
+     * <p>
      * Otherwise, this returns a path name formatted as follows:
-     * <p/>
+     * <p>
      * <code>host/hashCode/path.suffix</code>
-     * <p/>
+     * <p>
      * Where <code>host</code> is the name of the host machine, <code>hashCode</code> is a four digit hash code computed
      * from the string "path" or "path_query" (if the URL has a query string), <code>path</code> is the URL's path part,
      * <code>query</code> is the URL's query string, and <code>suffix</code> is either the path's suffix or a suffix
@@ -610,7 +616,7 @@ public class BasicDataFileStore extends AbstractFileStore
      * should a large number of files be requested from the same host. If two URLs have the same hash code, then both
      * URLs are stored under the same <code>hashCode</code> folder in the cache and are differentiated by their
      * <code>path</code> and <code>query</code> parts.
-     * <p/>
+     * <p>
      * This removes any private parameters from the query string to ensure that those parameters are not written to the
      * file store as part of the cache name. For example, the "CONNECTID" query parameter typically encodes a user's
      * unique connection id, and must not be shared. Writing this parameter to the cache would expose that parameter to
@@ -669,9 +675,9 @@ public class BasicDataFileStore extends AbstractFileStore
     /**
      * Makes a path to the file in the cache from the file's JAR URL and content type. This returns a path name
      * formatted as follows:
-     * <p/>
+     * <p>
      * <code>host/path.suffix</code>
-     * <p/>
+     * <p>
      * Where <code>host</code> is the path to the JAR file, <code>path</code> is the file's path within the JAR archive,
      * and <code>suffix</code> is either the path's suffix or a suffix created from the specified content type.
      *
@@ -772,11 +778,12 @@ public class BasicDataFileStore extends AbstractFileStore
      * store as part of the cache name. For example, the "CONNECTID" query parameter typically encodes a user's unique
      * connection id, and must not be shared. Writing this parameter to the cache would expose that parameter to anyone
      * using the same machine.
-     * <p/>
+     * <p>
      * This removes the key, the value, and any trailing parameter delimiter of all private parameters in the specified
      * query string. Recognized private query parameters are as follows:
-     * <p/>
-     * <ul> <li>CONNECTID</li> </ul>
+     * <ul> 
+     * <li>CONNECTID</li> 
+     * </ul>
      *
      * @param queryString the query string to examine.
      *

--- a/src/gov/nasa/worldwind/cache/BasicGpuResourceCache.java
+++ b/src/gov/nasa/worldwind/cache/BasicGpuResourceCache.java
@@ -17,7 +17,7 @@ import java.util.logging.Level;
  * maintains a map of resources that fit within a specifiable memory capacity. If adding a resource would exceed this
  * cache's capacity, existing but least recently used resources are removed from the cache to make room. The cache is
  * reduced to the "low water" size in this case (see {@link #setLowWater(long)}.
- * <p/>
+ * <p>
  * When a resource is removed from the cache, and if it is a recognized OpenGL resource -- a texture, a list of vertex
  * buffer IDs, a list of display list IDs, etc. -- and there is a current Open GL context, the appropriate glDelete
  * function is called to de-register the resource with the GPU. If there is no current OpenGL context the resource is
@@ -196,9 +196,9 @@ public class BasicGpuResourceCache implements GpuResourceCache
 
     /**
      * Sets the new low water level in bytes, which controls how aggresively the cache discards items.
-     * <p/>
+     * <p>
      * When the cache fills, it removes items until it reaches the low water level.
-     * <p/>
+     * <p>
      * Setting a high loWater level will increase cache misses, but decrease average add time, but setting a low loWater
      * will do the opposite.
      *

--- a/src/gov/nasa/worldwind/cache/BasicMemoryCache.java
+++ b/src/gov/nasa/worldwind/cache/BasicMemoryCache.java
@@ -159,9 +159,9 @@ public class BasicMemoryCache implements MemoryCache
 
     /**
      * Sets the new low water level in cache units, which controls how aggresively the cache discards items.
-     * <p/>
+     * <p>
      * When the cache fills, it removes items until it reaches the low water level.
-     * <p/>
+     * <p>
      * Setting a high loWater level will increase cache misses, but decrease average add time, but setting a low loWater
      * will do the opposite.
      *
@@ -189,7 +189,7 @@ public class BasicMemoryCache implements MemoryCache
     /**
      * Returns true if the cache contains the item referenced by key. No guarantee is made as to whether or not the item
      * will remain in the cache for any period of time.
-     * <p/>
+     * <p>
      * This function does not cause the object referenced by the key to be marked as accessed. <code>getObject()</code>
      * should be used for that purpose.
      *

--- a/src/gov/nasa/worldwind/cache/BasicRasterServerCache.java
+++ b/src/gov/nasa/worldwind/cache/BasicRasterServerCache.java
@@ -21,7 +21,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * The <code>BasicRasterServerCache</code> is an implementation of the memory cache that is specific to store maximum
  * possible cacheable items, until the heap size allows. Once the memory limit is hit, it will drop ALL cached items.
  * Also, BasicRasterServerCache creates a pruner thread that removes all cached items which were not used for 20 seconds
- * or more. The least recent use timeout is configurable via the <code>setLeastRecentUseTimeout()<code> method. In
+ * or more. The least recent use timeout is configurable via the <code>setLeastRecentUseTimeout()</code> method. In
  * addition, the <code>BasicRasterServerCache</code> allocates 100MB memory and keeps only a phantom reference to the
  * allocated 100M memory. Once any part of the application needs more memory the phantom referenced memory will be
  * immediately released and the phantom reference will be added to the internal reference queue, which is monitored by

--- a/src/gov/nasa/worldwind/cache/BasicSessionCache.java
+++ b/src/gov/nasa/worldwind/cache/BasicSessionCache.java
@@ -11,11 +11,11 @@ import gov.nasa.worldwind.util.*;
  * BasicSessionCache is a general receiving area for data represented as key-value pairs. Entries in a BasicSessionCache
  * may persist for the length of a Virtual Machine's run time, but may be evicted if the cache size increases beyond its
  * capacity.
- * <p/>
+ * <p>
  * Eviction of BasicSessionCache entries is accomplished by controlling the maximum number of entries in the cache. This
  * maximum value is set by calling {@link #setCapacity(int)}. The eldest entry in the cache (the first entry added) is
  * always evicted before any others.
- * <p/>
+ * <p>
  * BasicSessionClass is a thread safe class. Access to the cache data structures is synchronized at the method level.
  * Care must be taken by subclasses to ensure that method level synchronization is maintained.
  *

--- a/src/gov/nasa/worldwind/cache/FileStore.java
+++ b/src/gov/nasa/worldwind/cache/FileStore.java
@@ -100,7 +100,7 @@ public interface FileStore extends WWObject
 
     /**
      * Creates a new, empty file in the file store.
-     * <p/>
+     * <p>
      * If the file store has no write location, the file is not created and null is returned.
      *
      * @param fileName the name of the file to create.
@@ -217,12 +217,12 @@ public interface FileStore extends WWObject
      * file. Otherwise if the specified address is a URL to a remote location, this initiates a request for the file and
      * returns <code>null</code>. When the request succeeds the file is stored either in the local WorldWind cache or
      * in a temporary location and subsequent invocations of this method return a URL to the retrieved file.
-     * <p/>
+     * <p>
      * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the WorldWind
      * cache or in a temporary location. This parameter has no effect if the file exists locally. The temporary location
      * for a retrieved file does not persist between runtime sessions, and subsequent invocations of this method may not
      * return the same temporary location.
-     * <p/>
+     * <p>
      * If a remote file is requested multiple times with different values for <code>cacheRemoteFile</code>, it is
      * undefined whether the retrieved file is stored in the WorldWind cache or in a temporary location.
      *

--- a/src/gov/nasa/worldwind/cache/MemoryCache.java
+++ b/src/gov/nasa/worldwind/cache/MemoryCache.java
@@ -57,7 +57,7 @@ public interface MemoryCache
     void removeCacheListener(CacheListener listener);
 
     /**
-     * Discovers whether or not this cache contains the object referenced by <code> key. Currently no interface exists
+     * Discovers whether or not this cache contains the object referenced by <code>key</code>. Currently no interface exists
      * to discover if an object resides in the cache by referencing itself.
      *
      * @param key the key which the object is referenced by.
@@ -70,10 +70,10 @@ public interface MemoryCache
      * Attempts to add the object <code>clientObject</code>, with size <code>objectSize</code> and referred to by
      * <code>key</code> to the cache. <code>objectSize</code> is the size in cache units, but is not checked for
      * accuracy. Returns whether or not the add was successful.
-     * <p/>
+     * <p>
      * Note that the size passed in may be used, rather than the real size of the object. In some implementations, the
      * accuracy of the space used calls will depend on the collection of these sizes, rather than actual size.
-     * <p/>
+     * <p>
      * This method should be declared <code>synchronized</code> when it is implemented.
      *
      * @param key          an object used to reference the cached item.
@@ -87,7 +87,7 @@ public interface MemoryCache
     /**
      * Attempts to add the <code>Cacheable</code> object referenced by the key. No explicit size value is required as
      * this method queries the Cacheable to discover the size.
-     * <p/>
+     * <p>
      * This method should be declared <code>synchronized</code> when it is implemented.
      *
      * @param key          an object used to reference the cached item.
@@ -120,7 +120,7 @@ public interface MemoryCache
     /**
      * Empties the cache. After calling <code>clear()</code> on a <code>MemoryCache</code>, calls relating to used
      * capacity and number of items should return zero and the free capacity should be the maximum capacity.
-     * <p/>
+     * <p>
      * This method should be declared <code>synchronized</code> when it is implemented and should notify all
      * <code>CacheListener</code>s of entries removed.
      */

--- a/src/gov/nasa/worldwind/cache/SessionCache.java
+++ b/src/gov/nasa/worldwind/cache/SessionCache.java
@@ -8,7 +8,7 @@ package gov.nasa.worldwind.cache;
 /**
  * SessionCache is a general receiving area for data represented as key-value pairs. Entries in a SessionCache may
  * persist for the length of a Virtual Machine's run time, but may be evicted at any time.
- * <p/>
+ * <p>
  * Eviction of SessionCache entries is accomplished by controlling the maximum number of entries in the cache. This
  * maximum value is set by calling {@link #setCapacity(int)}. A SessionCache may be implemented with any eviction policy
  * (including a policy of no eviction). Most implementations evict the eldest entry added to the cache.

--- a/src/gov/nasa/worldwind/cache/ShapeDataCache.java
+++ b/src/gov/nasa/worldwind/cache/ShapeDataCache.java
@@ -17,7 +17,7 @@ import java.util.*;
 /**
  * Provides a mechanism to manage globe-specific representations of shapes. Typically used to manage per-globe state
  * when the application associates the same shape with multiple {@link gov.nasa.worldwind.WorldWindow}s.
- * <p/>
+ * <p>
  * This cache limits the amount of time an entry remains in the cache unused. The maximum unused time may be specified.
  * Entries unused within the specified duration are removed from the cache each time {@link
  * #getEntry(gov.nasa.worldwind.globes.Globe)} is called.
@@ -272,7 +272,7 @@ public class ShapeDataCache implements Iterable<ShapeDataCache.ShapeDataCacheEnt
 
     /**
      * Retrieves a specified entry from the cache.
-     * <p/>
+     * <p>
      * Note: Each time this method is called the cache is cleared of dead entries, as defined by their last-used time
      * relative to this cache's maximum unused time.
      *

--- a/src/gov/nasa/worldwind/data/AbstractDataRaster.java
+++ b/src/gov/nasa/worldwind/data/AbstractDataRaster.java
@@ -213,12 +213,12 @@ public abstract class AbstractDataRaster extends AVListImpl implements DataRaste
      * Reads the specified region of interest (ROI) with given extent, width, and height, and type
      *
      * @param params Required parameters are:
-     *               <p/>
+     *               <p>
      *               AVKey.HEIGHT as Integer, specifies a height of the desired ROI AVKey.WIDTH as Integer, specifies a
      *               width of the desired ROI AVKey.SECTOR as Sector, specifies an extent of the desired ROI
-     *               <p/>
+     *               <p>
      *               Optional parameters are:
-     *               <p/>
+     *               <p>
      *               AVKey.BAND_ORDER as array of integers, examples: for RGBA image: new int[] { 0, 1, 2, 3 }, or for
      *               ARGB image: new int[] { 3, 0, 1, 2 } or if you want only RGB bands of the RGBA image: new int[] {
      *               0, 1, 2 } or only Intensity (4th) band of the specific aerial image: new int[] { 3 }

--- a/src/gov/nasa/worldwind/data/BasicDataRasterReaderFactory.java
+++ b/src/gov/nasa/worldwind/data/BasicDataRasterReaderFactory.java
@@ -21,7 +21,7 @@ import gov.nasa.worldwind.util.Logging;
  *  {@link gov.nasa.worldwind.data.ImageIORasterReader}
 
  * </pre>
- * <p/>
+ * <p>
  * To specify a different factory, set the {@link gov.nasa.worldwind.avlist.AVKey#DATA_RASTER_READER_FACTORY_CLASS_NAME}
  * value in {@link gov.nasa.worldwind.Configuration}, either directly or via the WorldWind configuration file. To add
  * readers to the default set, create a subclass of this class, override {@link #findReaderFor(Object,

--- a/src/gov/nasa/worldwind/data/BasicRasterServer.java
+++ b/src/gov/nasa/worldwind/data/BasicRasterServer.java
@@ -163,7 +163,7 @@ public class BasicRasterServer extends WWObjectImpl implements RasterServer
     }
 
     /**
-     * Extracts all <Property/> key and values from the given DOM element
+     * Extracts all <code>Property</code> key and values from the given DOM element
      *
      * @param config Parsed configuration document.
      */
@@ -372,7 +372,7 @@ public class BasicRasterServer extends WWObjectImpl implements RasterServer
      *
      * @param reqParams This is a required parameter, must not be null or empty; Must contain AVKey.WIDTH, AVKey.HEIGHT,
      *                  and AVKey.SECTOR values.
-     *                  <p/>
+     *                  <p>
      *                  Optional keys are: AVKey.PIXEL_FORMAT (AVKey.ELEVATION | AVKey.IMAGE) AVKey.DATA_TYPE
      *                  AVKey.BYTE_ORDER (AVKey.BIG_ENDIAN | AVKey.LITTLE_ENDIAN )
      *
@@ -501,7 +501,7 @@ public class BasicRasterServer extends WWObjectImpl implements RasterServer
      * @param params This is a required parameter, must not be null or empty; Must contain AVKey.WIDTH, AVKey.HEIGHT,
      *               AVKey.SECTOR, and AVKey.IMAGE_FORMAT (mime type) values. Supported mime types are: "image/png",
      *               "image/jpeg", "image/dds".
-     *               <p/>
+     *               <p>
      *               Optional keys are: AVKey.PIXEL_FORMAT (AVKey.ELEVATION | AVKey.IMAGE) AVKey.DATA_TYPE
      *               AVKey.BYTE_ORDER (AVKey.BIG_ENDIAN | AVKey.LITTLE_ENDIAN )
      *

--- a/src/gov/nasa/worldwind/data/BufferWrapperRaster.java
+++ b/src/gov/nasa/worldwind/data/BufferWrapperRaster.java
@@ -190,7 +190,7 @@ public class BufferWrapperRaster extends AbstractDataRaster implements Cacheable
      * This returns a new sub-raster initialized with the specified properties. Called from <code>doGetSubRaster</code>
      * to create the sub-raster instance before populating its contents. This does not place any restrictions on the
      * specified <code>width</code>, <code>height</code>, <code>sector</code> or <code>params</code>.
-     * <p/>
+     * <p>
      * This returns a <code>{@link gov.nasa.worldwind.util.BufferWrapper.ByteBufferWrapper}</code>, a subclass of
      * BufferWrapperRaster backed by a ByteBuffer.
      *

--- a/src/gov/nasa/worldwind/data/CachedDataRaster.java
+++ b/src/gov/nasa/worldwind/data/CachedDataRaster.java
@@ -49,7 +49,7 @@ public class CachedDataRaster extends AVListImpl implements DataRaster
      * @param source the location of the local file, expressed as either a String path, a File, or a file URL.
      * @param params metadata as AVList, it is expected to next parameters: AVKey.WIDTH, AVKey.HEIGHT, AVKey.SECTOR,
      *               AVKey.PIXEL_FORMAT.
-     *               <p/>
+     *               <p>
      *               If any of these keys is missing, there will be an attempt made to retrieve missign metadata from
      *               the source using the reader.
      * @param reader A reference to a DataRasterReader instance

--- a/src/gov/nasa/worldwind/data/DataRasterReader.java
+++ b/src/gov/nasa/worldwind/data/DataRasterReader.java
@@ -23,10 +23,10 @@ public interface DataRasterReader extends AVList
      * The source may be one of the following:
      * <ul>
      *     <li>{@link java.io.File}</li>
-     *     <li>{@link String}</li> </ul>
+     *     <li>{@link String}</li> 
      *     <li>{@link java.io.InputStream}</li>
      *     <li>{@link java.net.URL}</li>
-     * <ul/>
+     * </ul>
      *
      * @param source the source to examine.
      * @param params parameters required by certain reader implementations. May be null for most readers.
@@ -41,10 +41,10 @@ public interface DataRasterReader extends AVList
      * The source may be one of the following:
      * <ul>
      *     <li>{@link java.io.File}</li>
-     *     <li>{@link String}</li> </ul>
+     *     <li>{@link String}</li> 
      *     <li>{@link java.io.InputStream}</li>
      *     <li>{@link java.net.URL}</li>
-     * <ul/>
+     * </ul>
      *
      * @param source the source to read.
      * @param params parameters required by certain reader implementations. May be null for most readers. If non-null,
@@ -61,10 +61,10 @@ public interface DataRasterReader extends AVList
      * The source may be one of the following:
      * <ul>
      *     <li>{@link java.io.File}</li>
-     *     <li>{@link String}</li> </ul>
+     *     <li>{@link String}</li> 
      *     <li>{@link java.io.InputStream}</li>
      *     <li>{@link java.net.URL}</li>
-     * <ul/>
+     * </ul>
      *
      * TODO: Why would the caller specify parameters to this method?
      *
@@ -84,10 +84,10 @@ public interface DataRasterReader extends AVList
      * The source may be one of the following:
      * <ul>
      *     <li>{@link java.io.File}</li>
-     *     <li>{@link String}</li> </ul>
+     *     <li>{@link String}</li>
      *     <li>{@link java.io.InputStream}</li>
      *     <li>{@link java.net.URL}</li>
-     * <ul/>
+     *  </ul>
      *
      * @param source the source to examine.
      * @param params parameters required by certain reader implementations. May be null for most readers.
@@ -103,10 +103,10 @@ public interface DataRasterReader extends AVList
      * The source may be one of the following:
      * <ul>
      *     <li>{@link java.io.File}</li>
-     *     <li>{@link String}</li> </ul>
+     *     <li>{@link String}</li>
      *     <li>{@link java.io.InputStream}</li>
      *     <li>{@link java.net.URL}</li>
-     * <ul/>
+     * </ul>
      *
      * @param source the source to examine.
      * @param params parameters required by certain reader implementations. May be null for most readers.

--- a/src/gov/nasa/worldwind/data/DataRasterReaderFactory.java
+++ b/src/gov/nasa/worldwind/data/DataRasterReaderFactory.java
@@ -18,7 +18,7 @@ public interface DataRasterReaderFactory
      * Search the list of available data raster readers for one that will read a specified data source. The
      * determination is based on both the data type and the data source reference; some readers may be able to open data
      * of the corresponding type but not as, for example, an InputStream or a URL.
-     * <p/>
+     * <p>
      * The list of readers searched is determined by the DataRasterReaderFactory associated with the current {@link
      * gov.nasa.worldwind.Configuration}, as specified by the {@link gov.nasa.worldwind.avlist.AVKey#DATA_RASTER_READER_FACTORY_CLASS_NAME}.
      * If no factory is specified in the configuration, {@link gov.nasa.worldwind.data.BasicDataRasterReaderFactory} is

--- a/src/gov/nasa/worldwind/data/GDALDataRaster.java
+++ b/src/gov/nasa/worldwind/data/GDALDataRaster.java
@@ -274,22 +274,23 @@ public class GDALDataRaster extends AbstractDataRaster implements Cacheable
 
     /**
      * Extracts metadata and sets next key/value pairs:
-     * <p/>
-     * <p/>
-     * <p/>
+     * <p>
      * AVKey.WIDTH - the maximum width of the image
-     * <p/>
+     * <p>
      * AVKey.HEIGHT - the maximum height of the image
-     * <p/>
-     * AVKey.COORDINATE_SYSTEM - one of the next values: AVKey.COORDINATE_SYSTEM_SCREEN
-     * AVKey.COORDINATE_SYSTEM_GEOGRAPHIC AVKey.COORDINATE_SYSTEM_PROJECTED
-     * <p/>
+     * <p>
+     * AVKey.COORDINATE_SYSTEM - one of the next values:
+     * <ul>
+     * <li>AVKey.COORDINATE_SYSTEM_SCREEN
+     * <li>AVKey.COORDINATE_SYSTEM_GEOGRAPHIC
+     * <li>AVKey.COORDINATE_SYSTEM_PROJECTED
+     * </ul>
      * AVKey.SECTOR - in case of Geographic CS, contains a regular Geographic Sector defined by lat/lon coordinates of
      * corners in case of Projected CS, contains a bounding box of the area
      *
-     * @param ds               GDAL's Dataset
+     * @param ds GDAL's Dataset
      * @param quickReadingMode if quick reading mode is enabled GDAL will not spend much time on heavy calculations,
-     *                         like for example calculating Min/Max for entire elevation raster
+     * like for example calculating Min/Max for entire elevation raster
      */
     protected void init(Dataset ds, boolean quickReadingMode)
     {
@@ -1011,23 +1012,21 @@ public class GDALDataRaster extends AbstractDataRaster implements Cacheable
      * Builds a writable data raster for the requested region of interest (ROI)
      *
      * @param params Required parameters are:
-     *               <p/>
-     *               <p/> AVKey.HEIGHT as Integer, specifies a height of the desired ROI
-     *               <p/>
-     *               <p/> AVKey.WIDTH as Integer, specifies a width of the desired ROI
-     *               <p/>
-     *               <p/> AVKey.SECTOR as Sector, specifies an extent of the desired ROI
-     *               <p/>
-     *               <p/>
-     *               <p/>
-     *               Optional parameters are:
-     *               <p/>
-     *               <p/> AVKey.BAND_ORDER as array of integers, examples: for RGBA image: new int[] { 0, 1, 2, 3 }, or
-     *               for  ARGB image: new int[] { 3, 0, 1, 2 } , or if you want only RGB bands of the RGBA image: new
-     *               int[] {0, 1, 2 }, or only Intensity (4th) band of the specific aerial image: new int[] { 3 }
+     * <p>
+     * AVKey.HEIGHT as Integer, specifies a height of the desired ROI
+     * <p>
+     * AVKey.WIDTH as Integer, specifies a width of the desired ROI
+     * <p>
+     * AVKey.SECTOR as Sector, specifies an extent of the desired ROI
+     * <p>
+     * Optional parameters are:
+     * <p>
+     * AVKey.BAND_ORDER as array of integers, examples: for RGBA image: new int[] { 0, 1, 2, 3 }, or for ARGB image: new
+     * int[] { 3, 0, 1, 2 } , or if you want only RGB bands of the RGBA image: new int[] {0, 1, 2 }, or only Intensity
+     * (4th) band of the specific aerial image: new int[] { 3 }
      *
      * @return A writable data raster: BufferedImageRaster (if the source dataset is imagery) or ByteBufferRaster (if
-     *         the source dataset is elevations)
+     * the source dataset is elevations)
      */
     @Override
     public DataRaster getSubRaster(AVList params)

--- a/src/gov/nasa/worldwind/data/RasterServer.java
+++ b/src/gov/nasa/worldwind/data/RasterServer.java
@@ -21,7 +21,7 @@ public interface RasterServer
      * Composes a Raster and returns as ByteBuffer in the requested format (image or elevation)
      *
      * @param params Required parameters in params:
-     *               <p/>
+     *               <p>
      *               AVKey.WIDTH - the height of the requested raster AVKey.HEIGHT - the height of the requested raster
      *               AVKey.SECTOR - a regular Geographic Sector defined by lat/lon coordinates of corners
      *

--- a/src/gov/nasa/worldwind/data/TiledRasterProducer.java
+++ b/src/gov/nasa/worldwind/data/TiledRasterProducer.java
@@ -698,20 +698,20 @@ public abstract class TiledRasterProducer extends AbstractDataStoreProducer
     /**
      * Extracts a maximum level limit from the AVList if the AVList contains AVKey.TILED_RASTER_PRODUCER_LIMIT_MAX_LEVEL.
      * This method requires <code>maxNumOfLevels</code> - the actual maximum numbers of levels.
-     * <p/>
+     * <p>
      * The AVKey.TILED_RASTER_PRODUCER_LIMIT_MAX_LEVEL could specify multiple things:
-     * <p/>
+     * <p>
      * If the value of the AVKey.TILED_RASTER_PRODUCER_LIMIT_MAX_LEVEL is "Auto" (as String), the calculated limit of
      * levels will be 70% of the actual maximum numbers of levels <code>maxNumOfLevels</code>.
-     * <p/>
+     * <p>
      * If the type of the value of the AVKey.TILED_RASTER_PRODUCER_LIMIT_MAX_LEVEL is Integer, it should contain an
      * integer number between 0 (for level 0 only) and the actual maximum numbers of levels
      * <code>maxNumOfLevels</code>.
-     * <p/>
+     * <p>
      * It is also possible to specify the limit as percents, in this case the type of the
      * AVKey.TILED_RASTER_PRODUCER_LIMIT_MAX_LEVEL value must be "String", have a numeric value as text and the "%"
      * percent sign in the end. Examples: "100%", "25%", "50%", etc.
-     * <p/>
+     * <p>
      * Value of AVKey.TILED_RASTER_PRODUCER_LIMIT_MAX_LEVEL could be a numeric string (for example, "3"), or Integer.
      * The value will be correctly extracted and compared with the <code>maxNumOfLevels</code>. Valid values must be
      * smaller or equal to <code>maxNumOfLevels</code>.
@@ -952,11 +952,14 @@ public abstract class TiledRasterProducer extends AbstractDataStoreProducer
      * Installs the configuration file which describes the tiled data produced by this TiledRasterProducer. The install
      * location, configuration filename, and configuration file contents are derived from the specified parameter list.
      * This throws an exception if the configuration file cannot be installed for any reason.
-     * <p/>
-     * The parameter list must contain <strong>at least</strong> the following keys: <table> <tr><th>Key</th></tr>
-     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#FILE_STORE_LOCATION}</td><td></td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}</td><td></td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td></td></tr> </table>
+     * <p>
+     * The parameter list must contain <strong>at least</strong> the following keys: 
+     * <table><caption>Parameter Keys</caption> 
+     * <tr><th>Key</th></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#FILE_STORE_LOCATION}</td><td></td></tr> 
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}</td><td></td></tr> 
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td></td></tr> 
+     * </table>
      *
      * @param params the parameters which describe the install location, the configuration filename, and the
      *               configuration file contents.
@@ -1028,10 +1031,13 @@ public abstract class TiledRasterProducer extends AbstractDataStoreProducer
     /**
      * Returns the location of the configuration file which describes the tiled data produced by this
      * TiledRasterProducer. The install location is derived from the specified parameter list. This returns null if the
-     * parameter list is null, or if it does not contain any of the following keys: <table> <tr><th>Key</th></tr>
-     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#FILE_STORE_LOCATION}</td><td></td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}</td><td></td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td></td></tr> </table>
+     * parameter list is null, or if it does not contain any of the following keys: 
+     * <table><caption>Parameter Keys</caption>
+     * <tr><th>Key</th></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#FILE_STORE_LOCATION}</td><td></td></tr> 
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}</td><td></td></tr> 
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td></td></tr> 
+     * </table>
      *
      * @param params the parameters which describe the install location.
      *

--- a/src/gov/nasa/worldwind/event/SelectEvent.java
+++ b/src/gov/nasa/worldwind/event/SelectEvent.java
@@ -17,25 +17,25 @@ import java.util.List;
  * caused the signal. See the <em>Field Summary</em> for a description of the possible operations. When a SelectEvent
  * occurs, all select event listeners registered with the associated {@link gov.nasa.worldwind.WorldWindow} are called.
  * Select event listeners are registered by calling {@link gov.nasa.worldwind.WorldWindow#addSelectListener(SelectListener)}.
- * <p/>
+ * <p>
  * A <code>ROLLOVER</code> SelectEvent is generated every frame when the cursor is over a visible object either because
  * the user moved it there or because the WorldWindow was repainted and a visible object was found to be under the
  * cursor. A <code>ROLLOVER</code> SelectEvent is also generated when there are no longer any objects under the cursor.
  * Select events generated for objects under the cursor have a non-null pickPoint, and contain the top-most visible
  * object of all objects at the cursor position.
- * <p/>
+ * <p>
  * A <code>BOX_ROLLOVER</code> SelectEvent is generated every frame when the selection box intersects a visible object
  * either because the user moved or expanded it or because the WorldWindow was repainted and a visible object was found
  * to intersect the box. A <code>BOX_ROLLOVER</code> SelectEvent is also generated when there are no longer any objects
  * intersecting the selection box. Select events generated for objects intersecting the selection box have a non-null
  * pickRectangle, and contain all top-most visible objects of all objects intersecting the selection box.
- * <p/>
+ * <p>
  * If a select listener performs some action in response to a select event, it should call the event's {@link
  * #consume()} method in order to indicate to subsequently called listeners that the event has been responded to and no
  * further action should be taken. Left press select events should not be consumed unless it is necessary to do so.
  * Consuming left press events prevents the WorldWindow from gaining focus, thereby preventing it from receiving key
  * events.
- * <p/>
+ * <p>
  * If no object is under the cursor but the cursor is over terrain, the select event will identify the terrain as the
  * picked object and will include the corresponding geographic position. See {@link
  * gov.nasa.worldwind.pick.PickedObject#isTerrain()}.

--- a/src/gov/nasa/worldwind/event/WWEvent.java
+++ b/src/gov/nasa/worldwind/event/WWEvent.java
@@ -45,7 +45,7 @@ public class WWEvent extends EventObject
 
     /**
      * Returns whether or not the event has been consumed.
-     * <p/>
+     * <p>
      * Note: if the event cannot be consumed, this still returns {@code true} if {@link #consume()} has been called,
      * though this has no effect.
      *

--- a/src/gov/nasa/worldwind/formats/dds/AlphaBlockDXT3.java
+++ b/src/gov/nasa/worldwind/formats/dds/AlphaBlockDXT3.java
@@ -10,7 +10,7 @@ package gov.nasa.worldwind.formats.dds;
  * The DXT2/DXT3 alpha block contains alpha values for 4x4 pixels, each quantized to fit into 4 bits. The alpha values
  * are tightly packed into 64 bits in the DXT file as follows, where the value aN represents the Nth alpha value in
  * hexadecimal notation:
- * <p/>
+ * <p>
  * | 63-56 | 55-48 | 47-40 | 39-32 | 31-24 | 23-16 | 15-8  | 7-0    |
  * | aFaE  | aDaC  | aBaA  | a9a8  | a7a6  | a5a4  | a3a2  | a1a0   |
  *

--- a/src/gov/nasa/worldwind/formats/dds/BlockDXT1.java
+++ b/src/gov/nasa/worldwind/formats/dds/BlockDXT1.java
@@ -13,7 +13,7 @@ package gov.nasa.worldwind.formats.dds;
  * first color is less than the second color, then one additional color is defined for a total of three colors, and the
  * fourth color is interpreted as transparent black. Finally, the block contains 4x4 2 bit indices into the array of
  * four colors (one of which may be transparent black).
- * <p/>
+ * <p>
  * From http://msdn.microsoft.com/en-us/library/bb204843(VS.85).aspx:
  * If 64-bit blocks - that is, format DXT1 - are used for the texture, it is possible to mix the opaque and 1-bit alpha
  * formats on a per-block basis within the same texture. In other words, the comparison of the unsigned integer

--- a/src/gov/nasa/worldwind/formats/dds/BlockDXT3Compressor.java
+++ b/src/gov/nasa/worldwind/formats/dds/BlockDXT3Compressor.java
@@ -10,7 +10,7 @@ import gov.nasa.worldwind.util.Logging;
 /**
  * Compressor for DXT2/DXT3 alpha and color blocks. This class is not thread safe. Unsynchronized access will result in
  * unpredictable behavior. Access to methods of this class must be synchronized by the caller.
- * <p/>
+ * <p>
  * Documentation on the DXT2/DXT3 format is available at http://msdn.microsoft.com/en-us/library/bb694531.aspx under
  * the name "BC2".
  *
@@ -36,7 +36,7 @@ public class BlockDXT3Compressor
      * Compress the 4x4 color block into a DXT2/DXT3 block using 16 4 bit alpha values, and four colors. This method
      * compresses the color block exactly as a DXT1 compressor, except that it guarantees that the DXT1 block will use
      * four colors.
-     * <p/>
+     * <p>
      * Access to this method must be synchronized by the caller. This method is frequently invoked by the DXT
      * compressor, so in order to reduce garbage each instance of this class has unsynchronized properties that are
      * reused during each call.

--- a/src/gov/nasa/worldwind/formats/dds/DDSCompressor.java
+++ b/src/gov/nasa/worldwind/formats/dds/DDSCompressor.java
@@ -13,7 +13,7 @@ import java.awt.image.*;
  * DDSCompressor converts in-memory images into a DDS file encoded with one of the DXT block compression algorithms. If
  * the caller wants to encode using a certain type of DXT compression, DDSCompressor provides the appropriate methods to
  * do that. Otherwise, DDSCompressor chooses the DXT compression scheme that best suits the source image.
- * <p/>
+ * <p>
  * Each compression method accepts a reference to a {@link gov.nasa.worldwind.formats.dds.DXTCompressionAttributes}.
  * This compressor performs the appropriate actions according to the attributes, such as building mip maps and
  * converting the source image to a premultiplied alpha format.

--- a/src/gov/nasa/worldwind/formats/shapefile/DBaseFile.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/DBaseFile.java
@@ -310,7 +310,7 @@ public class DBaseFile extends AVListImpl
 
     /**
      * Reads a {@link Header} instance from the given {@link java.nio.ByteBuffer};
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the header and will be set to the end of the
      * header after this method has completed.
      *
@@ -385,7 +385,7 @@ public class DBaseFile extends AVListImpl
 
     /**
      * Reads a sequence of {@link DBaseField} descriptions from the given {@link java.nio.ByteBuffer};
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the sequence and will be set to the end of the
      * sequence after this method has completed.
      *
@@ -440,7 +440,7 @@ public class DBaseFile extends AVListImpl
 
     /**
      * Reads a {@link DBaseRecord} instance from the given {@link java.nio.ByteBuffer};
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the record and will be set to the start of the
      * next record after this method has completed.
      *

--- a/src/gov/nasa/worldwind/formats/shapefile/Shapefile.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/Shapefile.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 /**
  * Parses an ESRI Shapefile (.shp) and provides access to its contents. For details on the Shapefile format see the ESRI
  * documentation at <a href="http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf">http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf</a>.
- * <p/>
+ * <p>
  * The Shapefile provides a streaming interface for parsing a Shapefile's contents. The streaming interface enables
  * applications to read Shapefiles that do not fit in memory. A typical usage pattern is as follows: <code>
  * <pre>
@@ -46,7 +46,7 @@ import java.util.logging.Level;
  * }
  * </pre>
  * </code>
- * <p/>
+ * <p>
  * The source Shapefile may be accompanied by an optional index file, attribute file, and projection file. Shapefile
  * constructors that accept a generic source such as {@link #Shapefile(Object) expect accompanying files to be in the
  * same logical folder as the Shapefile, have the same filename as the Shapefile, and have suffixes ".shx", ".dbf", and
@@ -54,9 +54,9 @@ import java.util.logging.Level;
  * without that information. Alternatively, the Shapefile can be constructed by providing a direct {@link
  * java.io.InputStream} to any of the accompanying sources by using the InputStream based constructors, such as {@link
  * #Shapefile(java.io.InputStream, java.io.InputStream, java.io.InputStream, java.io.InputStream)}.
- * <p/>
+ * <p>
  * <h3>Coordinate System</h3>
- * <p/>
+ * <p>
  * The Shapefile's coordinate system affects how the Shapefile's point coordinates are interpreted as follows: <ul>
  * <li>Unspecified - coordinates are not changed.</li> <li>Geographic - coordinates are validated during parsing.
  * Coordinates outside the standard range of +90/-90 latitude and +180/-180 longitude cause the Shapefile to throw an
@@ -64,7 +64,7 @@ import java.util.logging.Level;
  * #readNextRecord()} if any of the Shapefile's records contain an invalid coordinate.</li> <li>Universal Transverse
  * Mercator (UTM) - UTM coordinates are converted to geographic coordinates during parsing.</li> <li>Unsupported - the
  * Shapefile throws a {@link gov.nasa.worldwind.exception.WWRuntimeException} during construction.
- * <p/>
+ * <p>
  * The Shapefile's coordinate system can be specified in either an accompanying projection file, or by specifying the
  * coordinate system parameters in an {@link gov.nasa.worldwind.avlist.AVList} during Shapefile's construction. The
  * Shapefile gives priority to the AVList if an accompanying projection file is available and AVList projection
@@ -78,7 +78,7 @@ import java.util.logging.Level;
  * an integer in the range 1-60.</li> <li>{@link gov.nasa.worldwind.avlist.AVKey#PROJECTION_HEMISPHERE} - the UTM
  * hemisphere (if coordinate system is UTM); either {@link gov.nasa.worldwind.avlist.AVKey#NORTH} or {@link
  * gov.nasa.worldwind.avlist.AVKey#SOUTH}.</li> </ul>
- * <p/>
+ * <p>
  * Subclasses can override how the Shapefile reads and interprets its coordinate system. Override {@link
  * #readCoordinateSystem()} and {@link #validateCoordinateSystem(gov.nasa.worldwind.avlist.AVList)} to change how the
  * Shapefile parses an accompanying projection file and validates the coordinate system parameters. Override {@link
@@ -184,12 +184,12 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
      * java.io.InputStream}</li> <li>{@link java.net.URL}</li> <li>absolute {@link java.net.URI}</li><li>{@link
      * File}</li> <li>{@link String} containing a valid URL description or a file or resource name available on the
      * classpath.</li> </ul>
-     * <p/>
+     * <p>
      * The source Shapefile may be accompanied by an optional index file, attribute file, and projection file. To be
      * recognized by this Shapefile, accompanying files must be in the same logical folder as the Shapefile, have the
      * same filename as the Shapefile, and have suffixes ".shx", ".dbf", and ".prj" respectively. If any of these files
      * do not exist, or cannot be read for any reason, the Shapefile opens without that information.
-     * <p/>
+     * <p>
      * This throws an exception if the shapefile's coordinate system is unsupported.
      *
      * @param source the source of the shapefile.
@@ -240,12 +240,12 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
      * Opens an Shapefile from a general source. The source type may be one of the following: <ul> <li>{@link
      * java.io.InputStream}</li> <li>{@link java.net.URL}</li> <li>{@link File}</li> <li>{@link String} containing a
      * valid URL description or a file or resource name available on the classpath.</li> </ul>
-     * <p/>
+     * <p>
      * The source Shapefile may be accompanied by an optional index file, attribute file, and projection file. To be
      * recognized by this Shapefile, accompanying files must be in the same logical folder as the Shapefile, have the
      * same filename as the Shapefile, and have suffixes ".shx", ".dbf", and ".prj" respectively. If any of these files
      * do not exist, or cannot be read for any reason, the Shapefile opens without that information.
-     * <p/>
+     * <p>
      * This throws an exception if the shapefile's coordinate system is unsupported, or if the shapefile's coordinate
      * system is unsupported.
      *
@@ -261,11 +261,11 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Opens a Shapefile from an InputStream, and InputStreams to its optional resources.
-     * <p/>
+     * <p>
      * The source Shapefile may be accompanied optional streams to an index resource stream, an attribute resource
      * stream, and a projection resource stream. If any of these streams are null or cannot be read for any reason, the
      * Shapefile opens without that information.
-     * <p/>
+     * <p>
      * This throws an exception if the shapefile's coordinate system is unsupported.
      *
      * @param shpStream the shapefile geometry file stream.
@@ -303,11 +303,11 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Opens a Shapefile from an InputStream, and InputStreams to its optional resources.
-     * <p/>
+     * <p>
      * The source Shapefile may be accompanied optional streams to an index resource stream, an attribute resource
      * stream, and a projection resource stream. If any of these streams are null or cannot be read for any reason, the
      * Shapefile opens without that information.
-     * <p/>
+     * <p>
      * This throws an exception if the shapefile's coordinate system is unsupported.
      *
      * @param shpStream the shapefile geometry file stream.
@@ -326,11 +326,11 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Opens a Shapefile from an InputStream, and InputStreams to its optional resources.
-     * <p/>
+     * <p>
      * The source Shapefile may be accompanied optional streams to an index resource stream, and an attribute resource
      * stream. If any of these streams are null or cannot be read for any reason, the Shapefile opens without that
      * information.
-     * <p/>
+     * <p>
      * This throws an exception if the shapefile's coordinate system is unsupported.
      *
      * @param shpStream the shapefile geometry file stream.
@@ -349,7 +349,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Opens a Shapefile from an InputStream, and InputStreams to its optional resources.
-     * <p/>
+     * <p>
      * The source Shapefile may be accompanied optional streams to an index resource stream, and an attribute resource
      * stream. If any of these streams are null or cannot be read for any reason, the Shapefile opens without that
      * information.
@@ -480,7 +480,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
      * <li>{@link gov.nasa.worldwind.formats.shapefile.ShapefileRecordPolyline} if type is {@link #SHAPE_POLYLINE},
      * {@link #SHAPE_POLYLINE_M} or {@link #SHAPE_POLYLINE_Z}.</li> <li>{@link gov.nasa.worldwind.formats.shapefile.ShapefileRecordPolygon}
      * if type is {@link #SHAPE_POLYGON}, {@link #SHAPE_POLYGON_M} or {@link #SHAPE_POLYGON_Z}.</li> </ul>
-     * <p/>
+     * <p>
      * This throws an exception if the JVM cannot allocate enough memory to hold the buffer used to store the record's
      * point coordinates.
      *
@@ -535,7 +535,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
      * Closes the Shapefile, freeing any resources allocated during reading except the buffer containing the Shapefile's
      * points. This closes any {@link java.io.InputStream} passed to the Shapefile during construction. Subsequent calls
      * to {@link #nextRecord()} cause an IllegalStateException.
-     * <p/>
+     * <p>
      * After closing, the Shapefile's header information and point coordinates are still available. The following
      * methods are safe to call: <ul> <li>{@link #getVersion()}</li> <li>{@link #getLength()}</li> <li>{@link
      * #getShapeType()}</li> <li>{@link #getBoundingRectangle()}</li> <li>{@link #getNumberOfRecords()}</li> <li>{@link
@@ -954,7 +954,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Reads a {@link Header} instance from the given {@link java.nio.ByteBuffer};
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the header and will be set to the end of the
      * header after this method has completed.
      *
@@ -1268,7 +1268,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
     /**
      * Reads a {@link ShapefileRecord} instance from the given {@link java.nio.ByteBuffer}, or null if the buffer
      * contains a null record.
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the record and will be set to the start of the
      * next record after this method has completed.
      *
@@ -1296,11 +1296,11 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
      * Returns a new <code>{@link gov.nasa.worldwind.formats.shapefile.ShapefileRecord}</code> from the specified
      * buffer. The buffer's current position is assumed to be set at the start of the record and will be set to the
      * start of the next record after this method has completed.
-     * <p/>
+     * <p>
      * This returns an instance of of ShapefileRecord appropriate for the record's shape type. For example, if the
      * record's shape type is <code>SHAPE_POINT</code>, this returns a <code>ShapefileRecordPoint</code>, and if the
      * record's shape type is <code>SHAPE_NULL</code>, this returns <code>ShapefileRecordNull</code>.
-     * <p/>
+     * <p>
      * This returns <code>null</code> if the record's shape type is not one of the following types:
      * <code>SHAPE_POINT</code>, <code>SHAPE_POINT_M</code>, <code>SHAPE_POINT_Z</code>, <code>SHAPE_MULTI_POINT</code>,
      * <code>SHAPE_MULTI_POINT_M</code>, <code>SHAPE_MULTI_POINT_Z</code>, <code>SHAPE_NULL</code>,
@@ -1343,7 +1343,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Returns a new "null" {@link gov.nasa.worldwind.formats.shapefile.ShapefileRecord} from the specified buffer.
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the record and will be set to the start of the
      * next record after this method has completed.
      *
@@ -1358,7 +1358,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Returns a new point {@link gov.nasa.worldwind.formats.shapefile.ShapefileRecord} from the specified buffer.
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the record and will be set to the start of the
      * next record after this method has completed.
      *
@@ -1374,7 +1374,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
     /**
      * Returns a new multi-point {@link gov.nasa.worldwind.formats.shapefile.ShapefileRecord} from the specified
      * buffer.
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the record and will be set to the start of the
      * next record after this method has completed.
      *
@@ -1389,7 +1389,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Returns a new polyline {@link gov.nasa.worldwind.formats.shapefile.ShapefileRecord} from the specified buffer.
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the record and will be set to the start of the
      * next record after this method has completed.
      *
@@ -1404,7 +1404,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
 
     /**
      * Returns a new polygon {@link gov.nasa.worldwind.formats.shapefile.ShapefileRecord} from the specified buffer.
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the record and will be set to the start of the
      * next record after this method has completed.
      *
@@ -1630,7 +1630,7 @@ public class Shapefile extends AVListImpl implements Closeable, Exportable
      * This returns null if the buffer is null or if the buffer has no remaining elements. The returned coordinates are
      * interpreted according to the Shapefile's coordinate system. This throws a {@link
      * gov.nasa.worldwind.exception.WWRuntimeException} if the coordinate system is unsupported.
-     * <p/>
+     * <p>
      * The buffer current position is assumed to be set at the start of the point data and will be set to the end of the
      * point data after this method has completed.
      *

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefileLayerFactory.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefileLayerFactory.java
@@ -22,22 +22,22 @@ import java.util.Map;
 /**
  * A factory that creates {@link gov.nasa.worldwind.layers.Layer} instances from a shapefile layer configuration source
  * or a shapefile source.
- * <p/>
+ * <p>
  * <h1>Shapefile Geometry Conversion</h1>
- * <p/>
+ * <p>
  * Shapefile geometries are mapped to WorldWind objects as follows:
- * <p/>
+ * <p>
  * <table> <tr><th>Shapefile Geometry</th><th>WorldWind Object</th></tr> <tr><td>Point</td><td>{@link
  * gov.nasa.worldwind.render.PointPlacemark}</td></tr> <tr><td>MultiPoint</td><td>List of {@link
  * gov.nasa.worldwind.render.PointPlacemark}</td></tr> <tr><td>Polyline</td><td>{@link
  * gov.nasa.worldwind.formats.shapefile.ShapefilePolylines}</td></tr> <tr><td>Polygon</td><td>{@link
  * gov.nasa.worldwind.formats.shapefile.ShapefilePolygons}</td></tr> </table>
- * <p/>
+ * <p>
  * In addition, if the DBase attributes file associated with the shapefile has an attribute named "height" or "hgt", the
  * shapes in the shapefile are mapped to {@link gov.nasa.worldwind.formats.shapefile.ShapefileExtrudedPolygons}.
- * <p/>
+ * <p>
  * <h1>Shapefile Attributes</h1>
- * <p/>
+ * <p>
  * Shapefiles may have associated with them a DBase attributes file. This class provides a mechanism for mapping
  * attribute names in the DBase file to keys assigned to the created shapes. The mapping is specified as key/value
  * pairs, the key is the attribute name in the shapefile's DBase attributes file, the value is the key name to attach to
@@ -45,11 +45,11 @@ import java.util.Map;
  * fields in the DBase attributes may be mapped to a {@link gov.nasa.worldwind.avlist.AVKey#DISPLAY_NAME} key in the
  * av-list of the created shapes corresponding to each record. The mapping's key/value pairs are specified using {@link
  * #setDBaseMappings(gov.nasa.worldwind.avlist.AVList)}.
- * <p/>
+ * <p>
  * The rendering attributes applied to the created shapes may be specified to this class, either via the attribute
  * accessors of this class or a configuration file passed to {@link #createFromConfigSource(Object,
  * gov.nasa.worldwind.avlist.AVList)}.
- * <p/>
+ * <p>
  * The key-value attributes and the rendering attributes of certain created shapes may be specified programmatically
  * using a ShapefileRenderable.AttributeDelegate. The delegate is called for each shapefile record encountered during
  * parsing, after this factory applies its DBase attribute mapping and its default rendering attributes. Currently,
@@ -209,7 +209,7 @@ public class ShapefileLayerFactory implements Factory, ShapefileRenderable.Attri
     /**
      * Specifies an attribute delegate to call for each shapefile record encountered during parsing. The delegate is
      * called after this factory applies its DBase attribute mapping and its default rendering attributes.
-     * <p/>
+     * <p>
      * Currently, attribute delegates are called when parsing shapefiles containing polylines, polygons or extruded
      * polygons. shapefiles containing points or multi-points ignore the attribute delegate.
      *
@@ -249,10 +249,10 @@ public class ShapefileLayerFactory implements Factory, ShapefileRenderable.Attri
      * the following: <ul> <li>a {@link java.net.URL}</li> <li>a {@link java.io.File}</li> <li>a {@link
      * java.io.InputStream}</li> <li>{@link Element}</li> <li>a {@link String} holding a file name, a name of a resource
      * on the classpath, or a string representation of a URL</li> </ul>
-     * <p/>
+     * <p>
      * The XML configuration file indicated by the source must contain the shapefile location, and may contain elements
      * specifying shapefile attribute mappings, shape attributes to assign to created shapes, and layer properties.
-     * <p/>
+     * <p>
      * This returns with the new layer immediately, but executes shapefile parsing and shapefile geometry conversion on
      * a separate thread. Shapefile geometry is added to the returned layer as it becomes available. In order to receive
      * notifications when execution completes or if an exception occurs, use {@link #createFromConfigSource(Object,
@@ -287,14 +287,14 @@ public class ShapefileLayerFactory implements Factory, ShapefileRenderable.Attri
      * the following: <ul> <li>a {@link java.net.URL}</li> <li>a {@link java.io.File}</li> <li>a {@link
      * java.io.InputStream}</li> <li>{@link Element}</li> <li>a {@link String} holding a file name, a name of a resource
      * on the classpath, or a string representation of a URL</li> </ul>
-     * <p/>
+     * <p>
      * The XML configuration file indicated by the source must contain the shapefile location, and may contain elements
      * specifying shapefile attribute mappings, shape attributes to assign to created shapes, and layer properties.
-     * <p/>
+     * <p>
      * This returns with the new layer immediately, but executes shapefile parsing and shapefile geometry conversion on
      * a separate thread. Shapefile geometry is added to the returned layer as it becomes available. Once parsing
      * completes, this calls the callback's completion method with the completed layer as the sole argument.
-     * <p/>
+     * <p>
      * If an exception occurs during execution, this catches the exception and forwards it to the callback's exception
      * method. When an exception causes layer parsing or geometry conversion to fail, this calls the callback's
      * completion method before the separate thread terminates.
@@ -349,13 +349,13 @@ public class ShapefileLayerFactory implements Factory, ShapefileRenderable.Attri
      * following: <ul> <li>a {@link java.net.URL}</li> <li>a {@link java.io.File}</li> <li>a {@link
      * java.io.InputStream}</li> <li>{@link Shapefile}</li> <li>a {@link String} holding a file name, a name of a
      * resource on the classpath, or a string representation of a URL</li> </ul>
-     * <p/>
+     * <p>
      * This returns with the new layer immediately, but executes shapefile parsing and shapefile geometry conversion on
      * a separate thread. Shapefile geometry is added to the returned layer as it becomes available. In order to receive
      * notifications when execution completes or if an exception occurs, use {@link #createFromConfigSource(Object,
      * gov.nasa.worldwind.avlist.AVList, gov.nasa.worldwind.formats.shapefile.ShapefileLayerFactory.CompletionCallback)}
      * and specify a completion callback.
-     * <p/>
+     * <p>
      * If the source is a Shapefile instance, it is the responsibility of the caller to close the shapefile after this
      * factory completes execution.
      *
@@ -384,15 +384,15 @@ public class ShapefileLayerFactory implements Factory, ShapefileRenderable.Attri
      * following: <ul> <li>a {@link java.net.URL}</li> <li>a {@link java.io.File}</li> <li>a {@link
      * java.io.InputStream}</li> <li>{@link Shapefile}</li> <li>a {@link String} holding a file name, a name of a
      * resource on the classpath, or a string representation of a URL</li> </ul>
-     * <p/>
+     * <p>
      * This returns with the new layer immediately, but executes shapefile parsing and shapefile geometry conversion on
      * a separate thread. Shapefile geometry is added to the returned layer as it becomes available. Once parsing
      * completes, this calls the callback's completion method with the completed layer as the sole argument.
-     * <p/>
+     * <p>
      * If an exception occurs during execution, this catches the exception and forwards it to the callback's exception
      * method. When an exception causes layer parsing or geometry conversion to fail, this calls the callback's
      * completion method before the separate thread terminates.
-     * <p/>
+     * <p>
      * If the source is a Shapefile instance, it is the responsibility of the caller to close the shapefile after this
      * factory completes execution.
      *

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefilePolygons.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefilePolygons.java
@@ -465,7 +465,7 @@ public class ShapefilePolygons extends ShapefileRenderable implements OrderedRen
      * Values greater than 0 cause shape detail to appear at higher resolution at greater altitudes than normal, but at
      * an increased performance cost. Values less than 0 decrease the default resolution at any given altitude. The
      * default value is 0. Values typically range between -0.5 and 0.5.
-     * <p/>
+     * <p>
      * Note: The resolution-to-height relationship is defined by a scale factor that specifies the approximate size of
      * discernible lengths in the shape relative to eye distance. The scale is specified as a power of 10. A value of 3,
      * for example, specifies that a length of 1 meter on the shape should be distinguishable from an altitude of 10^3
@@ -502,7 +502,7 @@ public class ShapefilePolygons extends ShapefileRenderable implements OrderedRen
     /**
      * Specifies the outline line width to use during picking. A larger width than normal typically makes the outline
      * easier to pick.
-     * <p/>
+     * <p>
      * Note that the size of the pick aperture also affects the precision necessary to pick.
      *
      * @param outlinePickWidth the outline pick width. The default is 10.

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefilePolylines.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefilePolylines.java
@@ -241,7 +241,7 @@ public class ShapefilePolylines extends ShapefileRenderable implements OrderedRe
     /**
      * Specifies the outline line width to use during picking. A larger width than normal typically makes the outline
      * easier to pick.
-     * <p/>
+     * <p>
      * Note that the size of the pick aperture also affects the precision necessary to pick.
      *
      * @param outlinePickWidth the outline pick width. The default is 10.

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecord.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecord.java
@@ -229,7 +229,7 @@ public abstract class ShapefileRecord
     /**
      * Returns a four-element array containing this record's bounding rectangle, or null if this record has no bounding
      * rectangle.
-     * <p/>
+     * <p>
      * The returned array is ordered as follows: minimum Y, maximum Y, minimum X, and maximum X. If the Shapefile's
      * coordinate system is geographic, the elements can be interpreted as angular degrees in the order minimum
      * latitude, maximum latitude, minimum longitude, and maximum longitude.
@@ -280,7 +280,7 @@ public abstract class ShapefileRecord
      * records in a Shapefile must be of the same type. Throws an exception if the types do not match and the shape type
      * is not <code>{@link Shapefile#SHAPE_NULL}</code>. Records of type <code>SHAPE_NULL</code> are always valid, and
      * may appear in any Shapefile.
-     * <p/>
+     * <p>
      * For details, see the ESRI Shapefile specification at <a href="http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf"/>,
      * pages 4 and 5.
      *

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecordMultiPoint.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecordMultiPoint.java
@@ -13,7 +13,7 @@ import java.nio.ByteBuffer;
 /**
  * Represents a Shapefile record with a multi point shape type.  Multi-point shapes represent a set of x,y coordinate
  * pairs.
- * <p/>
+ * <p>
  * Multi-points may have optional z-coordinates or m-coordinates that accompany each x,y coordinate pair. If a
  * Multi-point has z-coordinates, then <code>{@link #getZValues()}</code> returns a non-<code>null</code> array of
  * values.  If a Multi-point has m-coordinates, then <code>{@link #getMValues()}</code> returns a non-<code>null</code>

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecordPoint.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecordPoint.java
@@ -13,7 +13,7 @@ import java.nio.ByteBuffer;
 
 /**
  * Represents a Shapefile record with a point shape type. Point shapes represent a single x,y coordinate pair.
- * <p/>
+ * <p>
  * Point shapes may have an optional z-coordinate or m-coordinate that accompanies the x,y coordinate pair. If a Point
  * has a z-coordinate, then <code>{@link #getZ()}</code> returns a non-<code>null</code> value. If a Point has an
  * m-coordinate, then <code>{@link #getM()}</code> returns a non-<code>null</code> value.

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecordPolygon.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecordPolygon.java
@@ -20,7 +20,7 @@ import java.util.*;
  * more x,y coordinate pairs that form a closed loop. Polygon shapes may contain multiple rings, where each ring is a
  * closed loop of four or more points. Rings defining a filled part of a polygon have a clockwise winding order, while
  * rings defining holes in the polygon have a counter-clockwise winding order.
- * <p/>
+ * <p>
  * Polygons may have optional z-coordinates or m-coordinates that accompany each coordinate pair. If a Polygon has
  * z-coordinates, then <code>{@link #getZValues()}</code> returns a non-<code>null</code> array of values.  If a Polygon
  * has m-coordinates, then <code>{@link #getMValues()}</code> returns a non-<code>null</code> array of values.

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecordPolyline.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefileRecordPolyline.java
@@ -17,7 +17,7 @@ import java.util.Locale;
  * Represents a Shapefile record with a polyline shape type. Polyline shapes represent an connected sequence of two or
  * more x,y coordinate pairs. Polyline shapes may contain multiple parts, where each part is an independent connected
  * sequence of two or more points.
- * <p/>
+ * <p>
  * Polylines may have optional z-coordinates or m-coordinates that accompany each coordinate pair. If a Polyline has
  * z-coordinates, then <code>{@link #getZValues()}</code> returns a non-<code>null</code> array of values.  If a
  * Polyline has m-coordinates, then <code>{@link #getMValues()}</code> returns a non-<code>null</code> array of values.

--- a/src/gov/nasa/worldwind/formats/shapefile/ShapefileRenderable.java
+++ b/src/gov/nasa/worldwind/formats/shapefile/ShapefileRenderable.java
@@ -24,7 +24,7 @@ public abstract class ShapefileRenderable extends WWObjectImpl
      * AttributeDelegate provides an entry point for configuring a ShapefileRenderable.Record's shape attributes and
      * key-value attributes during ShapefileRenderable construction. In particular, the dBASE attributes associated with
      * a ShapefileRecord are available only during these entry points.
-     * <p/>
+     * <p>
      * AttributeDelegate entry points may be called on a non-EDT thread. Implementations of AttributeDelegate may modify
      * the ShapefileRenderable.Record passed to these methods, but should not modify the ShapefileRenderable without
      * synchronizing access with the thread used to create the ShapefileRenderable.
@@ -35,7 +35,7 @@ public abstract class ShapefileRenderable extends WWObjectImpl
          * Entry point for configuring a ShapefileRenderable.Record's shape attributes and key-value attributes during
          * ShapefileRenderable construction. The ShapefileRecord's dBASE attributes are available only during the
          * execution of this method.
-         * <p/>
+         * <p>
          * This method may be called on a non-EDT thread. Implementations may modify the renderableRecord, but should
          * not modify the ShapefileRenderable without synchronizing access with the thread used to create the
          * ShapefileRenderable.

--- a/src/gov/nasa/worldwind/formats/tiff/GeoCodec.java
+++ b/src/gov/nasa/worldwind/formats/tiff/GeoCodec.java
@@ -171,12 +171,12 @@ class GeoCodec
     /**
      * Returns the geocoordinates for a given pixel, as determined by the modeling coordinate tranformation embodied in
      * the GeoCodec.
-     * <p/>
+     * <p>
      * TODO: Also throws UnsupportedOperationException if this is anything other than a "simple" georeferenced mapping,
      * meaning that there's a single tie-point known about the point 0,0, we know the inter-pixel spacing, and there's
      * no rotation of the image required.  Geo referencing may also be specified via a general 4x4 matrix, or by a list
      * if tie-points, implying a rubbersheeting transformation. These two cases remain to be implemented.
-     * <p/>
+     * <p>
      *
      * @param row pixel-row index
      * @param col pixel-column index
@@ -202,7 +202,7 @@ class GeoCodec
 
     /**
      * Gets the values of the given GeoKey as an array of ints.
-     * <p/>
+     * <p>
      * While this method handles the general case of multiple ints associated with a key, typically there will be only a
      * single value.
      *

--- a/src/gov/nasa/worldwind/formats/tiff/GeotiffReader.java
+++ b/src/gov/nasa/worldwind/formats/tiff/GeotiffReader.java
@@ -556,7 +556,7 @@ public class GeotiffReader implements Disposable
 
     /**
      * Returns true if georeferencing information was found in this file.
-     * <p/>
+     * <p>
      * Note: see getGeoKeys() for determining if projection information is contained in the file.
      *
      * @throws java.io.IOException if data type is not supported or unknown

--- a/src/gov/nasa/worldwind/formats/vpf/GeoSymAttributeConverter.java
+++ b/src/gov/nasa/worldwind/formats/vpf/GeoSymAttributeConverter.java
@@ -17,11 +17,11 @@ import java.util.ArrayList;
  * The GeoSymAttributeConverter application converts GeoSym line attributes, area attributes, and area patterns into a
  * form usable by WorldWind VPF shapes. Outputs to "gsac-out" a comma-separated-value (CSV) file containing line and
  * area attributes for VPF line and area shapes, and PNG images containing area patterns for VPF area shapes.
- * <p/>
+ * <p>
  * GeoSymAttributeConverter is used to build the VPF symbol JAR file <code>vpf-symbols.jar</code>. For instructions on
  * how to build <code>vpf-symbols.jar</code>, see the file <code>VPF_README.txt</code>, which is distributed in each
  * WorldWind release.
- * <p/>
+ * <p>
  * <code> Usage: java -cp worldwind.jar gov.nasa.worldwind.formats.vpf.GeoSymAttributeConverter [full path to
  * "GeoSymEd2Final/GRAPHICS/CTEXT"] </code>
  *

--- a/src/gov/nasa/worldwind/formats/vpf/GeoSymAttributeExpressionProvider.java
+++ b/src/gov/nasa/worldwind/formats/vpf/GeoSymAttributeExpressionProvider.java
@@ -99,7 +99,7 @@ public class GeoSymAttributeExpressionProvider
 
     /**
      * See MIL-HDBK-857A, section 6.4.
-     * <p/>
+     * <p>
      * Parses the specified queue of logical expression components according to the precendence rules specified in
      * MIL-HDBK-857A, returning a reference to a a live Expression which may be evaluated against any set of attribute
      * values.

--- a/src/gov/nasa/worldwind/formats/vpf/GeoSymSupport.java
+++ b/src/gov/nasa/worldwind/formats/vpf/GeoSymSupport.java
@@ -562,7 +562,7 @@ public class GeoSymSupport
      * determine at least one "true" condition for a particular instance of a feature in the VPF dataset, there are
      * default CGMs provided in GeoSym for displaying that feature.  The following table identifies which symbol should
      * be used to symbolize an "unknown" point, line, or area feature.
-     * <p/>
+     * <p>
      * Note that the default symbols should only be placed under two conditions: 1.  There is no row in the *sym.txt
      * file for the feature (fcode) 2.  After evaluating all rows in the *sym.txt file for that fcode, there is no row
      * that results in an evaluation of "true".

--- a/src/gov/nasa/worldwind/formats/vpf/VPFBasicSymbolFactory.java
+++ b/src/gov/nasa/worldwind/formats/vpf/VPFBasicSymbolFactory.java
@@ -183,7 +183,7 @@ public class VPFBasicSymbolFactory implements VPFSymbolFactory
     /**
      * From MIL-DTL-89045A, section 3.5.3.1.1: A point feature may be symbolized as either a point symbol or as a text
      * label or both.
-     * <p/>
+     * <p>
      * From MIL-HDBK-857A, section 6.5.3.1: For point features (e.g., buoys, beacons, lights) that are composed of
      * several symbol components, displaying the components according to the row ids in the *sym.txt file will result in
      * the properly constructed composite symbol.
@@ -241,12 +241,12 @@ public class VPFBasicSymbolFactory implements VPFSymbolFactory
     /**
      * From MIL-DTL-89045A, section 3.5.3.1.1: An area feature may be symbolized by any combination of point, line, or
      * area symbol as well as with a text label.
-     * <p/>
+     * <p>
      * From MIL-HDBK-857A, section 6.4.1.4: It is also possible for there to exist multiple symbology components for
      * area features.  The most common situation is the need for the addition of the low accuracy symbol (see
      * 6.4.1.3.4).  This situation is implemented in the same way as for points, with an additional row in the *sym.txt
      * table to control the placement of the low accuracy symbol.
-     * <p/>
+     * <p>
      * It is also possible for the symbolization of an area feature to require multiple rows to specify the components
      * of the full area symbol.  This situation will exist for those area features requiring both a solid fill and a
      * pattern fill.  In this case, the two area symbols will be specified using two rows in the *sym.txt file with the
@@ -254,11 +254,11 @@ public class VPFBasicSymbolFactory implements VPFSymbolFactory
      * also requires a boundary and/or a centered point symbol, those symbols will be specified in the second row for
      * the area feature (along with the area pattern).  Section 6.5 explains the ramifications of this approach in more
      * detail.
-     * <p/>
+     * <p>
      * For these reasons, as well as for the placement of text labels (see section 6.4.1.5), it is crucial that
      * application software access all rows from the sym.txt file for a given product/delineation/feature code in order
      * to ensure full symbolization for any feature.
-     * <p/>
+     * <p>
      * From MIL-HDBK-857A, section 6.5.3.2: There are some area features (e.g., Maritime Areas) that require both a
      * solid fill and one or more pattern fills.  Since the areasym column can only contain a single CGM reference,
      * there is a separate row in the *sym.txt file for each of the area symbols, as well as for the line symbol and/or

--- a/src/gov/nasa/worldwind/formats/vpf/VPFSymbolComparator.java
+++ b/src/gov/nasa/worldwind/formats/vpf/VPFSymbolComparator.java
@@ -14,9 +14,9 @@ import java.util.Comparator;
  * the correct sequence, the GeoSym application software must allow for the definition of a display order for the
  * features being displayed.  GeoSym uses four "nested" methods to define the order in which symbols should be
  * displayed.
- * <p/>
+ * <p>
  * 1. Display priority 2. Feature delineation 3. Order of rows in *sym.txt 4. Symbol type
- * <p/>
+ * <p>
  * 6.5.1  Display Priority.  The first criterion to use to determine the order to display features is the display
  * priority.  Each row in the *sym.txt file defines a display priority number to that specific feature/attribute. The
  * display priority is a value between 0 and 9, where 9 identifies the highest priority.  A feature/attribute with a
@@ -25,31 +25,31 @@ import java.util.Comparator;
  * corresponding S57 object class/attribute.  The S52 lookup tables were then utilized to obtain the display priority
  * values assigned to each object class.  For all other products, the display priority values were based on cartographic
  * experience with the corresponding hardcopy map/chart.
- * <p/>
+ * <p>
  * 6.5.2  Feature Delineation.  Once the features to be displayed have been sorted based on display priority, they must
  * then be sorted by their delineation (area, line, point).  If the display priority is equal among features, then the
  * "painter's algorithm" should be used to display the area features first, followed by the linear features and then the
  * point features.
- * <p/>
+ * <p>
  * 6.5.3  Order of Rows in *sym.txt.  The third criterion that affects the display order is the order of the rows in the
  * fullsym.txt file.  The order will be represented in the id column of each row.  Row ids will always be serial but may
  * not necessarily be consecutive.  Stated another way, the row ID for row N will always be less than the row ID for row
  * N+1.  Symbology being displayed based on this criterion should be displayed based on the least row id to the greatest
  * row id.
- * <p/>
+ * <p>
  * 6.5.3.1  Point Features with Components.  For point features (e.g., buoys, beacons, lights) that are composed of
  * several symbol components, displaying the components according to the row ids in the *sym.txt file will result in the
  * properly constructed composite symbol.  Each symbol component is based on the value of a specific attribute and the
  * components will vary in display priority so should already have been sorted according to that value before examining
  * the row ids in the *sym.txt file.
- * <p/>
+ * <p>
  * 6.5.3.2  Area Features with Multiple Fills.  There are some area features (e.g., Maritime Areas) that require both a
  * solid fill and one or more pattern fills.  Since the areasym column can only contain a single CGM reference, there is
  * a separate row in the *sym.txt file for each of the area symbols, as well as for the line symbol and/or point symbol
  * that apply to the specific area feature.  These multiple rows will have sequential row ids in the *sym.txt file
  * according to the order in which the symbols are to be displayed on the screen:  solid fill, pattern fill (may be more
  * than one), linear boundary, centered point symbol (may be more than one).
- * <p/>
+ * <p>
  * 6.5.3.3  Features with Text Labels  As a general rule, the display priority specified for a feature's text label(s)
  * is the highest value possible, regardless of the display priority assigned to the base feature.  In DNC, all text
  * labels will have a display priority of 8 (per IHO S52).  In all other products, text labels have a display priority
@@ -59,7 +59,7 @@ import java.util.Comparator;
  * for that feature.  Since the row(s) defining the text label(s) will always follow the row(s) defining the CGM symbols
  * for a feature, displaying the symbols and text labels according to their row ids (lowest to highest) in *sym.txt will
  * still result in the correct final symbology for a feature being displayed.
- * <p/>
+ * <p>
  * 6.5.4  Symbol Type.  The final criterion for determining the order for symbol display applies only to area features.
  * Area features can be symbolized by any combination of centered point symbol, linear boundary, solid fill and/or
  * pattern fill.  Except for the special case where an area feature's symbology requires both a solid and pattern

--- a/src/gov/nasa/worldwind/formats/worldfile/WorldFile.java
+++ b/src/gov/nasa/worldwind/formats/worldfile/WorldFile.java
@@ -897,7 +897,7 @@ public class WorldFile
 
     /**
      * Checks if the source is accompanied by any world file
-     * <p/>
+     * <p>
      * The source type may be one of the following: <ul><li>{@link java.net.URL}</li> <li>{@link java.net.URI}</li>
      * <li>{@link java.io.File}</li> <li>{@link String} containing a valid URL description, a valid URI description, or
      * a valid path to a local file.</li> </ul>
@@ -931,7 +931,7 @@ public class WorldFile
 
     /**
      * Reads and decodes world file for the source
-     * <p/>
+     * <p>
      * The source type may be one of the following: <ul><li>{@link java.net.URL}</li> <li>{@link java.net.URI}</li>
      * <li>{@link java.io.File}</li> <li>{@link String} containing a valid URL description, a valid URI description, or
      * a valid path to a local file.</li> </ul>

--- a/src/gov/nasa/worldwind/geom/Angle.java
+++ b/src/gov/nasa/worldwind/geom/Angle.java
@@ -195,13 +195,14 @@ public class Angle implements Comparable<Angle>
 
     /**
      * Obtain an angle from a degrees, minute and seconds character string.
-     * <p>eg:<pre>
+     * <p>eg:
+     * <pre>
      * 123 34 42
      * -123* 34' 42" (where * stands for the degree symbol)
      * +45* 12' 30" (where * stands for the degree symbol)
      * 45 12 30 S
      * 45 12 30 N
-     * </p>
+     * </pre>
      * For a string containing both a sign and compass direction, the compass direction will take precedence.
      *
      * @param dmsString the degrees, minute and second character string.
@@ -579,11 +580,14 @@ public class Angle implements Comparable<Angle>
 
     /**
      * Limits a specified angle to be within a specified minimum and maximum.
-     * <p/>
-     * The returned angle is undefined if min > max. Otherwise, this method's return value is equivalent to the
+     * <p>
+     * The returned angle is undefined if {@code min > max}. Otherwise, this method's return value is equivalent to the
      * following:
-     * <p/>
-     * <ul> <li>min - If value < min</li> <li>max - If value > max</li> <li>value - If min <= value <= max</li> </ul>
+     * <ul> 
+     * <li>min - If {@code value < min}</li> 
+     * <li>max - If {@code value > max}</li> 
+     * <li>value - If {@code min <= value <= max}</li> 
+     * </ul>
      *
      * @param value The angle to clamp.
      * @param min   The minimum angle to clamp to.

--- a/src/gov/nasa/worldwind/geom/Box.java
+++ b/src/gov/nasa/worldwind/geom/Box.java
@@ -29,29 +29,57 @@ public class Box implements Extent, Renderable
      * <code>Box's</code> 2D convex hull in screen coordinates. The index to this table is a 6-bit code, where each bit
      * denotes whether one of the <code>Box's</code> six planes faces the <code>View</code>. This code is organized as
      * follows:
-     * <p/>
-     * <table> <tr><td><strong>Bit</strong></td><td align="center" width="50">5</td><td align="center"
-     * width="50">4</td><td align="center" width="50">3</td><td align="center" width="50">2</td align="center"
-     * width="50"><td align="center" width="50">1</td><td align="center" width="50">0</td></tr> <tr align="center"><td
-     * align="left"><strong>Code</strong></td><td align="center" width="50">left</td><td align="center"
-     * width="50">right</td><td align="center" width="50">back</td><td align="center" width="50">front</td><td
-     * align="center" width="50">bottom</td><td align="center" width="50">top</td></tr> </table>
-     * <p/>
+     * <table> <caption>Codes</caption>
+     * <tr>
+     * <td><strong>Bit</strong></td>
+     * <td align="center">5</td>
+     * <td align="center" >4</td>
+     * <td align="center" >3</td>
+     * <td align="center" >2</td>
+     * <td align="center" >1</td>
+     * <td align="center" >0</td>
+     * </tr>
+     * <tr align="center">
+     * <td align="left"><strong>Code</strong></td>
+     * <td align="center" >left</td>
+     * <td align="center" >right</td>
+     * <td align="center" >back</td>
+     * <td align="center" >front</td>
+     * <td align="center" >bottom</td>
+     * <td align="center" >top</td>
+     * </tr>
+     * </table>
+     * <p>
      * Since at most three of a <code>Box's</code> planes can be visible at one time, there are a total of 26 unique
      * vertex combinations that define a <code>Box's</code> 2D convex hull in the viewport. Index codes that represent a
      * valid combination of planes facing the <code>View</code> result in an array of 4 or 6 integers (depending on
      * whether one, two or three planes face the <code>View</code>), where each element in the array is an index for one
      * of the <code>Box's</code> eight vertices as follows:
-     * <p/>
-     * <table> <tr align="center"><td align="left"><strong>Index</strong></td><td align="center" width="125">0</td><td
-     * align="center" width="125">1</td><td align="center" width="125">2</td><td align="center" width="125">3</td><td
-     * align="center" width="125">4</td><td align="center" width="125">5</td><td align="center" width="125">6</td><td
-     * align="center" width="125">7</td></tr> <tr align="center"><td align="left"><strong>Vertex</strong></td><td
-     * align="center" width="125">bottom-lower-left</td><td align="center" width="125">bottom-lower-right</td><td
-     * align="center" width="125">bottom-upper-right</td><td align="center" width="125">bottom-upper-left</td><td
-     * align="center" width="125">top-lower-left</td><td align="center" width="125">top-lower-right</td><td
-     * align="center" width="125">top-upper-right</td><td align="center" width="125">top-upper-left</td></tr> </table>
-     * <p/>
+     * <table> <caption>Vertices</caption>
+     * <tr align="center">
+     * <td align="left"><strong>Index</strong></td>
+     * <td align="center" >0</td>
+     * <td align="center" >1</td>
+     * <td align="center" >2</td>
+     * <td align="center" >3</td>
+     * <td align="center" >4</td>
+     * <td align="center" >5</td>
+     * <td align="center" >6</td>
+     * <td align="center" >7</td>
+     * </tr>
+     * <tr align="center">
+     * <td align="left"><strong>Vertex</strong></td>
+     * <td align="center" >bottom-lower-left</td>
+     * <td align="center" >bottom-lower-right</td>
+     * <td align="center" >bottom-upper-right</td>
+     * <td align="center" >bottom-upper-left</td>
+     * <td align="center" >top-lower-left</td>
+     * <td align="center" >top-lower-right</td>
+     * <td align="center" >top-upper-right</td>
+     * <td align="center" >top-upper-left</td>
+     * </tr>
+     * </table>
+     * <p>
      * The vertices are organized so that they appear in counter-clockwise order on the screen. Index codes that
      * represent an invalid combination of planes facing the <code>View</code> map to <code>null</code>.
      */
@@ -139,10 +167,10 @@ public class Box implements Extent, Renderable
      * faces are specified by two scalar locations along each axis, each location indicating a face. The non-unit length
      * of an axis is the distance between its respective two locations. The longest side is specified first, followed by
      * the second longest side and then the shortest side.
-     * <p/>
+     * <p>
      * The axes are normally principal axes computed from a collection of points in order to form an oriented bounding
      * volume. See {@link WWMath#computePrincipalAxes(Iterable)}.
-     * <p/>
+     * <p>
      * Note: No check is made to ensure the order of the face locations.
      *
      * @param axes the unit-length axes.
@@ -513,7 +541,7 @@ public class Box implements Extent, Renderable
     /**
      * Computes a <code>Box</code> that bounds a specified buffer of points. Principal axes are computed for the points
      * and used to form a <code>Box</code>.
-     * <p/>
+     * <p>
      * The buffer must contain XYZ coordinate tuples which are either tightly packed or offset by the specified stride.
      * The stride specifies the number of buffer elements between the first coordinate of consecutive tuples. For
      * example, a stride of 3 specifies that each tuple is tightly packed as XYZXYZXYZ, whereas a stride of 5 specifies
@@ -890,7 +918,7 @@ public class Box implements Extent, Renderable
      * <code>view</code>. The returned integer is a 6-bit code, where each bit denotes whether one of this
      * <code>Box's</code> six planes faces the <code>View</code>. See the documentation for <code>{@link
      * #ProjectionHullTable}</code> for details.
-     * <p/>
+     * <p>
      * If the <code>view</code> is inside this <code>Box</code>, this returns 0 indicating that none of this
      * <code>Box's</code> planes face the <code>view</code>.
      *

--- a/src/gov/nasa/worldwind/geom/Extent.java
+++ b/src/gov/nasa/worldwind/geom/Extent.java
@@ -97,7 +97,7 @@ public interface Extent
      * infinite plane defined by the <code>view's</code> viewport. This area is not limited to the size of the
      * <code>view's</code> viewport, and portions of this <code>Extent</code> are not clipped by the <code>view's</code>
      * frustum.
-     * <p/>
+     * <p>
      * This returns <code>Double.POSITIVE_INFINITY</code> if the <code>view's</code> eye point is inside this
      * <code>Extent</code>, or if any portion of this <code>Extent</code> is behind the eye point. In either case, this
      * <code>Extent</code> has no finite projection on the <code>view</code>.

--- a/src/gov/nasa/worldwind/geom/Frustum.java
+++ b/src/gov/nasa/worldwind/geom/Frustum.java
@@ -9,7 +9,7 @@ import gov.nasa.worldwind.util.Logging;
 
 /**
  * Represents a view frustum composed of six planes: left, right, bottom, top, near far.
- * <p/>
+ * <p>
  * Frustum instances are immutable.
  *
  * @author Tom Gaskins
@@ -40,7 +40,7 @@ public class Frustum
 
     /**
      * Create a frustum from six {@link gov.nasa.worldwind.geom.Plane}s defining the frustum boundaries.
-     * <p/>
+     * <p>
      * None of the arguments may be null.
      *
      * @param near   the near plane

--- a/src/gov/nasa/worldwind/geom/LatLon.java
+++ b/src/gov/nasa/worldwind/geom/LatLon.java
@@ -14,7 +14,7 @@ import java.util.*;
 /**
  * Represents a point on the two-dimensional surface of a globe. Latitude is the degrees North and ranges between [-90,
  * 90], while longitude refers to degrees East, and ranges between (-180, 180].
- * <p/>
+ * <p>
  * Instances of <code>LatLon</code> are immutable.
  *
  * @author Tom Gaskins
@@ -1782,16 +1782,16 @@ public class LatLon
 
     /**
      * Computes the distance between two points on an ellipsoid iteratively.
-     * <p/>
+     * <p>
      * NOTE: This method was copied from the UniData NetCDF Java library. http://www.unidata.ucar.edu/software/netcdf-java/
-     * <p/>
+     * <p>
      * Algorithm from U.S. National Geodetic Survey, FORTRAN program "inverse," subroutine "INVER1," by L. PFEIFER and
      * JOHN G. GERGEN. See http://www.ngs.noaa.gov/TOOLS/Inv_Fwd/Inv_Fwd.html
-     * <p/>
+     * <p>
      * Original documentation: SOLUTION OF THE GEODETIC INVERSE PROBLEM AFTER T.VINCENTY MODIFIED RAINSFORD'S METHOD
      * WITH HELMERT'S ELLIPTICAL TERMS EFFECTIVE IN ANY AZIMUTH AND AT ANY DISTANCE SHORT OF ANTIPODAL
      * STANDPOINT/FOREPOINT MUST NOT BE THE GEOGRAPHIC POLE
-     * <p/>
+     * <p>
      * Requires close to 1.4 E-5 seconds wall clock time per call on a 550 MHz Pentium with Linux 7.2.
      * <p>
      * The algorithm used is iterative and will iterate only 10 times if it does not converge.

--- a/src/gov/nasa/worldwind/geom/Matrix.java
+++ b/src/gov/nasa/worldwind/geom/Matrix.java
@@ -1607,12 +1607,16 @@ public class Matrix
     /**
      * Computes a symmetric covariance Matrix from the x, y, z coordinates of the specified points Iterable. This
      * returns null if the points Iterable is empty, or if all of the points are null.
-     * <p/>
+     * <p>
      * The returned covariance matrix represents the correlation between each pair of x-, y-, and z-coordinates as
      * they're distributed about the point Iterable's arithmetic mean. Its layout is as follows:
-     * <p/>
-     * <code> C(x, x)  C(x, y)  C(x, z) <br/> C(x, y)  C(y, y)  C(y, z) <br/> C(x, z)  C(y, z)  C(z, z) </code>
-     * <p/>
+     * <pre>
+     * {@code 
+     * C(x, x)  C(x, y)  C(x, z) 
+     * C(x, y)  C(y, y)  C(y, z) 
+     * C(x, z)  C(y, z)  C(z, z) 
+     * }
+     * </pre>
      * C(i, j) is the covariance of coordinates i and j, where i or j are a coordinate's dispersion about its mean
      * value. If any entry is zero, then there's no correlation between the two coordinates defining that entry. If the
      * returned matrix is diagonal, then all three coordinates are uncorrelated, and the specified point Iterable is
@@ -1672,17 +1676,21 @@ public class Matrix
     /**
      * Computes a symmetric covariance Matrix from the x, y, z coordinates of the specified buffer of points. This
      * returns null if the buffer is empty.
-     * <p/>
+     * <p>
      * The returned covariance matrix represents the correlation between each pair of x-, y-, and z-coordinates as
      * they're distributed about the points arithmetic mean. Its layout is as follows:
-     * <p/>
-     * <code> C(x, x)  C(x, y)  C(x, z) <br/> C(x, y)  C(y, y)  C(y, z) <br/> C(x, z)  C(y, z)  C(z, z) </code>
-     * <p/>
+     * <pre>
+     * <code> 
+     * C(x, x)  C(x, y)  C(x, z) 
+     * C(x, y)  C(y, y)  C(y, z) 
+     * C(x, z)  C(y, z)  C(z, z) 
+     * </code>
+     * </pre>
      * C(i, j) is the covariance of coordinates i and j, where i or j are a coordinate's dispersion about its mean
      * value. If any entry is zero, then there's no correlation between the two coordinates defining that entry. If the
      * returned matrix is diagonal, then all three coordinates are uncorrelated, and the specified points are
      * distributed evenly about their mean point.
-     * <p/>
+     * <p>
      * The buffer must contain XYZ coordinate tuples which are either tightly packed or offset by the specified stride.
      * The stride specifies the number of buffer elements between the first coordinate of consecutive tuples. For
      * example, a stride of 3 specifies that each tuple is tightly packed as XYZXYZXYZ, whereas a stride of 5 specifies
@@ -2422,10 +2430,10 @@ public class Matrix
 
     /**
      * Extracts this viewing matrix's eye point.
-     * <p/>
+     * <p>
      * This method assumes that this matrix represents a viewing matrix. If this does not represent a viewing matrix the
      * results are undefined.
-     * <p/>
+     * <p>
      * In model coordinates, a viewing matrix's eye point is the point the viewer is looking from and maps to the center
      * of the screen.
      *
@@ -2445,10 +2453,10 @@ public class Matrix
 
     /**
      * Extracts this viewing matrix's forward vector.
-     * <p/>
+     * <p>
      * This method assumes that this matrix represents a viewing matrix. If this does not represent a viewing matrix the
      * results are undefined.
-     * <p/>
+     * <p>
      * In model coordinates, a viewing matrix's forward vector is the direction the viewer is looking and maps to a
      * vector going into the screen.
      *
@@ -2463,10 +2471,10 @@ public class Matrix
 
     /**
      * Extracts this viewing matrix's parameters given a viewing origin and a globe.
-     * <p/>
+     * <p>
      * This method assumes that this matrix represents a viewing matrix. If this does not represent a viewing matrix the
      * results are undefined.
-     * <p/>
+     * <p>
      * This returns a parameterization of this viewing matrix based on the specified origin and globe. The origin
      * indicates the model coordinate point that the view's orientation is relative to, while the globe provides the
      * necessary model coordinate context for the origin and the orientation. The origin should be either the view's eye

--- a/src/gov/nasa/worldwind/geom/Plane.java
+++ b/src/gov/nasa/worldwind/geom/Plane.java
@@ -69,7 +69,7 @@ public final class Plane
 
     /**
      * Returns the plane that passes through the specified three points. The plane's normal is the cross product of the
-     * two vectors from <code>pb</code> to </code>pa</code> and <code>pc</code> to </code>pa</code>, respectively. The
+     * two vectors from <code>pb</code> to <code>pa</code> and <code>pc</code> to <code>pa</code>, respectively. The
      * returned plane is undefined if any of the specified points are colinear.
      *
      * @param pa the first point.

--- a/src/gov/nasa/worldwind/geom/PolarPoint.java
+++ b/src/gov/nasa/worldwind/geom/PolarPoint.java
@@ -9,7 +9,7 @@ import gov.nasa.worldwind.util.Logging;
 
 /**
  * Represents a point in space defined by a latitude, longitude and distance from the origin.
- * <p/>
+ * <p>
  * Instances of <code>PolarPoint</code> are immutable.
  *
  * @author Tom Gaskins

--- a/src/gov/nasa/worldwind/geom/Sector.java
+++ b/src/gov/nasa/worldwind/geom/Sector.java
@@ -22,7 +22,7 @@ import java.util.*;
  * 90 degrees latitude and +/- 180 degrees longitude. The minimums and maximums are relative to these ranges, e.g., -80
  * is less than 20. Behavior of the class is undefined for angles outside these ranges. Normalization is not performed
  * on the angles by this class, nor is it verified by the class' methods. See {@link Angle} for a description of
- * specifying angles. <p/> <code>Sector</code> instances are immutable. </p>
+ * specifying angles. <p> <code>Sector</code> instances are immutable. </p>
  *
  * @author Tom Gaskins
  * @version $Id: Sector.java 2397 2014-10-28 17:13:04Z dcollins $
@@ -1048,7 +1048,7 @@ public class Sector implements Cacheable, Comparable<Sector>, Iterable<LatLon>
      * normalized to +/- 90 degrees latitude and +/- 180 degrees longitude. The result of the operation is undefined if
      * they are not.
      *
-     * @param latLon the position to test, with angles normalized to +/- &#960 latitude and +/- 2&#960 longitude.
+     * @param latLon the position to test, with angles normalized to +/- &#960; latitude and +/- 2&#960; longitude.
      *
      * @return <code>true</code> if the position is within the sector, <code>false</code> otherwise.
      *
@@ -1071,8 +1071,8 @@ public class Sector implements Cacheable, Comparable<Sector>, Iterable<LatLon>
      * are assumed to be normalized to +/- 90 degrees latitude and +/- 180 degrees longitude. The result of the
      * operation is undefined if they are not.
      *
-     * @param radiansLatitude  the latitude in radians of the position to test, normalized +/- &#960.
-     * @param radiansLongitude the longitude in radians of the position to test, normalized +/- 2&#960.
+     * @param radiansLatitude  the latitude in radians of the position to test, normalized +/- &#960;.
+     * @param radiansLongitude the longitude in radians of the position to test, normalized +/- 2&#960;.
      *
      * @return <code>true</code> if the position is within the sector, <code>false</code> otherwise.
      */

--- a/src/gov/nasa/worldwind/geom/Sphere.java
+++ b/src/gov/nasa/worldwind/geom/Sphere.java
@@ -13,7 +13,7 @@ import com.jogamp.opengl.GL2;
 import com.jogamp.opengl.glu.*;
 
 /**
- * Represents a sphere in three dimensional space. <p/> Instances of <code>Sphere</code> are immutable. </p>
+ * Represents a sphere in three dimensional space. <p> Instances of <code>Sphere</code> are immutable. </p>
  *
  * @author Tom Gaskins
  * @version $Id: Sphere.java 1171 2013-02-11 21:45:02Z dcollins $

--- a/src/gov/nasa/worldwind/geom/Vec4.java
+++ b/src/gov/nasa/worldwind/geom/Vec4.java
@@ -95,10 +95,12 @@ public class Vec4
     /**
      * Constructs a new Vec4 with coordinate values read from the specified double array. The specified offset must be 0
      * or greater, the specified length must be 1 or greater, and the array must have capacity equal to or greater than
-     * <code>offset + length</code>. Coordinates are assigned as follows:<p><code>x = array[offset]</code><br/> <code>y
-     * = array[offset + 1]</code> if <code>length > 1</code>, otherwise <code>y=0</code><br/><code>z = array[offset +
-     * 2]</code> if <code>length > 2</code>, otherwise <code>z=0</code><br/><code>w = array[offset + 3]</code> if
-     * <code>length > 3</code>, otherwise <code>w=1</code></p>
+     * <code>offset + length</code>. Coordinates are assigned as follows:
+     * <p>
+     * {@code x = array[offset]}<br> 
+     * {@code y = array[offset + 1]} if {@code length > 1}, otherwise {@code y=0}<br>
+     * {@code z = array[offset + * 2]} if {@code length > 2}, otherwise {@code z=0}<br>
+     * {@code w = array[offset + 3]} if {@code length > 3}, otherwise {@code w=1}
      *
      * @param array  the double array from which to read coordinate data.
      * @param offset the array starting index.
@@ -154,10 +156,12 @@ public class Vec4
     /**
      * Constructs a new Vec4 with coordinate values read from the specified float array. The specified offset must be 0
      * or greater, the specified length must be 1 or greater, and the array must have capacity equal to or greater than
-     * <code>offset + length</code>. Coordinates are assigned as follows:<p><code>x = array[offset]</code><br/> <code>y
-     * = array[offset + 1]</code> if <code>length > 1</code>, otherwise <code>y=0</code><br/><code>z = array[offset +
-     * 2]</code> if <code>length > 2</code>, otherwise <code>z=0</code><br/><code>w = array[offset + 3]</code> if
-     * <code>length > 3</code>, otherwise <code>w=1</code></p>
+     * <code>offset + length</code>. Coordinates are assigned as follows:
+     * <p>
+     * {@code x = array[offset]}<br> 
+     * {@code y = array[offset + 1]} if {@code length > 1}, otherwise {@code y=0}<br>
+     * {@code z = array[offset + 2]} if {@code length > 2}, otherwise {@code z=0}<br>
+     * {@code w = array[offset + 3]} if {@code length > 3}, otherwise {@code w=1}
      *
      * @param array  the float array from which to read coordinate data.
      * @param offset the array starting index.
@@ -210,8 +214,10 @@ public class Vec4
     /**
      * Constructs a new Vec4 with <code>x</code> and <code>y</code> values from the specified double array. The
      * specified offset must be 0 or greater, and the array must have capacity equal to or greater than <code>offset +
-     * 2</code>. Coordinates are assigned as follows:<p><code>x = array[offset]</code><br/><code>y = array[offset +
-     * 1]</code></p>
+     * 2</code>. Coordinates are assigned as follows:
+     * <p>
+     * <code>x = array[offset]</code><br>
+     * <code>y = array[offset + 1]</code></p>
      *
      * @param array  the double array from which to read coordinate data.
      * @param offset the array starting index.
@@ -236,8 +242,11 @@ public class Vec4
     /**
      * Constructs a new Vec4 with <code>x</code>, <code>y</code> and <code>z</code> values from the specified double
      * array. The specified offset must be 0 or greater, and the array must have capacity equal to or greater than
-     * <code>offset + 3</code>. Coordinates are assigned as follows:<p><code>x = array[offset]</code><br/><code>y =
-     * array[offset + 1]</code><br/><code>z = array[offset + 2]</code></p>
+     * <code>offset + 3</code>. Coordinates are assigned as follows:
+     * <p>
+     * <code>x = array[offset]</code><br>
+     * <code>y = array[offset + 1]</code><br>
+     * <code>z = array[offset + 2]</code></p>
      *
      * @param array  the double array from which to read coordinate data.
      * @param offset the array starting index.
@@ -263,9 +272,12 @@ public class Vec4
     /**
      * Constructs a new Vec4 with <code>x</code>, <code>y</code>, <code>z</code> and <code>w</code> values from the
      * specified double array. The specified offset must be 0 or greater, and the array must have capacity equal to or
-     * greater than <code>offset + 4</code>. Coordinates are assigned as follows:<p><code>x =
-     * array[offset]</code><br/><code>y = array[offset + 1]</code><br/><code>z = array[offset + 2]</code><br/><code>w =
-     * array[offset + 3]</code></p>
+     * greater than <code>offset + 4</code>. Coordinates are assigned as follows:
+     * <p>
+     * <code>x = array[offset]</code><br>
+     * <code>y = array[offset + 1]</code><br>
+     * <code>z = array[offset + 2]</code><br>
+     * <code>w = array[offset + 3]</code>
      *
      * @param array  the double array from which to read coordinate data.
      * @param offset the array starting index.
@@ -291,11 +303,12 @@ public class Vec4
     /**
      * Writes this Vec4's coordinate values to the specified double array. The specified offset must be 0 or greater,
      * the specified length must be 1 or greater, and the array must have capacity equal to or greater than <code>offset
-     * + length</code>. Coordinates are written to the array as follows:<p><code>array[offset] =
-     * x</code><br/><code>array[offset + 1] = y</code> if <code>length > 1</code>, otherwise <code>array[offset +
-     * 1]</code> is not written to<br/> <code>array[offset + 2] = z</code> if <code>length > 2</code>, otherwise
-     * <code>array[offset + 2]</code> is not written to<br/><code>array[offset + 3] = w</code> if <code>length >
-     * 3</code>, otherwise <code>array[offset + 3]</code> is not written to</p>
+     * + length</code>. Coordinates are written to the array as follows:
+     * <p>
+     * {@code array[offset] = x}<br>
+     * {@code array[offset + 1] = y} if {@code length > 1}, otherwise {@code array[offset + 1]} is not written to<br> 
+     * {@code array[offset + 2] = z} if {@code length > 2}, otherwise {@code array[offset + 2]} is not written to<br>
+     * {@code array[offset + 3] = w} if {@code length > 3}, otherwise {@code array[offset + 3]} is not written to</p>
      *
      * @param array  the double array to receive the coordinate data.
      * @param offset the array starting index.
@@ -351,11 +364,12 @@ public class Vec4
     /**
      * Writes this Vec4's coordinate values to the specified float array. The specified offset must be 0 or greater, the
      * specified length must be 1 or greater, and the array must have capacity equal to or greater than <code>offset +
-     * length</code>. Coordinates are written to the array as follows:<p><code>array[offset] =
-     * x</code><br/><code>array[offset + 1] = y</code> if <code>length > 1</code>, otherwise <code>array[offset +
-     * 1]</code> is not written to<br/> <code>array[offset + 2] = z</code> if <code>length > 2</code>, otherwise
-     * <code>array[offset + 2]</code> is not written to<br/><code>array[offset + 3] = w</code> if <code>length >
-     * 3</code>, otherwise <code>array[offset + 3]</code> is not written to</p>
+     * length</code>. Coordinates are written to the array as follows:
+     * <p>
+     * {@code array[offset] = x}<br>
+     * {@code array[offset + 1] = y} if {@code length > 1}, otherwise {@code array[offset + 1]} is not written to<br> 
+     * {@code array[offset + 2] = z} if {@code length > 2}, otherwise {@code array[offset + 2]} is not written to<br>
+     * {@code array[offset + 3] = w} if {@code length > 3}, otherwise {@code array[offset + 3]} is not written to</p>
      *
      * @param array  the float array to receive the coordinate data.
      * @param offset the array starting index.
@@ -410,8 +424,10 @@ public class Vec4
     /**
      * Writes this Vec4's <code>x</code> and <code>y</code> values to the specified double array. The specified offset
      * must be 0 or greater, and the array must have have capacity equal to or greater than <code>offset + 2</code>.
-     * Coordinates are written to the array as follows:<p><code>array[offset] = x</code><br/><code>array[offset + 1] =
-     * y</code></p>
+     * Coordinates are written to the array as follows:
+     * <p>
+     * <code>array[offset] = x</code><br>
+     * <code>array[offset + 1] = y</code></p>
      *
      * @param array  the double array to receive the coordinate data.
      * @param offset the array starting index.
@@ -436,8 +452,11 @@ public class Vec4
     /**
      * Writes this Vec4's <code>x</code>, <code>y</code> and <code>z</code> values to the specified double array. The
      * specified offset must be 0 or greater, and the array must have have capacity equal to or greater than
-     * <code>offset + 3</code>. Coordinates are written to the array as follows:<p><code>array[offset] =
-     * x</code><br/><code>array[offset + 1] = y</code><br/><code>array[offset + 2] = z</code></p>
+     * <code>offset + 3</code>. Coordinates are written to the array as follows:
+     * <p>
+     * <code>array[offset] = x</code><br>
+     * <code>array[offset + 1] = y</code><br>
+     * <code>array[offset + 2] = z</code></p>
      *
      * @param array  the double array to receive the coordinate data.
      * @param offset the array starting index.
@@ -462,9 +481,12 @@ public class Vec4
     /**
      * Writes this Vec4's <code>x</code>, <code>y</code>, <code>z</code> and <code>w</code> values to the specified
      * double array. The specified offset must be 0 or greater, and the array must have have capacity equal to or
-     * greater than <code>offset + 4</code>. Coordinates are written to the array as follows:<p><code>array[offset] =
-     * x</code><br/><code>array[offset + 1] = y</code><br/><code>array[offset + 2] = z</code><br/><code>array[offset +
-     * 3] = w</code></p>
+     * greater than <code>offset + 4</code>. Coordinates are written to the array as follows:
+     * <p>
+     * <code>array[offset] = x</code><br>
+     * <code>array[offset + 1] = y</code><br>
+     * <code>array[offset + 2] = z</code><br>
+     * <code>array[offset + 3] = w</code></p>
      *
      * @param array  the double array to receive the coordinate data.
      * @param offset the array starting index.
@@ -490,7 +512,7 @@ public class Vec4
      * Returns a representation of this vector as an <code>x y z</code> point suitable for use where four-dimensional
      * homogeneous coordinates are required. The returned vector has <code>x y z</code> coordinates are equal to this
      * vector's <code>x y z</code> coordinates, and has <code>w</code> coordinate equal to 1.0.
-     * <p/>
+     * <p>
      * A three-dimensional point in homogeneous coordinates is necessary when transforming that point by a 4x4
      * transformation matrix, or when calculating the dot product of the point and the equation of a plane. The returned
      * vector is affected by the translation component of a 4x4 transformation matrix.
@@ -512,7 +534,7 @@ public class Vec4
      * Returns a representation of this vector as an <code>x y z</code> direction suitable for use where
      * four-dimensional homogeneous coordinates are required. The returned vector has <code>x y z</code> coordinates are
      * equal to this vector's <code>x y z</code> coordinates, and has <code>w</code> coordinate equal to 0.0.
-     * <p/>
+     * <p>
      * A three-dimensional direction in homogeneous coordinates is necessary when transforming that direction by a 4x4
      * transformation matrix. The returned vector is not affected by the translation component of a 4x4 transformation
      * matrix, and therefore remains invariant under translation.
@@ -1153,7 +1175,7 @@ public class Vec4
     /**
      * Returns the arithmetic mean of the x, y, z coordinates of the specified points buffer. This returns null if the
      * buffer is empty.
-     * <p/>
+     * <p>
      * The buffer must contain XYZ coordinate tuples which are either tightly packed or offset by the specified stride.
      * The stride specifies the number of buffer elements between the first coordinate of consecutive tuples. For
      * example, a stride of 3 specifies that each tuple is tightly packed as XYZXYZXYZ, whereas a stride of 5 specifies

--- a/src/gov/nasa/worldwind/geom/coords/MGRSCoord.java
+++ b/src/gov/nasa/worldwind/geom/coords/MGRSCoord.java
@@ -109,10 +109,10 @@ public class MGRSCoord
      * <p>
      * The string will be converted to uppercase and stripped of all spaces before being evaluated.
      * </p>
-     * <p>Valid examples:<br />
-     * 32TLP5626635418<br />
-     * 32 T LP 56266 35418<br />
-     * 11S KU 528 111<br />
+     * <p>Valid examples:<br>
+     * 32TLP5626635418<br>
+     * 32 T LP 56266 35418<br>
+     * 11S KU 528 111<br>
      * </p>
      * @param MGRSString the MGRS coordinate text string.
      * @param globe the <code>Globe</code> - can be null (will use WGS84).

--- a/src/gov/nasa/worldwind/geom/coords/MGRSCoordConverter.java
+++ b/src/gov/nasa/worldwind/geom/coords/MGRSCoordConverter.java
@@ -861,7 +861,7 @@ class MGRSCoordConverter
      * The function Get_Grid_Values sets the letter range used for the 2nd letter in the MGRS coordinate string, based
      * on the set number of the utm zone. It also sets the false northing using a value of A for the second letter of
      * the grid square, based on the grid pattern and set number of the utm zone.
-     * <p/>
+     * <p>
      * Key values that are set in this function include:  ltr2_low_value, ltr2_high_value, and false_northing.
      *
      * @param zone Zone number

--- a/src/gov/nasa/worldwind/globes/ElevationModel.java
+++ b/src/gov/nasa/worldwind/globes/ElevationModel.java
@@ -11,16 +11,16 @@ import gov.nasa.worldwind.geom.*;
 import java.util.List;
 
 /**
- * <p/>
+ * <p>
  * Provides the elevations to a {@link Globe} or other object holding elevations.
- * <p/>
+ * <p>
  * An <code>ElevationModel</code> often approximates elevations at multiple levels of spatial resolution. For any given
  * viewing position, the model determines an appropriate target resolution. That target resolution may not be
  * immediately achievable, however, because the corresponding elevation data might not be locally available and must be
  * retrieved from a remote location. When this is the case, the <code>Elevations</code> object returned for a sector
  * holds the resolution achievable with the data currently available. That resolution may not be the same as the target
  * resolution. The achieved resolution is made available in the interface.
- * <p/>
+ * <p>
  *
  * @author Tom Gaskins
  * @version $Id: ElevationModel.java 3420 2015-09-10 23:25:43Z tgaskins $
@@ -84,7 +84,7 @@ public interface ElevationModel extends WWObject, Restorable, Disposable
     /**
      * Specifies the value used to identify missing data in an elevation model. Locations with this elevation value are
      * assigned the missing-data replacement value, specified by {@link #setMissingDataReplacement(double)}.
-     * <p/>
+     * <p>
      * The missing-data value is often specified by the metadata of the data set, in which case the elevation model
      * automatically defines that value to be the missing-data signal. When the missing-data signal is not specified in
      * the metadata, the application may specify it via this method.
@@ -194,7 +194,7 @@ public interface ElevationModel extends WWObject, Restorable, Disposable
      * Returns the elevation at a specified location. If the elevation at the specified location is the elevation
      * model's missing data signal, or if the location specified is outside the elevation model's coverage area, the
      * elevation model's missing data replacement value is returned.
-     * <p/>
+     * <p>
      * The elevation returned from this method is the best available in memory. If no elevation is in memory, the
      * elevation model's minimum extreme elevation at the location is returned. Local disk caches are not consulted.
      *

--- a/src/gov/nasa/worldwind/globes/EllipsoidalGlobe.java
+++ b/src/gov/nasa/worldwind/globes/EllipsoidalGlobe.java
@@ -902,12 +902,12 @@ public class EllipsoidalGlobe extends WWObjectImpl implements Globe
      * points to the intersection of the prime meridian and the equator, in the equatorial plane. The X axis completes a
      * right-handed coordinate system, and is 90 degrees east of the Z axis and also in the equatorial plane. Sea level
      * is at z = zero.
-     * <p/>
+     * <p>
      * This method provides an interface for efficient generation of a grid of cartesian points within a sector. The
      * grid is constructed by dividing the sector into <code>numLon x numLat</code> evenly separated points in
      * geographic coordinates. The first and last points in latitude and longitude are placed at the sector's minimum
      * and maximum boundary, and the remaining points are spaced evenly between those boundary points.
-     * <p/>
+     * <p>
      * For each grid point within the sector, an elevation value is specified via an array of elevations. The
      * calculation at each position incorporates the associated elevation.
      *

--- a/src/gov/nasa/worldwind/globes/FlatGlobe.java
+++ b/src/gov/nasa/worldwind/globes/FlatGlobe.java
@@ -17,7 +17,7 @@ import gov.nasa.worldwind.util.Logging;
  * is Mercator. New projections may be added by extending this class and overriding {@link
  * #geodeticToCartesian(gov.nasa.worldwind.geom.Angle, gov.nasa.worldwind.geom.Angle, double) geodeticToCartesian}
  * {@link #cartesianToGeodetic(gov.nasa.worldwind.geom.Vec4) cartesianToGeodetic}.
- * <p/>
+ * <p>
  * This globe uses a Cartesian coordinate system in the world plane is located at the origin and has UNIT-Z as normal.
  * The Y axis points to the north pole. The Z axis points up. The X axis completes a right-handed coordinate system, and
  * points east. Latitude and longitude zero are at the origin on y and x respectively. Sea level is at z = zero.

--- a/src/gov/nasa/worldwind/globes/GeographicProjection.java
+++ b/src/gov/nasa/worldwind/globes/GeographicProjection.java
@@ -11,7 +11,7 @@ import gov.nasa.worldwind.geom.*;
 /**
  * Defines an interface to project geographic coordinates to Cartesian coordinates. Used by {@link Globe2D}
  * implementations to transform geographic coordinates to meters and back.
- * <p/>
+ * <p>
  * Each implementation of this interface defines its own constructors, which may accept arguments that completely define
  * the projection.
  *
@@ -55,7 +55,7 @@ public interface GeographicProjection
 
     /**
      * Converts a geographic position to meters in Cartesian coordinates.
-     * <p/>
+     * <p>
      * Note: The input arguments are not checked for <code>null</code> prior to being used. The caller, typically a
      * {@link Globe2D} implementation, is expected do perform that check prior to calling this method.
      *
@@ -75,12 +75,12 @@ public interface GeographicProjection
 
     /**
      * Converts a grid of geographic positions to a grid of points in Cartesian coordinates.
-     * <p/>
+     * <p>
      * This method provides an interface for efficient generation of a grid of cartesian points within a sector. The
      * grid is constructed by dividing the sector into <code>numLon x numLat</code> evenly separated points in
      * geographic coordinates. The first and last points in latitude and longitude are placed at the sector's minimum
      * and maximum boundary, and the remaining points are spaced evenly between those boundary points.
-     * <p/>
+     * <p>
      * For each grid point within the sector, an elevation value is specified via an array of elevations. The
      * calculation at each position incorporates the associated elevation.
      *
@@ -104,7 +104,7 @@ public interface GeographicProjection
 
     /**
      * Converts a Cartesian point in meters to a geographic position.
-     * <p/>
+     * <p>
      * Note: The input arguments are not checked for <code>null</code> prior to being used. The caller, typically a
      * {@link Globe2D} implementation, is expected do perform that check prior to calling this method.
      *

--- a/src/gov/nasa/worldwind/globes/Globe.java
+++ b/src/gov/nasa/worldwind/globes/Globe.java
@@ -17,27 +17,27 @@ import java.util.List;
  * elevations for geographic positions on the surface of the globe. Globe provides methods for converting geographic
  * positions (latitude, longitude, and elevation) to cartesian coordinates, and for converting cartesian to geographic.
  * The origin and orientation of the cartesian coordinate system are determined by implementations of this interface.
- * <p/>
+ * 
  * <h1>Computations in Cartesian Coordinates</h1>
- * <p/>
+ * <p>
  * Globe provides methods for performing computations in the coordinate system represented by a globe's surface in
  * cartesian coordinates. These methods perform work with respect to the globe's actual shape in 3D cartesian
  * coordinates. For an ellipsoidal globe, these methods are equivalent to the ellipsoidal coordinate computations below.
  * For an instance of {@link Globe2D}, these methods work in the cartesian coordinates specified by the globe's 2D
  * projection.
- * <p/>
+ * 
  * <ul> <li>{@link #computePointFromPosition(gov.nasa.worldwind.geom.Angle, gov.nasa.worldwind.geom.Angle, double)}</li>
  * <li>{@link #computePositionFromPoint(gov.nasa.worldwind.geom.Vec4)}</li> <li>{@link
  * #computeSurfaceNormalAtLocation(gov.nasa.worldwind.geom.Angle, gov.nasa.worldwind.geom.Angle)}</li> <li>{@link
  * #computeSurfaceOrientationAtPosition(gov.nasa.worldwind.geom.Angle, gov.nasa.worldwind.geom.Angle, double)}</li>
  * </ul>
- * <p/>
+ * 
  * <h1>Computations in Ellipsoidal Coordinates</h1>
- * <p/>
+ * <p>
  * Globe provides methods for performing computation on the ellipsoid represented by a globe's equatorial radius and its
  * polar radius. These methods perform work with respect to the ellipsoid in 3D cartesian coordinates. Calling any of
  * these methods on an instance of Globe2D will return the same result as a 3D globe with equivalent radii.
- * <p/>
+ * 
  * <ul> <li>{@link #computeEllipsoidalPointFromPosition(gov.nasa.worldwind.geom.Angle, gov.nasa.worldwind.geom.Angle,
  * double)}</li> <li>{@link #computePositionFromEllipsoidalPoint(gov.nasa.worldwind.geom.Vec4)}</li> <li>{@link
  * #computeEllipsoidalNormalAtLocation(gov.nasa.worldwind.geom.Angle, gov.nasa.worldwind.geom.Angle)}</li> <li>{@link
@@ -91,7 +91,7 @@ public interface Globe extends WWObject, Extent
      * Indicates the elevation at a specified location. If the elevation at the specified location is the elevation
      * model's missing data signal, or if the location specified is outside the elevation model's coverage area, the
      * elevation model's missing data replacement value is returned.
-     * <p/>
+     * <p>
      * The elevation returned from this method is the best available in memory. If no elevation is in memory, the
      * elevation model's minimum extreme elevation at the location is returned. Local disk caches are not consulted.
      *
@@ -242,12 +242,12 @@ public interface Globe extends WWObject, Extent
 
     /**
      * Computes a grid of cartesian points corresponding to a grid of geographic positions.
-     * <p/>
+     * <p>
      * This method provides an interface for efficient generation of a grid of cartesian points within a sector. The
      * grid is constructed by dividing the sector into <code>numLon x numLat</code> evenly separated points in
      * geographic coordinates. The first and last points in latitude and longitude are placed at the sector's minimum
      * and maximum boundary, and the remaining points are spaced evenly between those boundary points.
-     * <p/>
+     * <p>
      * For each grid point within the sector, an elevation value is specified via an array of elevations. The
      * calculation at each position incorporates the associated elevation.
      *
@@ -296,12 +296,20 @@ public interface Globe extends WWObject, Extent
      */
     Vec4 computeNorthPointingTangentAtLocation(Angle latitude, Angle longitude);
 
-    /** @see #computeSurfaceOrientationAtPosition(gov.nasa.worldwind.geom.Angle, gov.nasa.worldwind.geom.Angle, double). */
-    @SuppressWarnings({"JavaDoc"})
+    /**
+     * @param latitude Latitude of the location.
+     * @param longitude Longitude of the location.
+     * @param metersElevation Elevation of the location
+     * @return Matrix
+     * @see #computeSurfaceOrientationAtPosition(gov.nasa.worldwind.geom.Angle, gov.nasa.worldwind.geom.Angle, double) 
+     */
     Matrix computeModelCoordinateOriginTransform(Angle latitude, Angle longitude, double metersElevation);
 
-    /** @see #computeSurfaceOrientationAtPosition(gov.nasa.worldwind.geom.Position) */
-    @SuppressWarnings({"JavaDoc"})
+    /**
+     * @param position Position
+     * @return Matrix
+     * @see #computeSurfaceOrientationAtPosition(gov.nasa.worldwind.geom.Position) 
+     */
     Matrix computeModelCoordinateOriginTransform(Position position);
 
     /**
@@ -336,7 +344,7 @@ public interface Globe extends WWObject, Extent
 
     /**
      * Computes a ellipsoidal point from a latitude, longitude, and elevation.
-     * <p/>
+     * <p>
      * The returned point is a function of this globe's equatorial radius and its polar radius, and always represents a
      * point on the ellipsoid in 3D cartesian coordinates that corresponds to the specified position. Calling this
      * method on an instance of Globe2D will return a point on the ellipsoid defined by the 2D globe's radii.
@@ -354,7 +362,7 @@ public interface Globe extends WWObject, Extent
 
     /**
      * Computes a ellipsoidal point from a latitude and longitude.
-     * <p/>
+     * <p>
      * The returned point is a function of this globe's equatorial radius and its polar radius, and always represents a
      * point on the ellipsoid in 3D cartesian coordinates that corresponds to the specified location. Calling this
      * method on an instance of Globe2D will return a point on the ellipsoid defined by the 2D globe's radii.
@@ -369,7 +377,7 @@ public interface Globe extends WWObject, Extent
 
     /**
      * Computes a ellipsoidal point from a latitude, longitude, and elevation.
-     * <p/>
+     * <p>
      * The returned point is a function of this globe's equatorial radius and its polar radius, and always represents a
      * point on the ellipsoid in 3D cartesian coordinates that corresponds to the specified position. Calling this
      * method on an instance of Globe2D will return a point on the ellipsoid defined by the 2D globe's radii.
@@ -385,7 +393,7 @@ public interface Globe extends WWObject, Extent
 
     /**
      * Computes the geographic position of a point in ellipsoidal coordinates.
-     * <p/>
+     * <p>
      * The returned position is a function of this globe's equatorial radius and its polar radius, and always represents
      * a position corresponding to the point on the ellipsoid in 3D cartesian coordinates. Calling this method on an
      * instance of Globe2D will return a position corresponding to the ellipsoid defined by the 2D globe's radii.
@@ -400,7 +408,7 @@ public interface Globe extends WWObject, Extent
     /**
      * Computes a vector perpendicular to the surface of the ellipsoid specified by this globe, in cartesian
      * coordinates.
-     * <p/>
+     * <p>
      * The returned vector is a function of this globe's equatorial radius and its polar radius, and always represents a
      * vector normal to the corresponding ellipsoid in 3D cartesian coordinates. Calling this method on an instance of
      * Globe2D will return a vector normal to the ellipsoid defined by the 2D globe's radii.
@@ -421,7 +429,7 @@ public interface Globe extends WWObject, Extent
      * East. The Y axis is mapped to the vector tangent to the ellipsoid and pointing to the North Pole. The Z axis is
      * mapped to the ellipsoidal normal at (latitude, longitude, metersElevation). The origin is mapped to the
      * ellipsoidal position of (latitude, longitude, metersElevation).
-     * <p/>
+     * <p>
      * The returned matrix is a function of this globe's equatorial radius and its polar radius, and always represents a
      * transform matrix appropriate for the corresponding ellipsoid in 3D cartesian coordinates. Calling this method on
      * an instance of Globe2D will return a transform matrix for the ellipsoid defined by the 2D globe's radii.

--- a/src/gov/nasa/worldwind/globes/projections/ProjectionTransverseMercator.java
+++ b/src/gov/nasa/worldwind/globes/projections/ProjectionTransverseMercator.java
@@ -16,7 +16,7 @@ import gov.nasa.worldwind.util.*;
  * may be specified and defaults to the Prime Meridian (0 longitude). By default, the projection computes values for 30
  * degrees either side of the central meridian. This may be changed via the {@link
  * #setWidth(gov.nasa.worldwind.geom.Angle)} method, but the projection may fail for large widths.
- * <p/>
+ * <p>
  * The projection limits are modified to reflect the central meridian and the width, however the projection limits are
  * clamped to a minimum of -180 degrees and a maximum of +180 degrees. It's therefore not possible to display a band
  * whose central meridian is plus or minus 180.

--- a/src/gov/nasa/worldwind/layers/AbstractGraticuleLayer.java
+++ b/src/gov/nasa/worldwind/layers/AbstractGraticuleLayer.java
@@ -617,9 +617,11 @@ public class AbstractGraticuleLayer extends AbstractLayer
     }
 
     /**
-     * Determines whether the grid should be updated. It returns true if: <ul> <li>the eye has moved more than 1% of its
-     * altitude above ground <li>the view FOV, heading or pitch have changed more than 1 degree <li>vertical
-     * exaggeration has changed </ul
+     * Determines whether the grid should be updated. It returns true if:
+     * <ul>
+     * <li>the eye has moved more than 1% of its altitude above ground
+     * <li>the view FOV, heading or pitch have changed more than 1 degree <li>vertical exaggeration has changed
+     * </ul>
      *
      * @param dc the current <code>DrawContext</code>.
      *

--- a/src/gov/nasa/worldwind/layers/AbstractLayer.java
+++ b/src/gov/nasa/worldwind/layers/AbstractLayer.java
@@ -385,12 +385,16 @@ public abstract class AbstractLayer extends WWObjectImpl implements Layer
 
     /**
      * Appends layer configuration parameters as elements to the specified context. This appends elements for the
-     * following parameters: <table> <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> <tr><td>{@link
-     * AVKey#DISPLAY_NAME}</td><td>DisplayName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#OPACITY}</td><td>Opacity</td><td>Double</td></tr> <tr><td>{@link AVKey#MAX_ACTIVE_ALTITUDE}</td><td>ActiveAltitudes/@max</td><td>Double</td></tr>
-     * <tr><td>{@link AVKey#MIN_ACTIVE_ALTITUDE}</td><td>ActiveAltitudes/@min</td><td>Double</td></tr> <tr><td>{@link
-     * AVKey#NETWORK_RETRIEVAL_ENABLED}</td><td>NetworkRetrievalEnabled</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#MAP_SCALE}</td><td>MapScale</td><td>Double</td></tr> <tr><td>{@link AVKey#SCREEN_CREDIT}</td><td>ScreenCredit</td><td>ScreenCredit</td></tr>
+     * following parameters: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr>
+     * <tr><td>{@link AVKey#DISPLAY_NAME}</td><td>DisplayName</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#OPACITY}</td><td>Opacity</td><td>Double</td></tr>
+     * <tr><td>{@link AVKey#MAX_ACTIVE_ALTITUDE}</td><td>ActiveAltitudes/@max</td><td>Double</td></tr>
+     * <tr><td>{@link AVKey#MIN_ACTIVE_ALTITUDE}</td><td>ActiveAltitudes/@min</td><td>Double</td></tr>
+     * <tr><td>{@link AVKey#NETWORK_RETRIEVAL_ENABLED}</td><td>NetworkRetrievalEnabled</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#MAP_SCALE}</td><td>MapScale</td><td>Double</td></tr>
+     * <tr><td>{@link AVKey#SCREEN_CREDIT}</td><td>ScreenCredit</td><td>ScreenCredit</td></tr>
      * </table>
      *
      * @param params  the key-value pairs which define the layer configuration parameters.
@@ -441,13 +445,17 @@ public abstract class AbstractLayer extends WWObjectImpl implements Layer
     /**
      * Parses layer configuration parameters from the specified DOM document. This writes output as key-value pairs to
      * params. If a parameter from the XML document already exists in params, that parameter is ignored. Supported key
-     * and parameter names are: <table> <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> <tr><td>{@link
-     * AVKey#DISPLAY_NAME}</td><td>DisplayName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#OPACITY}</td><td>Opacity</td><td>Double</td></tr> <tr><td>{@link AVKey#MAX_ACTIVE_ALTITUDE}</td><td>ActiveAltitudes/@max</td><td>Double</td></tr>
-     * <tr><td>{@link AVKey#MIN_ACTIVE_ALTITUDE}</td><td>ActiveAltitudes/@min</td><td>Double</td></tr> <tr><td>{@link
-     * AVKey#NETWORK_RETRIEVAL_ENABLED}</td><td>NetworkRetrievalEnabled</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#MAP_SCALE}</td><td>MapScale</td><td>Double</td></tr> <tr><td>{@link AVKey#SCREEN_CREDIT}</td><td>ScreenCredit</td><td>{@link
-     * ScreenCredit}</td></tr> </table>
+     * and parameter names are: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> 
+     * <tr><td>{@link AVKey#DISPLAY_NAME}</td><td>DisplayName</td><td>String</td> </tr> 
+     * <tr><td>{@link AVKey#OPACITY}</td><td>Opacity</td><td>Double</td></tr> 
+     * <tr><td>{@link AVKey#MAX_ACTIVE_ALTITUDE}</td><td>ActiveAltitudes/@max</td><td>Double</td></tr>
+     * <tr><td>{@link AVKey#MIN_ACTIVE_ALTITUDE}</td><td>ActiveAltitudes/@min</td><td>Double</td></tr> 
+     * <tr><td>{@link AVKey#NETWORK_RETRIEVAL_ENABLED}</td><td>NetworkRetrievalEnabled</td><td>Boolean</td></tr> 
+     * <tr><td>{@link AVKey#MAP_SCALE}</td><td>MapScale</td><td>Double</td></tr> 
+     * <tr><td>{@link AVKey#SCREEN_CREDIT}</td><td>ScreenCredit</td><td>{@link ScreenCredit}</td></tr> 
+     * </table>
      *
      * @param domElement the XML document root to parse for layer configuration elements.
      * @param params     the output key-value pairs which recieve the layer configuration parameters. A null reference

--- a/src/gov/nasa/worldwind/layers/AirspaceLayer.java
+++ b/src/gov/nasa/worldwind/layers/AirspaceLayer.java
@@ -196,7 +196,7 @@ public class AirspaceLayer extends AbstractLayer
      * layer will maintain a reference to <code>airspaceIterable</code> strictly for picking and rendering. This layer
      * will not modify the Iterable reference. However, this will clear the internal collection of Airspaces, and will
      * prevent any modification to its contents via <code>addAirspace, addAirspaces, or removeAirspaces</code>.
-     * <p/>
+     * <p>
      * If the specified <code>airspaceIterable</code> is null, this layer will revert to maintaining its internal
      * collection.
      *

--- a/src/gov/nasa/worldwind/layers/AnnotationLayer.java
+++ b/src/gov/nasa/worldwind/layers/AnnotationLayer.java
@@ -182,7 +182,7 @@ public class AnnotationLayer extends AbstractLayer
      * layer will maintain a reference to <code>annotationIterable</code> strictly for picking and rendering. This layer
      * will not modify the Iterable reference. However, this will clear the internal collection of Annotations, and will
      * prevent any modification to its contents via <code>addAnnotation, addAnnotations, or removeAnnotations</code>.
-     * <p/>
+     * <p>
      * If the specified <code>annotationIterable</code> is null, this layer will revert to maintaining its internal
      * collection.
      *

--- a/src/gov/nasa/worldwind/layers/BasicLayerFactory.java
+++ b/src/gov/nasa/worldwind/layers/BasicLayerFactory.java
@@ -34,7 +34,7 @@ public class BasicLayerFactory extends BasicFactory
      * <li>a {@link java.net.URL}</li> <li>a {@link java.io.File}</li> <li>a {@link java.io.InputStream}</li> <li>{@link
      * Element}</li> <li>a {@link String} holding a file name, a name of a resource on the classpath, or a string
      * representation of a URL</li> </ul>
-     * <p/>
+     * <p>
      * For tiled image layers, this maps the <code>serviceName</code> attribute of the <code>Layer/Service</code>
      * element of the XML configuration file to the appropriate base tiled image layer type. Service types recognized
      * are: <ul> <li>"WMS" for layers that draw their data from a WMS web service.</li> <li>"WWTileService" for layers
@@ -134,7 +134,7 @@ public class BasicLayerFactory extends BasicFactory
     /**
      * Create a collection of layer lists and their included layers described by an array of XML layer-list description
      * elements.
-     * <p/>
+     * <p>
      * Any exceptions occurring during creation of the layer lists or their included layers are logged and not
      * re-thrown. The layers associated with the exceptions are not included in the returned layer list.
      *
@@ -211,7 +211,7 @@ public class BasicLayerFactory extends BasicFactory
 
     /**
      * Create a list of layers described by an array of XML layer description elements.
-     * <p/>
+     * <p>
      * Any exceptions occurring during creation of the layers are logged and not re-thrown. The layers associated with
      * the exceptions are not included in the returned layer list.
      *
@@ -250,7 +250,7 @@ public class BasicLayerFactory extends BasicFactory
      *
      * @throws WWUnrecognizedException if the layer type or service type given in the describing element is
      *                                 unrecognized.
-     * @see #createTiledImageLayer(org.w3c.dom.Element, gov.nasa.worldwind.avlist.AVList).
+     * @see #createTiledImageLayer(org.w3c.dom.Element, gov.nasa.worldwind.avlist.AVList)
      */
     protected Layer createFromLayerDocument(Element domElement, AVList params)
     {

--- a/src/gov/nasa/worldwind/layers/BasicTiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/BasicTiledImageLayer.java
@@ -346,7 +346,7 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
      * the specified format. Otherwise, this returns the texture data in its native format. If <code>useMipMaps</code>
      * is true, this generates mip maps for any non-DDS texture data, and uses any mip-maps contained in DDS texture
      * data.
-     * <p/>
+     * <p>
      * Supported texture formats are as follows: <ul> <li><code>image/dds</code> - Returns DDS texture data, converting
      * the data to DDS if necessary. If the data is already in DDS format it's returned as-is.</li> </ul>
      *
@@ -401,10 +401,10 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all imagery for a given sector and resolution to the
      * current WorldWind file cache, without downloading imagery that is already in the cache.
-     * <p/>
+     * <p>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link BasicTiledImageLayerBulkDownloader}.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -426,10 +426,10 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all imagery for a given sector and resolution to a
      * specified {@link FileStore}, without downloading imagery that is already in the file store.
-     * <p/>
+     * <p>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link BasicTiledImageLayerBulkDownloader}.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -462,7 +462,7 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
     /**
      * Get the estimated size in bytes of the imagery not in the WorldWind file cache for the given sector and
      * resolution.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -481,7 +481,7 @@ public class BasicTiledImageLayer extends TiledImageLayer implements BulkRetriev
     /**
      * Get the estimated size in bytes of the imagery not in a specified file store for a specified sector and
      * resolution.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *

--- a/src/gov/nasa/worldwind/layers/BasicTiledImageLayerBulkDownloader.java
+++ b/src/gov/nasa/worldwind/layers/BasicTiledImageLayerBulkDownloader.java
@@ -22,7 +22,7 @@ import java.util.*;
 /**
  * Downloads imagery not currently available in the WorldWind file cache or a specified file store. The class derives
  * from {@link Thread} and is meant to operate in its own thread.
- * <p/>
+ * <p>
  * The sector and resolution associated with the downloader are specified during construction and are final.
  *
  * @author tag
@@ -39,7 +39,7 @@ public class BasicTiledImageLayerBulkDownloader extends BulkRetrievalThread
 
     /**
      * Constructs a downloader to retrieve imagery not currently available in the WorldWind file cache.
-     * <p/>
+     * <p>
      * The thread returned is not started during construction, the caller must start the thread.
      *
      * @param layer      the layer for which to download imagery.
@@ -61,7 +61,7 @@ public class BasicTiledImageLayerBulkDownloader extends BulkRetrievalThread
 
     /**
      * Constructs a downloader to retrieve imagery not currently available in a specified file store.
-     * <p/>
+     * <p>
      * The thread returned is not started during construction, the caller must start the thread.
      *
      * @param layer      the layer for which to download imagery.

--- a/src/gov/nasa/worldwind/layers/CachedRenderableLayer.java
+++ b/src/gov/nasa/worldwind/layers/CachedRenderableLayer.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 /**
  * Holds a collection of Renderables and manages local caching of them. Provides searching for Renderables by sector,
  * location or name.
- * <p/>
+ * <p>
  * NOTE: This class is experimental and not fully implemented. You should not use it now.
  *
  * @author tag

--- a/src/gov/nasa/worldwind/layers/CompassLayer.java
+++ b/src/gov/nasa/worldwind/layers/CompassLayer.java
@@ -139,7 +139,7 @@ public class CompassLayer extends AbstractLayer
      * its image file. Values greater than 1 magify the image, values less than one minify it. If the layer's resize
      * behavior is other than AVKey.RESIZE_KEEP_FIXED_SIZE, the icon's displayed sized is further affected by the value
      * specified by {@link #setCompassToViewportScale(double)} and the current viewport size.
-     * <p/>
+     * <p>
      * The default icon scale is 0.5.
      *
      * @param iconScale the icon scale factor

--- a/src/gov/nasa/worldwind/layers/IconLayer.java
+++ b/src/gov/nasa/worldwind/layers/IconLayer.java
@@ -232,7 +232,7 @@ public class IconLayer extends AbstractLayer
      * maintain a reference to <code>iconIterable</code> strictly for picking and rendering. This layer will not modify
      * the Iterable reference. However, this will clear the internal collection of Icons, and will prevent any
      * modification to its contents via <code>addIcon, addIcons, or removeIcons</code>.
-     * <p/>
+     * <p>
      * If the specified <code>iconIterable</code> is null, this layer will revert to maintaining its internal
      * collection.
      *

--- a/src/gov/nasa/worldwind/layers/Layer.java
+++ b/src/gov/nasa/worldwind/layers/Layer.java
@@ -46,7 +46,7 @@ public interface Layer extends WWObject, Disposable, Restorable
 
     /**
      * Returns the layer's opacity, the degree to which it is blended with underlying layers.
-     * <p/>
+     * <p>
      * Many layers apply special usage of opacity, and some ignore it in favor of the opacity settings of their internal
      * renderables. See the description of this method in specific layers to determine usage there.
      *
@@ -56,7 +56,7 @@ public interface Layer extends WWObject, Disposable, Restorable
 
     /**
      * Sets the layer's opacity, the degree to which it is blended with underlying layers.
-     * <p/>
+     * <p>
      * Many layers apply special usage of opacity, and some ignore it in favor of the opacity settings of their internal
      * renderables. See the description of this method in specific layers to determine usage there.
      *
@@ -67,7 +67,7 @@ public interface Layer extends WWObject, Disposable, Restorable
 
     /**
      * Indicates whether the layer performs selection during picking.
-     * <p/>
+     * <p>
      * Most layers enable picking by default. However, this becomes inconvenient for {@link
      * gov.nasa.worldwind.render.SurfaceImage} and {@link gov.nasa.worldwind.layers.SurfaceImageLayer}} when the image
      * covers a large area because the view input handlers detect the surface image rather than the terrain as the top
@@ -224,7 +224,7 @@ public interface Layer extends WWObject, Disposable, Restorable
     /**
      * Indicates the altitude above which this layer likely has low value or is not expected to be active. This value is
      * independent of the maximum active altitude, {@link #setMaxActiveAltitude(double)} and does not reflect it.
-     * <p/>
+     * <p>
      * The returned altitude is valid when the field of view indicated by {@link gov.nasa.worldwind.View#getFieldOfView()}
      * is set to its default value. Changing the field of view to any value other than the default may change this
      * layer's maximum effective altitude, but the returned altitude will not reflect that change.
@@ -239,7 +239,7 @@ public interface Layer extends WWObject, Disposable, Restorable
     /**
      * Indicates the altitude below which this layer likely has low value or is not expected to be active. This value is
      * independent of the minimum active altitude, {@link #setMinActiveAltitude(double)} and does not reflect it.
-     * <p/>
+     * <p>
      * The returned altitude is valid when the field of view indicated by {@link gov.nasa.worldwind.View#getFieldOfView()}
      * is set to its default value. Changing the field of view to any value other than the default may change this
      * layer's minimum effective altitude, but the returned altitude will not reflect that change.

--- a/src/gov/nasa/worldwind/layers/LocalRasterServerLayer.java
+++ b/src/gov/nasa/worldwind/layers/LocalRasterServerLayer.java
@@ -25,9 +25,9 @@ public class LocalRasterServerLayer extends BasicTiledImageLayer
 {
     /**
      * Constructs a layer from a list of parameters describing the layer.
-     * <p/>
+     * <p>
      * Parameter values for DATASET_NAME and DATA_CACHE_NAME are required.
-     * <p/>
+     * <p>
      * TODO: Enumerate the other required and optional parameters.
      *
      * @param params the parameters describing the dataset.
@@ -44,9 +44,9 @@ public class LocalRasterServerLayer extends BasicTiledImageLayer
 
     /**
      * Constructs a layer from an XML document description.
-     * <p/>
+     * <p>
      * Either the specified XML document or parameter list must contain values for DATASET_NAME and DATA_CACHE_NAME.
-     * <p/>
+     * <p>
      * TODO: Enumerate the other required and optional parameters.
      *
      * @param dom    the XML document describing the dataset.
@@ -66,9 +66,9 @@ public class LocalRasterServerLayer extends BasicTiledImageLayer
 
     /**
      * Constructs a layer from an XML document {@link Element}.
-     * <p/>
+     * <p>
      * Either the specified XML element or parameter list must contain values for DATASET_NAME and DATA_CACHE_NAME.
-     * <p/>
+     * <p>
      * TODO: Enumerate the other required and optional parameters.
      *
      * @param domElement the XML document describing the dataset.

--- a/src/gov/nasa/worldwind/layers/RenderableLayer.java
+++ b/src/gov/nasa/worldwind/layers/RenderableLayer.java
@@ -39,7 +39,7 @@ public class RenderableLayer extends AbstractLayer
      * Adds the specified <code>renderable</code> to the end of this layer's internal collection. If this layer's
      * internal collection has been overridden with a call to {@link #setRenderables(Iterable)}, this will throw an
      * exception.
-     * <p/>
+     * <p>
      * If the <code>renderable</code> implements {@link gov.nasa.worldwind.avlist.AVList}, the layer forwards its
      * property change events to the layer's property change listeners. Any property change listeners the layer attaches
      * to the <code>renderable</code> are removed in {@link #removeRenderable(gov.nasa.worldwind.render.Renderable)},
@@ -78,7 +78,7 @@ public class RenderableLayer extends AbstractLayer
      * Inserts the specified <code>renderable</code> at the specified <code>index</code> in this layer's internal
      * collection. If this layer's internal collection has been overridden with a call to {@link
      * #setRenderables(Iterable)}, this will throw an exception.
-     * <p/>
+     * <p>
      * If the <code>renderable</code> implements {@link gov.nasa.worldwind.avlist.AVList}, the layer forwards its
      * property change events to the layer's property change listeners. Any property change listeners the layer attaches
      * to the <code>renderable</code> are removed in {@link #removeRenderable(gov.nasa.worldwind.render.Renderable)},
@@ -133,7 +133,7 @@ public class RenderableLayer extends AbstractLayer
      * Adds the contents of the specified <code>renderables</code> to this layer's internal collection. If this layer's
      * internal collection has been overriden with a call to {@link #setRenderables(Iterable)}, this will throw an
      * exception.
-     * <p/>
+     * <p>
      * If any of the <code>renderables</code> implement {@link gov.nasa.worldwind.avlist.AVList}, the layer forwards
      * their property change events to the layer's property change listeners. Any property change listeners the layer
      * attaches to the <code>renderable</code> are removed in {@link #removeRenderable(gov.nasa.worldwind.render.Renderable)},
@@ -177,7 +177,7 @@ public class RenderableLayer extends AbstractLayer
      * Removes the specified <code>renderable</code> from this layer's internal collection, if it exists. If this
      * layer's internal collection has been overridden with a call to {@link #setRenderables(Iterable)}, this will throw
      * an exception.
-     * <p/>
+     * <p>
      * If the <code>renderable</code> implements {@link gov.nasa.worldwind.avlist.AVList}, this stops forwarding the its
      * property change events to the layer's property change listeners. Any property change listeners the layer attached
      * to the <code>renderable</code> in {@link #addRenderable(gov.nasa.worldwind.render.Renderable)} or {@link
@@ -215,7 +215,7 @@ public class RenderableLayer extends AbstractLayer
     /**
      * Clears the contents of this layer's internal Renderable collection. If this layer's internal collection has been
      * overriden with a call to {@link #setRenderables(Iterable)}, this will throw an exception.
-     * <p/>
+     * <p>
      * If any of the <code>renderables</code> implement {@link gov.nasa.worldwind.avlist.AVList}, this stops forwarding
      * their property change events to the layer's property change listeners. Any property change listeners the layer
      * attached to the <code>renderables</code> in {@link #addRenderable(gov.nasa.worldwind.render.Renderable)} or
@@ -311,14 +311,14 @@ public class RenderableLayer extends AbstractLayer
      * will not modify the reference, or dispose of its contents. This will also clear and dispose of the internal
      * collection of Renderables, and will prevent any modification to its contents via <code>addRenderable,
      * addRenderables, removeRenderables, or dispose</code>.
-     * <p/>
+     * <p>
      * Unlike {@link #addRenderable(gov.nasa.worldwind.render.Renderable)} or {@link #addRenderables(Iterable)}, this
      * does not forward any of the renderable's property change events to the layer's property change listeners. Since
      * the layer is not in control of the iIterable's contents, attaching property change listeners to the renderables
      * could cause the them to hold dangling references to the layer. If any of the renderables in the Iterable rely on
      * forwarding property change events for proper operation - such as {@link gov.nasa.worldwind.render.AbstractBrowserBalloon}
      * - use {@link #addRenderables(Iterable)} instead.
-     * <p/>
+     * <p>
      * If the specified <code>renderableIterable</code> is null, this layer reverts to maintaining its internal
      * collection.
      *
@@ -360,7 +360,7 @@ public class RenderableLayer extends AbstractLayer
     /**
      * Disposes the contents of this layer's internal Renderable collection, but does not remove any elements from that
      * collection.
-     * <p/>
+     * <p>
      * If any of layer's internal Renderables implement {@link gov.nasa.worldwind.avlist.AVList}, this stops forwarding
      * their property change events to the layer's property change listeners. Any property change listeners the layer
      * attached to the <code>renderables</code> in {@link #addRenderable(gov.nasa.worldwind.render.Renderable)} or
@@ -524,7 +524,7 @@ public class RenderableLayer extends AbstractLayer
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * This implementation forwards the message to each Renderable that implements {@link MessageListener}.
      *
      * @param message The message that was received.

--- a/src/gov/nasa/worldwind/layers/SkyGradientLayer.java
+++ b/src/gov/nasa/worldwind/layers/SkyGradientLayer.java
@@ -15,8 +15,9 @@ import java.awt.*;
 
 /**
  * Renders an atmosphere around the globe and a sky dome at low altitude.
- * <p/>
- * Note : based on a spherical globe.<br /> Issue : Ellipsoidal globe doesnt match the spherical atmosphere everywhere.
+ * <p>
+ * Note : based on a spherical globe.<br> 
+ * Issue : Ellipsoidal globe doesnt match the spherical atmosphere everywhere.
  *
  * @author Patrick Murris
  * @version $Id: SkyGradientLayer.java 2146 2014-07-11 17:37:04Z tgaskins $

--- a/src/gov/nasa/worldwind/layers/SurfaceImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/SurfaceImageLayer.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Displays a collection of local images on the globe.
- * <p/>
+ * <p>
  * Note: The view input handlers detect surface images rather than the terrain as the top picked object in {@link
  * gov.nasa.worldwind.event.SelectEvent}s and will not respond to the user's attempts at navigation when the cursor is
  * over the image. If this is not the desired behavior, disable picking for the layer containing the surface image.
@@ -45,14 +45,14 @@ public class SurfaceImageLayer extends RenderableLayer
     }
 
     /**
-     * Add an image to the collection, reprojecting it to geographic (latitude & longitude) coordinates if necessary.
+     * Add an image to the collection, reprojecting it to geographic (latitude and longitude) coordinates if necessary.
      * The image's location is determined from metadata files co-located with the image file. The number, names and
      * contents of these files are governed by the type of the specified image. Location metadata must be available.
-     * <p/>
+     * <p>
      * If projection information is available and reprojection of the image's projection type is supported, the image
      * will be reprojected to geographic coordinates. If projection information is not available then it's assumed that
      * the image is already in geographic projection.
-     * <p/>
+     * <p>
      * Only reprojection from UTM is currently provided.
      *
      * @param imagePath the path to the image file.
@@ -183,7 +183,7 @@ public class SurfaceImageLayer extends RenderableLayer
 
     /**
      * Add an image to the collection and specify its coverage. The image is assumed to be in geographic projection
-     * (latitude & longitude).
+     * (latitude and longitude).
      *
      * @param imagePath the path to the image file.
      * @param sector    the geographic location of the image.
@@ -219,7 +219,7 @@ public class SurfaceImageLayer extends RenderableLayer
 
     /**
      * Add a {@link BufferedImage} to the collection at an explicitly specified location. The image is assumed to be in
-     * geographic projection (latitude & longitude).
+     * geographic projection (latitude and longitude).
      *
      * @param name   a unique name to associate with the image so that it can be subsequently referred to without having
      *               to keep a reference to the image itself. Use this name in calls to {@link #removeImage(String)}.
@@ -286,7 +286,7 @@ public class SurfaceImageLayer extends RenderableLayer
 
     /**
      * Add an image to the collection at an explicitly specified location. The image is assumed to be in geographic
-     * projection (latitude & longitude).
+     * projection (latitude and longitude).
      *
      * @param imagePath the path to the image file.
      * @param corners   the geographic location of the image's corners, specified in order of lower-left, lower-right,
@@ -323,7 +323,7 @@ public class SurfaceImageLayer extends RenderableLayer
 
     /**
      * Add a {@link BufferedImage} to the collection at an explicitly specified location. The image is assumed to be in
-     * geographic projection (latitude & longitude).
+     * geographic projection (latitude and longitude).
      *
      * @param name    a unique name to associate with the image so that it can be subsequently referred to without
      *                having to keep a reference to the image itself. Use this name in calls to {@link

--- a/src/gov/nasa/worldwind/layers/TerrainProfileLayer.java
+++ b/src/gov/nasa/worldwind/layers/TerrainProfileLayer.java
@@ -22,9 +22,11 @@ import java.util.*;
 import java.util.List;
 
 /**
- * Displays a terrain profile graph in a screen corner. <p/> <p> Usage: do setEventSource(wwd) to have the graph
- * activated and updated with position changes. See public properties for options: keepProportions, follow, unit, start
- * and end latlon... </p>
+ * Displays a terrain profile graph in a screen corner. 
+ * <p> 
+ * Usage: do setEventSource(wwd) to have the graph activated and updated with position changes. 
+ * See public properties for options: keepProportions, follow, unit, start
+ * and end latlon... 
  *
  * @author Patrick Murris
  * @version $Id: TerrainProfileLayer.java 2053 2014-06-10 20:16:57Z tgaskins $

--- a/src/gov/nasa/worldwind/layers/TextureTile.java
+++ b/src/gov/nasa/worldwind/layers/TextureTile.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * This class manages the conversion and timing of image data to a JOGL Texture, and provides an interface for binding
  * the texture and applying any texture transforms to align the texture and texture coordinates.
- * <p/>
+ * <p>
  *
  * @author tag
  * @version $Id: TextureTile.java 1171 2013-02-11 21:45:02Z dcollins $
@@ -102,7 +102,7 @@ public class TextureTile extends Tile implements SurfaceTile
     /**
      * Returns the texture data most recently specified for the tile. New texture data is typically specified when a new
      * image is read, either initially or in response to image expiration.
-     * <p/>
+     * <p>
      * If texture data is non-null, a new texture is created from the texture data when the tile is next bound or
      * otherwise initialized. The texture data field is then set to null. Subsequently setting texture data to be
      * non-null causes a new texture to be created when the tile is next bound or initialized.
@@ -117,11 +117,11 @@ public class TextureTile extends Tile implements SurfaceTile
     /**
      * Specifies new texture data for the tile. New texture data is typically specified when a new image is read, either
      * initially or in response to image expiration.
-     * <p/>
+     * <p>
      * If texture data is non-null, a new texture is created from the texture data when the tile is next bound or
      * otherwise initialized. The texture data field is then set to null. Subsequently setting texture data to be
      * non-null causes a new texture to be created when the tile is next bound or initialized.
-     * <p/>
+     * <p>
      * When a texture is created from the texture data, the texture data field is set to null to indicate that the data
      * has been converted to a texture and its resources may be released.
      *

--- a/src/gov/nasa/worldwind/layers/TiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/TiledImageLayer.java
@@ -168,7 +168,7 @@ public abstract class TiledImageLayer extends AbstractLayer
      * Values greater than 0 cause imagery to appear at higher resolution at greater altitudes than normal, but at an
      * increased performance cost. Values less than 0 decrease the default resolution at any given altitude. The default
      * value is 0. Values typically range between -0.5 and 0.5.
-     * <p/>
+     * <p>
      * Note: The resolution-to-height relationship is defined by a scale factor that specifies the approximate size of
      * discernible lengths in the image relative to eye distance. The scale is specified as a power of 10. A value of 3,
      * for example, specifies that 1 meter on the surface should be distinguishable from an altitude of 10^3 meters
@@ -827,24 +827,26 @@ public abstract class TiledImageLayer extends AbstractLayer
 
     /**
      * Appends TiledImageLayer configuration parameters as elements to the specified context. This appends elements for
-     * the following parameters: <table> <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> <tr><td>{@link
-     * AVKey#SERVICE_NAME}</td><td>Service/@serviceName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#IMAGE_FORMAT}</td><td>ImageFormat</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#AVAILABLE_IMAGE_FORMATS}</td><td>AvailableImageFormats/ImageFormat</td><td>String array</td></tr>
-     * <tr><td>{@link AVKey#FORCE_LEVEL_ZERO_LOADS}</td><td>ForceLevelZeroLoads</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#RETAIN_LEVEL_ZERO_TILES}</td><td>RetainLevelZeroTiles</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#TEXTURE_FORMAT}</td><td>TextureFormat</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#USE_MIP_MAPS}</td><td>UseMipMaps</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#USE_TRANSPARENT_TEXTURES}</td><td>UseTransparentTextures</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#URL_CONNECT_TIMEOUT}</td><td>RetrievalTimeouts/ConnectTimeout/Time</td><td>Integer milliseconds</td></tr>
-     * <tr><td>{@link AVKey#URL_READ_TIMEOUT}</td><td>RetrievalTimeouts/ReadTimeout/Time</td><td>Integer
-     * milliseconds</td></tr> <tr><td>{@link AVKey#RETRIEVAL_QUEUE_STALE_REQUEST_LIMIT}</td>
-     * <td>RetrievalTimeouts/StaleRequestLimit/Time</td><td>Integer milliseconds</td></tr> </table> This also writes
-     * common layer and LevelSet configuration parameters by invoking {@link gov.nasa.worldwind.layers.AbstractLayer#createLayerConfigElements(gov.nasa.worldwind.avlist.AVList,
+     * the following parameters:
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr>
+     * <tr><td>{@link AVKey#SERVICE_NAME}</td><td>Service/@serviceName</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#IMAGE_FORMAT}</td><td>ImageFormat</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#AVAILABLE_IMAGE_FORMATS}</td><td>AvailableImageFormats/ImageFormat</td><td>String array</td></tr>
+     * <tr><td>{@link AVKey#FORCE_LEVEL_ZERO_LOADS}</td><td>ForceLevelZeroLoads</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#RETAIN_LEVEL_ZERO_TILES}</td><td>RetainLevelZeroTiles</td><td>Boolean</td></tr> 
+     * <tr><td>{@link AVKey#TEXTURE_FORMAT}</td><td>TextureFormat</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#USE_MIP_MAPS}</td><td>UseMipMaps</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#USE_TRANSPARENT_TEXTURES}</td><td>UseTransparentTextures</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#URL_CONNECT_TIMEOUT}</td><td>RetrievalTimeouts/ConnectTimeout/Time</td><td>Integer milliseconds</td></tr>
+     * <tr><td>{@link AVKey#URL_READ_TIMEOUT}</td><td>RetrievalTimeouts/ReadTimeout/Time</td><td>Integer milliseconds</td></tr>
+     * <tr><td>{@link AVKey#RETRIEVAL_QUEUE_STALE_REQUEST_LIMIT}</td><td>RetrievalTimeouts/StaleRequestLimit/Time</td><td>Integer milliseconds</td></tr>
+     * </table>
+     * This also writes common layer and LevelSet configuration parameters by invoking {@link gov.nasa.worldwind.layers.AbstractLayer#createLayerConfigElements(gov.nasa.worldwind.avlist.AVList,
      * org.w3c.dom.Element)} and {@link DataConfigurationUtils#createLevelSetConfigElements(gov.nasa.worldwind.avlist.AVList,
      * org.w3c.dom.Element)}.
      *
-     * @param params  the key-value pairs which define the TiledImageLayer configuration parameters.
+     * @param params the key-value pairs which define the TiledImageLayer configuration parameters.
      * @param context the XML document root on which to append TiledImageLayer configuration elements.
      *
      * @return a reference to context.
@@ -937,26 +939,32 @@ public abstract class TiledImageLayer extends AbstractLayer
     /**
      * Parses TiledImageLayer configuration parameters from the specified DOM document. This writes output as key-value
      * pairs to params. If a parameter from the XML document already exists in params, that parameter is ignored.
-     * Supported key and parameter names are: <table> <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr>
-     * <tr><td>{@link AVKey#SERVICE_NAME}</td><td>Service/@serviceName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#IMAGE_FORMAT}</td><td>ImageFormat</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#AVAILABLE_IMAGE_FORMATS}</td><td>AvailableImageFormats/ImageFormat</td><td>String array</td></tr>
-     * <tr><td>{@link AVKey#FORCE_LEVEL_ZERO_LOADS}</td><td>ForceLevelZeroLoads</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#RETAIN_LEVEL_ZERO_TILES}</td><td>RetainLevelZeroTiles</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#TEXTURE_FORMAT}</td><td>TextureFormat</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#USE_MIP_MAPS}</td><td>UseMipMaps</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#USE_TRANSPARENT_TEXTURES}</td><td>UseTransparentTextures</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#URL_CONNECT_TIMEOUT}</td><td>RetrievalTimeouts/ConnectTimeout/Time</td><td>Integer milliseconds</td></tr>
+     * Supported key and parameter names are:
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr>
+     * <tr><td>{@link AVKey#SERVICE_NAME}</td><td>Service/@serviceName</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#IMAGE_FORMAT}</td><td>ImageFormat</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#AVAILABLE_IMAGE_FORMATS}</td><td>AvailableImageFormats/ImageFormat</td><td>String
+     * array</td></tr>
+     * <tr><td>{@link AVKey#FORCE_LEVEL_ZERO_LOADS}</td><td>ForceLevelZeroLoads</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#RETAIN_LEVEL_ZERO_TILES}</td><td>RetainLevelZeroTiles</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#TEXTURE_FORMAT}</td><td>TextureFormat</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#USE_MIP_MAPS}</td><td>UseMipMaps</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#USE_TRANSPARENT_TEXTURES}</td><td>UseTransparentTextures</td><td>Boolean</td></tr>
+     * <tr><td>{@link AVKey#URL_CONNECT_TIMEOUT}</td><td>RetrievalTimeouts/ConnectTimeout/Time</td><td>Integer
+     * milliseconds</td></tr>
      * <tr><td>{@link AVKey#URL_READ_TIMEOUT}</td><td>RetrievalTimeouts/ReadTimeout/Time</td><td>Integer
-     * milliseconds</td></tr> <tr><td>{@link AVKey#RETRIEVAL_QUEUE_STALE_REQUEST_LIMIT}</td>
-     * <td>RetrievalTimeouts/StaleRequestLimit/Time</td><td>Integer milliseconds</td></tr> </table> This also parses
-     * common layer and LevelSet configuration parameters by invoking {@link gov.nasa.worldwind.layers.AbstractLayer#getLayerConfigParams(org.w3c.dom.Element,
+     * milliseconds</td></tr>
+     * <tr><td>{@link AVKey#RETRIEVAL_QUEUE_STALE_REQUEST_LIMIT}</td><td>RetrievalTimeouts/StaleRequestLimit/Time</td><td>Integer
+     * milliseconds</td></tr>
+     * </table>
+     * This also parses common layer and LevelSet configuration parameters by invoking {@link gov.nasa.worldwind.layers.AbstractLayer#getLayerConfigParams(org.w3c.dom.Element,
      * gov.nasa.worldwind.avlist.AVList)} and {@link gov.nasa.worldwind.util.DataConfigurationUtils#getLevelSetConfigParams(org.w3c.dom.Element,
      * gov.nasa.worldwind.avlist.AVList)}.
      *
      * @param domElement the XML document root to parse for TiledImageLayer configuration parameters.
-     * @param params     the output key-value pairs which recieve the TiledImageLayer configuration parameters. A null
-     *                   reference is permitted.
+     * @param params the output key-value pairs which recieve the TiledImageLayer configuration parameters. A null
+     * reference is permitted.
      *
      * @return a reference to params, or a new AVList if params is null.
      *
@@ -1022,9 +1030,11 @@ public abstract class TiledImageLayer extends AbstractLayer
     /**
      * Parses TiledImageLayer configuration parameters from previous versions of configuration documents. This writes
      * output as key-value pairs to params. If a parameter from the XML document already exists in params, that
-     * parameter is ignored. Supported key and parameter names are: <table> <tr><th>Parameter</th><th>Element
-     * Path</th><th>Type</th></tr> <tr><td>{@link AVKey#TEXTURE_FORMAT}</td><td>CompressTextures</td><td>"image/dds" if
-     * CompressTextures is "true"; null otherwise</td></tr> </table>
+     * parameter is ignored. Supported key and parameter names are:
+     * <table> <caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> 
+     * <tr><td>{@link AVKey#TEXTURE_FORMAT}</td><td>CompressTextures</td><td>"image/dds" if CompressTextures is "true"; null otherwise</td></tr> 
+     * </table>
      *
      * @param domElement the XML document root to parse for legacy TiledImageLayer configuration parameters.
      * @param params     the output key-value pairs which recieve the TiledImageLayer configuration parameters. A null
@@ -1268,10 +1278,11 @@ public abstract class TiledImageLayer extends AbstractLayer
      * is greater than one, a full-width segment along the top of the canvas is blank. If the aspect ratio is less than
      * one, a full-height segment along the right side of the canvase is blank. If the <code>image</code> argument was
      * non-null, that buffered image is returned.
-     *
+     * 
+     * @throws java.lang.Exception if uncaught exception is thrown
      * @throws IllegalArgumentException if <code>sector</code> is null.
      * @see ImageUtil#mergeImage(gov.nasa.worldwind.geom.Sector, gov.nasa.worldwind.geom.Sector, double,
-     * java.awt.image.BufferedImage, java.awt.image.BufferedImage)  ;
+     * java.awt.image.BufferedImage, java.awt.image.BufferedImage)
      */
     public BufferedImage composeImageForSector(Sector sector, int canvasWidth, int canvasHeight, double aspectRatio,
         int levelNumber, String mimeType, boolean abortOnError, BufferedImage image, int timeout) throws Exception

--- a/src/gov/nasa/worldwind/layers/ViewControlsLayer.java
+++ b/src/gov/nasa/worldwind/layers/ViewControlsLayer.java
@@ -15,10 +15,10 @@ import java.awt.*;
 /**
  * This layer displays onscreen view controls. Controls are available for pan, zoom, heading, pitch, tilt, field-of-view
  * and vertical exaggeration. Each of the controls can be enabled or disabled independently.
- * <p/>
+ * <p>
  * An instance of this class depends on an instance of {@link ViewControlsSelectListener} to control it. The select
  * listener must be registered as such via {@link gov.nasa.worldwind.WorldWindow#addSelectListener(gov.nasa.worldwind.event.SelectListener)}.
- * <p/>
+ * <p>
  * <code>ViewControlsLayer</code> instances are not sharable among <code>WorldWindow</code>s.
  *
  * @author Patrick Murris

--- a/src/gov/nasa/worldwind/layers/ViewControlsSelectListener.java
+++ b/src/gov/nasa/worldwind/layers/ViewControlsSelectListener.java
@@ -45,8 +45,8 @@ public class ViewControlsSelectListener implements SelectListener
     protected double veStep = 0.1;
 
     /**
-     * Construct a controller for specified <code>WorldWindow</code> and <code>ViewControlsLayer<c/code>.
-     * <p/>
+     * Construct a controller for specified <code>WorldWindow</code> and <code>ViewControlsLayer</code>.
+     * <p>
      * <code>ViewControlLayer</code>s are not sharable among <code>WorldWindow</code>s. A separate layer and controller
      * must be established for each window that's to have view controls.
      *
@@ -88,7 +88,7 @@ public class ViewControlsSelectListener implements SelectListener
      *
      * @param delay the repeat timer delay in milliseconds.
      *
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException if delay less than zero
      */
     public void setRepeatTimerDelay(int delay)
     {
@@ -180,7 +180,7 @@ public class ViewControlsSelectListener implements SelectListener
      *
      * @param value the pitch increment value in decimal degrees.
      *
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException if value less than zero
      */
     public void setPitchIncrement(double value)
     {
@@ -209,7 +209,7 @@ public class ViewControlsSelectListener implements SelectListener
      *
      * @param value the field of view increment factor.
      *
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException if value less than one
      */
     public void setFovIncrement(double value)
     {
@@ -238,7 +238,7 @@ public class ViewControlsSelectListener implements SelectListener
      *
      * @param value the vertical exaggeration increment.
      *
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException if value less than zero
      */
     public void setVeIncrement(double value)
     {

--- a/src/gov/nasa/worldwind/layers/WorldMapLayer.java
+++ b/src/gov/nasa/worldwind/layers/WorldMapLayer.java
@@ -21,11 +21,11 @@ import java.util.ArrayList;
 
 /**
  * Displays a world map overlay with a current-position crosshair in a screen corner.
- * <p/>
+ * <p>
  * A {@link gov.nasa.worldwindx.examples.ClickAndGoSelectListener} can be used in conjunction with this layer to move
  * the view to a selected location when that location is clicked within the layer's map. Specify
  * <code>WorldMapLayer.class</code> when constructing the <code>ClickAndGoSelectListener</code>.
- * <p/>
+ * <p>
  * Note: This layer may not be shared among multiple {@link WorldWindow}s.
  *
  * @author Patrick Murris

--- a/src/gov/nasa/worldwind/layers/placename/PlaceNameLayer.java
+++ b/src/gov/nasa/worldwind/layers/placename/PlaceNameLayer.java
@@ -1230,10 +1230,10 @@ public class PlaceNameLayer extends AbstractLayer implements BulkRetrievable
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all placenames for a given sector and resolution to the
      * current WorldWind file cache.
-     * <p/>
+     * <p>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link PlaceNameLayerBulkDownloader}.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -1258,10 +1258,10 @@ public class PlaceNameLayer extends AbstractLayer implements BulkRetrievable
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all placenames for a given sector and resolution to a
      * specified file store.
-     * <p/>
+     * <p>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link PlaceNameLayerBulkDownloader}.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -1289,7 +1289,7 @@ public class PlaceNameLayer extends AbstractLayer implements BulkRetrievable
     /**
      * Get the estimated size in bytes of the placenames not in the WorldWind file cache for the given sector and
      * resolution.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -1308,7 +1308,7 @@ public class PlaceNameLayer extends AbstractLayer implements BulkRetrievable
     /**
      * Get the estimated size in bytes of the placenames not in a specified file store for the given sector and
      * resolution.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *

--- a/src/gov/nasa/worldwind/layers/placename/PlaceNameLayerBulkDownloader.java
+++ b/src/gov/nasa/worldwind/layers/placename/PlaceNameLayerBulkDownloader.java
@@ -20,7 +20,7 @@ import java.util.*;
 /**
  * Downloads placenames not currently available in the WorldWind file cache or a specified {@link FileStore}. The class
  * derives from {@link Thread} and is meant to operate in its own thread.
- * <p/>
+ * <p>
  * The sector and resolution associated with the downloader are specified during construction and are final.
  *
  * @author tag
@@ -37,7 +37,7 @@ public class PlaceNameLayerBulkDownloader extends BulkRetrievalThread
 
     /**
      * Constructs a downloader to retrieve placenames not currently available in the WorldWind file cache.
-     * <p/>
+     * <p>
      * The thread returned is not started during construction, the caller must start the thread.
      *
      * @param layer      the layer for which to download placenames.
@@ -60,7 +60,7 @@ public class PlaceNameLayerBulkDownloader extends BulkRetrievalThread
     /**
      * Constructs a downloader to retrieve placenames not currently available in a specified file store and places it
      * there.
-     * <p/>
+     * <p>
      * The thread returned is not started during construction, the caller must start the thread.
      *
      * @param layer      the layer for which to download placenames.

--- a/src/gov/nasa/worldwind/ogc/collada/ColladaRoot.java
+++ b/src/gov/nasa/worldwind/ogc/collada/ColladaRoot.java
@@ -236,6 +236,7 @@ public class ColladaRoot extends ColladaAbstractObject implements ColladaRendera
      * @return a new {@link ColladaRoot} for the specified source, or null if the source type is not supported.
      *
      * @throws IllegalArgumentException if the source is null.
+     * @throws javax.xml.stream.XMLStreamException if an error occurs reading the source.
      * @throws IOException              if an error occurs while reading the source.
      */
     public static ColladaRoot createAndParse(Object docSource) throws IOException, XMLStreamException
@@ -324,9 +325,9 @@ public class ColladaRoot extends ColladaAbstractObject implements ColladaRendera
     /**
      * Specifies this shape's altitude mode, one of {@link WorldWind#ABSOLUTE}, {@link WorldWind#RELATIVE_TO_GROUND} or
      * {@link WorldWind#CLAMP_TO_GROUND}.
-     * <p/>
+     * <p>
      * Note: If the altitude mode is unrecognized, {@link WorldWind#ABSOLUTE} is used.
-     * <p/>
+     * <p>
      * Note: Subclasses may recognize additional altitude modes or may not recognize the ones described above.
      *
      * @param altitudeMode the altitude mode. The default value is {@link WorldWind#ABSOLUTE}.
@@ -534,7 +535,7 @@ public class ColladaRoot extends ColladaAbstractObject implements ColladaRendera
     /**
      * Resolves a reference to a local element identified by address and identifier, where {@code linkBase} identifies a
      * document, including the current document, and {@code linkRef} is the id of the desired element.
-     * <p/>
+     * <p>
      * If {@code linkBase} refers to a local COLLADA file and {@code linkRef} is non-null, the return value is the
      * element identified by {@code linkRef}. If {@code linkRef} is null, the return value is a parsed {@link
      * ColladaRoot} for the COLLADA file identified by {@code linkBase}. Otherwise, {@code linkBase} is returned.
@@ -591,7 +592,7 @@ public class ColladaRoot extends ColladaAbstractObject implements ColladaRendera
      * Resolves a reference to a remote element identified by address and identifier, where {@code linkBase} identifies
      * a remote document, and {@code linkRef} is the id of the desired element. This method retrieves resources
      * asynchronously using the {@link gov.nasa.worldwind.cache.FileStore}.
-     * <p/>
+     * <p>
      * The return value is null if the file is not yet available in the FileStore. If {@code linkBase} refers to a
      * COLLADA file and {@code linkRef} is non-null, the return value is the element identified by {@code linkRef}. If
      * {@code linkBase} refers to a COLLADA file and {@code linkRef} is null, the return value is a parsed {@link

--- a/src/gov/nasa/worldwind/ogc/collada/impl/ColladaMeshShape.java
+++ b/src/gov/nasa/worldwind/ogc/collada/impl/ColladaMeshShape.java
@@ -29,7 +29,7 @@ import java.util.List;
  * instances are created by {@link #createTriangleMesh(java.util.List, gov.nasa.worldwind.ogc.collada.ColladaBindMaterial)
  * createTriangleMesh} and {@link #createLineMesh(java.util.List, gov.nasa.worldwind.ogc.collada.ColladaBindMaterial)
  * createLineMesh}.
- * <p/>
+ * <p>
  * This shape supports only COLLADA line and triangle geometries.
  *
  * @author pabercrombie
@@ -227,6 +227,7 @@ public class ColladaMeshShape extends AbstractGeneralShape
      *
      * @param geometries   COLLADA elements that defines geometry for this shape. Must contain at least one element.
      * @param bindMaterial Material applied to the mesh. May be null.
+     * @return A triangle mesh shape.
      */
     public static ColladaMeshShape createTriangleMesh(List<ColladaTriangles> geometries,
         ColladaBindMaterial bindMaterial)
@@ -245,6 +246,7 @@ public class ColladaMeshShape extends AbstractGeneralShape
      *
      * @param geometries   COLLADA elements that defines geometry for this shape. Must contain at least one element.
      * @param bindMaterial Material applied to the mesh. May be null.
+     * @return A Collada mesh shape.
      */
     public static ColladaMeshShape createLineMesh(List<ColladaLines> geometries,
         ColladaBindMaterial bindMaterial)
@@ -283,7 +285,7 @@ public class ColladaMeshShape extends AbstractGeneralShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * COLLADA shapes do not support intersection tests because the shape may be rendered multiple times with different
      * transform matrices. It's not possible to determine intersection without the transform matrix applied when the
      * shape is rendered.
@@ -721,7 +723,7 @@ public class ColladaMeshShape extends AbstractGeneralShape
 
     /**
      * Compute enough geometry to determine this shape's extent, reference point and eye distance.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc        the current draw context.
@@ -967,7 +969,7 @@ public class ColladaMeshShape extends AbstractGeneralShape
 
     /**
      * Computes the minimum distance between this shape and the eye point.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1043,6 +1045,7 @@ public class ColladaMeshShape extends AbstractGeneralShape
     /**
      * Indicates the texture applied to this shape.
      *
+     * @param geometry Geometry to apply.
      * @return The texture that must be applied to the shape, or null if there is no texture, or the texture is not
      *         available.
      */

--- a/src/gov/nasa/worldwind/ogc/collada/io/ColladaDoc.java
+++ b/src/gov/nasa/worldwind/ogc/collada/io/ColladaDoc.java
@@ -18,7 +18,7 @@ public interface ColladaDoc
 {
     /**
      * Returns an {@link java.io.InputStream} to the associated COLLADA document.
-     * <p/>
+     * <p>
      * Implementations of this interface do not close the stream; the user of the class must close the stream.
      *
      * @return an input stream positioned to the head of the COLLADA document.

--- a/src/gov/nasa/worldwind/ogc/kml/KMLAbstractContainer.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLAbstractContainer.java
@@ -67,7 +67,7 @@ public class KMLAbstractContainer extends KMLAbstractFeature
      * Indicates whether this <code>KMLAbstractContainer</code> is active and should be rendered on the specified
      * <code>DrawContext</code>. This returns <code>true</code> if this container's <code>visibility</code> is
      * unspecified (<code>null</code>) or is set to <code>true</code>.
-     * <p/>
+     * <p>
      * Regions do not apply directly to KML containers, because a descendant features can override the container's
      * Region with its own. Since a descendant Region may be larger or have a less restrictive LOD range than this
      * container, we cannot determine the visibility of the entire tree based on this container's Region. A container's
@@ -87,7 +87,7 @@ public class KMLAbstractContainer extends KMLAbstractFeature
 
     /**
      * Pre-renders the KML features held by this <code>KMLAbstractContainer</code>.
-     * <p/>
+     * <p>
      * Pushes this container's Region on the KML traversal context's region stack before rendering the features, and
      * pops the Region off the stack afterward. Descendant features use the KML traversal context's region stack to
      * inherit Regions from parent containers.
@@ -111,7 +111,7 @@ public class KMLAbstractContainer extends KMLAbstractFeature
 
     /**
      * Renders the KML features held by this <code>KMLAbstractContainer</code>.
-     * <p/>
+     * <p>
      * Pushes this container's Region on the KML traversal context's region stack before rendering the features, and
      * pops the Region off the stack afterward. Descendant features use the KML traversal context's region stack to
      * inherit Regions from parent containers.

--- a/src/gov/nasa/worldwind/ogc/kml/KMLAbstractFeature.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLAbstractFeature.java
@@ -20,7 +20,7 @@ import java.util.*;
 
 /**
  * Represents the KML <i>Feature</i> element and provides access to its contents.
- * <p/>
+ * <p>
  * <code>KMLAbstractFeature</code> implements the <code>KMLRenderable</code> interface, but does not actually render
  * anything. Subclasses should override the methods <code>{@link #doPreRender(gov.nasa.worldwind.ogc.kml.impl.KMLTraversalContext,
  * gov.nasa.worldwind.render.DrawContext)}</code> and <code>{@link #doRender(gov.nasa.worldwind.ogc.kml.impl.KMLTraversalContext,
@@ -224,7 +224,7 @@ public abstract class KMLAbstractFeature extends KMLAbstractObject implements KM
 
     /**
      * Set the balloon associated with this feature.
-     * <p/>
+     * <p>
      * Note: Balloon is not a field in the KML Feature element. It's a direct field of this class and enables the client
      * to associate a balloon with the feature.
      *
@@ -294,14 +294,16 @@ public abstract class KMLAbstractFeature extends KMLAbstractObject implements KM
     /**
      * Indicates whether this <code>KMLAbstractFeature</code> is active and should be rendered on the specified
      * <code>DrawContext</code>. This returns <code>true</code> if the following conditions are all <code>true</code>:
-     * <p/>
-     * <ul> <li>This feature's <code>visibility</code> is unspecified (<code>null</code>) or is set to
-     * <code>true</code>.</li> <li>This feature as no Region and does not inherit a Region from an ancestor, or its
-     * Region is active for the specified <code>DrawContext</code>.</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>This feature's <code>visibility</code> is unspecified (<code>null</code>) or is set to
+     * <code>true</code>.</li> 
+     * <li>This feature as no Region and does not inherit a Region from an ancestor, or its
+     * Region is active for the specified <code>DrawContext</code>.</li> 
+     * </ul>
+     * <p>
      * If this feature has no Region, this inherits the Region of its nearest ancestor by using the Region on the top of
      * the KML traversal context's region stack (if any). If there is no ancestor Region this feature is assumed to be
-     * the <code>DrawContext's</cod> view and is rendered according to its <code>visibility</code> flag. A Region is
+     * the <code>DrawContext's</code> view and is rendered according to its <code>visibility</code> flag. A Region is
      * considered active if it is visible, and the <code>DrawContext</code> meets the Region's level of detail
      * criteria.
      *
@@ -364,7 +366,7 @@ public abstract class KMLAbstractFeature extends KMLAbstractObject implements KM
      * Obtains the effective values for a specified sub-style (<i>IconStyle</i>, <i>ListStyle</i>, etc.) and state
      * (<i>normal</i> or <i>highlight</i>). The returned style is the result of merging values from this feature
      * instance's style selectors and its styleUrl, if any, with precedence given to style selectors.
-     * <p/>
+     * <p>
      * A remote <i>styleUrl</i> that has not yet been resolved is not included in the result. In this case the returned
      * sub-style is marked with the value {@link gov.nasa.worldwind.avlist.AVKey#UNRESOLVED}. The same is true when a
      * StyleMap style selector contains a reference to an external Style and that reference has not been resolved.

--- a/src/gov/nasa/worldwind/ogc/kml/KMLAbstractStyleSelector.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLAbstractStyleSelector.java
@@ -33,7 +33,7 @@ public abstract class KMLAbstractStyleSelector extends KMLAbstractObject
      * Obtains the selector's effective style for a specified style type (<i>IconStyle</i>, <i>ListStyle</i>, etc.) and
      * state (<i>normal</i> or <i>highlight</i>). The returned style is the result of merging values from the specified
      * style selectors and style URL, with precedence given to style selectors.
-     * <p/>
+     * <p>
      * Remote <i>styleUrls</i> that have not yet been resolved are not included in the result. In this case the returned
      * sub-style is marked with a field named {@link gov.nasa.worldwind.avlist.AVKey#UNRESOLVED}. The same is true when
      * a StyleMap refers to a Style other than one internal to the KML document.
@@ -88,7 +88,7 @@ public abstract class KMLAbstractStyleSelector extends KMLAbstractObject
      * Obtains the selector's effective style for a specified style type (<i>IconStyle</i>, <i>ListStyle</i>, etc.) and
      * state (<i>normal</i> or <i>highlight</i>). The returned style is the result of merging values from the specified
      * style selector and style URL, with precedence given to style selector.
-     * <p/>
+     * <p>
      * Remote <i>styleUrls</i> that have not yet been resolved are not included in the result. In this case the returned
      * sub-style is marked with the value {@link gov.nasa.worldwind.avlist.AVKey#UNRESOLVED}.
      *

--- a/src/gov/nasa/worldwind/ogc/kml/KMLCoordinateTokenizer.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLCoordinateTokenizer.java
@@ -17,17 +17,17 @@ import java.util.*;
  * <pre>
  * -18.3,23.5,0 -19.3,23.4,1 -20.0,23.5,2
  * </pre>
- * <p/>
+ * <p>
  * However, some KML files do not follow the spec and embed white space within the coordinate tuples. This tokenizer
  * attempts to be lenient with whitespace handling. If a tuple ends with a comma, the tokenizer considers the next token
  * in the input stream to be part of the same coordinate, not the start of a new coordinate.
- * <p/>
+ * <p>
  * For example:
  * <pre>
  * -18.3,23.56,9     34.9, 56.0, 2     56.9, 19     90.0,23.9,44
  * </pre>
  * Will be tokenized to four coordinates: (23.56, -18.3, 9), (56.0, 34.9, 2), (56.9, 19, 0), and (90, 23.9, 44).
- * <p/>
+ * <p>
  * The tokenizer also handles coordinate strings with no embedded white space. For example:
  * <pre>
  * -18.3,23.56,9,34.9,56.0,2

--- a/src/gov/nasa/worldwind/ogc/kml/KMLLink.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLLink.java
@@ -271,9 +271,9 @@ public class KMLLink extends KMLAbstractObject
      * <code>viewFormat</code> and <code>httpQuery</code>. Otherwise, this returns the concatenation of the
      * <code>href</code>, the <code>viewFormat</code> and the <code>httpQuery</code> for form an absolute URL string. If
      * the the <code>href</code> contains a query string, the <code>viewFormat</code> and <code>httpQuery</code> are
-     * appended to that string. If necessary, this inserts the <code>&</code> character between the <code>href</code>'s
+     * appended to that string. If necessary, this inserts the {@code &} character between the <code>href</code>'s
      * query string, the <code>viewFormat</code>, and the <code>httpQuery</code>.
-     * <p/>
+     * <p>
      * This substitutes the following parameters in <code>viewFormat</code> and <code>httpQuery</code>: <ul>
      * <li><code>[bboxWest],[bboxSouth],[bboxEast],[bboxNorth]</code> - visible bounds of the globe, or 0 if the globe
      * is not visible. The visible bounds are scaled from their centroid by this link's

--- a/src/gov/nasa/worldwind/ogc/kml/KMLNetworkLink.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLNetworkLink.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.*;
 
 /**
  * Represents the KML <i>NetworkLink</i> element and provides access to its contents.
- * <p/>
+ * <p>
  * During rendering, <code>KMLNetworkLink</code> retrieves and loads its network resource whenever necessary. Upon a
  * successful retrieval, <code>KMLNetworkLink</code> sends an <code>AVKey.RETRIEVAL_STATE_SUCCESSFUL</code> property
  * change event to this link's property change listeners. Once retrieved and loaded, <code>KMLNetworkLink</code> stores
  * its network resource by calling <code>setNetworkResource</code>, draws its network resource during preRendering and
  * rendering, and forwards property change events from the network resource to its property change listeners.
- * <p/>
+ * <p>
  * During retrieval, <code>KMLNetworkLink</code> attempts to use either the <code>Link</code> or the <code>Url</code>.
  * The <code>Link</code> is the preferred method for encoding a KML NetworkLink's address since KML version 2.1,
  * therefore we give it priority over <code>Url</code>.
@@ -217,7 +217,7 @@ public class KMLNetworkLink extends KMLAbstractContainer implements PropertyChan
 
     /**
      * Specifies the network resource referenced by this <code>KMLNetworkLink</code>, or <code>null</code> if this link
-     * has no resource. If the specified <code>kmlRoot</code> is not <code>null</code, this link draws the
+     * has no resource. If the specified <code>kmlRoot</code> is not <code>null</code>, this link draws the
      * <code>kmlRoot</code> during preRendering and rendering, and forwards property change events from the
      * <code>kmlRoot</code> to this link's property change listeners.
      *
@@ -372,7 +372,7 @@ public class KMLNetworkLink extends KMLAbstractContainer implements PropertyChan
      * resource is retrieved and loaded, this calls <code>{@link #setNetworkResource(KMLRoot)}</code> to specify this
      * link's new network resource, and sends an <code>{@link gov.nasa.worldwind.avlist.AVKey#RETRIEVAL_STATE_SUCCESSFUL}</code>
      * property change event to this link's property change listeners.
-     * <p/>
+     * <p>
      * This does nothing if this <code>KMLNetworkLink</code> has no <code>KMLLink</code>.
      *
      * @param address the address of the resource to retrieve
@@ -445,10 +445,11 @@ public class KMLNetworkLink extends KMLAbstractContainer implements PropertyChan
      * Indicates whether the network resource references by this <code>KMLNetworkLink</code> should be retrieved to the
      * WorldWind cache or to a temporary location. This returns <code>true</code> if all of the following conditions
      * are met, and <code>false</code> otherwise:
-     * <p/>
-     * <ul> <li>This network link has either a <code>Link</code> or a <code>Url</code> element.</li> <li>The Link or Url
-     * element's <code>refreshMode</code> is not <code>onInterval</code> or <code>onExpire</code>.</li> <li>The Link or
-     * Url element's <code>viewRefreshMode</code> is not <code>onStop</code>.</li> </ul>
+     * <ul> 
+     * <li>This network link has either a <code>Link</code> or a <code>Url</code> element.</li> 
+     * <li>The Link or Url element's <code>refreshMode</code> is not <code>onInterval</code> or <code>onExpire</code>.</li> 
+     * <li>The Link or Url element's <code>viewRefreshMode</code> is not <code>onStop</code>.</li> 
+     * </ul>
      *
      * @return <code>true</code> if this link's network resource can should be stored in a cache, or <code>false</code>
      *         if it should be stored in a temporary location.

--- a/src/gov/nasa/worldwind/ogc/kml/KMLRegion.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLRegion.java
@@ -19,11 +19,11 @@ import java.util.*;
 /**
  * Represents the KML <i>Region</i> element and provides access to its contents. Regions define an area of interest
  * described by a geographic bounding box and an optional minimum and maximum altitude.
- * <p/>
- * <strong>Bounding Box</strong> </br> A Region's bounding box controls when the Region is active by defining a volume
+ * <p>
+ * <strong>Bounding Box</strong> <br> A Region's bounding box controls when the Region is active by defining a volume
  * that must intersect the viewing frustum. The bounding box is computed according to the <code>altitudeMode</code>
  * attribute of a Region's geographic <code>LatLonAltBox</code> as follows:
- * <p/>
+ * 
  * <ul> <li><strong>clampToGround (default)</strong>: The bounding box encloses the terrain surface in the sector
  * defined by the north, south, east, and west limits of this Region's <code>LatLonAltBox</code>.</li>
  * <li><strong>relativeToGround</strong>: The bounding box encloses the volume in the sector defined by the north,
@@ -32,11 +32,11 @@ import java.util.*;
  * bounding box encloses the volume in the sector defined by the north, south, east, and west limits of the Region's
  * <code>LatLonAltBox</code>, and who's upper and lower altitude are specified by its minAltitude and maxAltitude,
  * relative to mean sea level.</li> </ul>
- * <p/>
- * <strong>Level of Detail</strong> <br/> A Region's level of detail determines when it is active by defining an upper
+ * <p>
+ * <strong>Level of Detail</strong> <br> A Region's level of detail determines when it is active by defining an upper
  * and lower boundary on the Region's screen area or the Region's distance to the view. The level of detail is computed
  * according to the <code>altitudeMode</code> attribute of a Region's geographic <code>LatLonAltBox</code> as follows:
- * <p/>
+ * 
  * <ul> <li><strong>clampToGround (default)</strong>: The level of detail is determined by computing the distance from
  * the eye point and Region sector, scaling the distance by the <code>KMLTraversalContext's</code> detail hint, then
  * comparing that scaled distance to the Region's min and max pixel sizes in meters (the Region sector's area divided by
@@ -50,24 +50,24 @@ import java.util.*;
  * level of detail is determined by computing the number of pixels the Region occupies on screen, and comparing that
  * pixel count to the Region's <code>minLodPixels</code> and <code>maxLodPixels</code>. The Region is active when the
  * pixel count is greater or equal to <code>minLodPixels</code> and less than <code>maxLodPixels</code>.</li> </ul>
- * <p/>
+ * <p>
  * In order to prevent Regions with adjacent level of detail ranges from activating at the same time, Region gives
  * priority to higher level of detail ranges. For example, suppose that two KML features representing different detail
  * levels of a Collada model have Regions with LOD range 100-200 and 200-300. Region avoids activating both features in
  * the event that both their level of detail criteria are met by giving priority to the second range: 200-300.
- * <p/>
- * <strong>KML Feature Hierarchies</strong> <br/> When a Region is attached to a KML feature, the feature and its
+ * <p>
+ * <strong>KML Feature Hierarchies</strong> <br> When a Region is attached to a KML feature, the feature and its
  * descendants are displayed only when the Region is active. A Region is active when its bounding box is in view and its
  * level of detail criteria are met. Region provides the <code>isActive</code> method for determining if a Region is
  * active for a specified <code>DrawContext</code>.
- * <p/>
+ * <p>
  * Regions do not apply directly to KML containers, because a descendant feature can override the container's Region
  * with its own Region. If a feature does not specify a Region it inherits the Region of its nearest ancestor. Since a
  * child feature's Region may be larger or have a less restrictive level of detail range than its ancestor's Region, the
  * visibility of an entire KML feature tree cannot be determined based on a container's Region. Instead, visibility must
  * be determined at each leaf feature.
- * <p/>
- * <strong>Limitations</strong> <br/> The Region bounding box must lie between -90 to 90 degrees latitude, and -180 to
+ * <p>
+ * <strong>Limitations</strong> <br> The Region bounding box must lie between -90 to 90 degrees latitude, and -180 to
  * 180 degrees longitude. Regions that span the date line are currently not supported.
  *
  * @author tag
@@ -94,33 +94,33 @@ public class KMLRegion extends KMLAbstractObject
     /**
      * <code>RegionData</code> holds a Region's computed data used during a single call to <code>Region.isActive</code>,
      * and is unique to a particular <code>Globe</code>.
-     * <p/>
+     * <p>
      * RegionData entries are places in a Region's <code>regionDataCache</code>, and are retrieved during each call to
      * <code>isActive</code> using the current <code>Globe</code> as the cache key. RegionData's elements depend on the
      * <code>Globe's</code> <code>ElevationModel</code>, and therefore cannot be permanently cached. Each RegionData
      * entry is valid for a random amount of time between its <code>minExpiryTime</code> and its
      * <code>maxExpiryTime</code>, after which it must be regenerated. The time is randomized to amortize the cost of
      * regenerating data for multiple Regions over multiple frames.
-     * <p/>
-     * <strong>isActive</strong> <br/> RegionData's <code>isActive</code> property indicates whether the Region
+     * <p>
+     * <strong>isActive</strong> <br> RegionData's <code>isActive</code> property indicates whether the Region
      * associated with a RegionData entry is active. This is used to share the result of computing <code>isActive</code>
      * among multiple calls during the same frame. For example, the preRender and render passes need not each compute
      * <code>isActive</code>, and can therefore share the same computation by ensuring that this property is set at most
      * once per frame. Callers determine when to recompute <code>isActive</code> by comparing the
      * <code>DrawContext's</code> current frame number against the RegionData's <code>activeFrameNumber</code>. This
      * property is accessed by calling <code>isActive</code> and <code>setActive</code>.
-     * <p/>
-     * <strong>extent</strong> <br/> RegionData's <code>extent</code> property is an <code>Extent</code> used to
+     * <p>
+     * <strong>extent</strong> <br> RegionData's <code>extent</code> property is an <code>Extent</code> used to
      * determine if a Region's bounding box is in view. This property is accessed by calling <code>getExtent</code> and
      * <code>setExtent</code>. May be <code>null</code>.
-     * <p/>
-     * <strong>sector</strong> <br/> RegionData's <code>sector</code> property is a <code>Sector</code> used to
+     * <p>
+     * <strong>sector</strong> <br> RegionData's <code>sector</code> property is a <code>Sector</code> used to
      * determine if Regions with an <code>altitudeMode</code> of <code>clampToGround</code> are in view. Accessed by
      * calling <code>getSector</code> and <code>setSector</code>. When a Region's <code>altitudeMode</code> is
      * <code>clampToGround</code>, the Region's sector can be used to determine visibility because the Region is defined
      * to be on the <code>Globe's</code> surface.
-     * <p/>
-     * <strong>points</strong> <br/> RegionData's <code>points</code> property indicates a list of model-coordinate
+     * <p>
+     * <strong>points</strong> <br> RegionData's <code>points</code> property indicates a list of model-coordinate
      * points representing the corners and interior of the Region. These points are used to determine the distance
      * between the Region and the <code>View's</code> eye point. If the Region has altitude mode of
      * <code>clampToGround</code>, this list must contain five points: the model-coordinate points of the Region's four
@@ -289,7 +289,7 @@ public class KMLRegion extends KMLAbstractObject
          * Specifies the model-coordinate points representing the corners and interior of this entry's Region. These
          * points are used to determine the distance between this entry's Region and the <code>View's</code> eye point.
          * Specify <code>null</code> to indicate that this entry' Region has no geographic bounding box.
-         * <p/>
+         * <p>
          * If this entry's Region has altitude mode <code>clampToGround</code>, this list must contain five points: the
          * model-coordinate points of the Region's four corners and center point on the surface terrain.
          *
@@ -370,7 +370,7 @@ public class KMLRegion extends KMLAbstractObject
      * Indicates whether this Region is active on the specified <code>DrawContext</code>. A Region is active if its
      * bounding box intersects the viewing frustum, and its level of detail criteria are met for the specified traversal
      * context and draw context.
-     * <p/>
+     * <p>
      * This always returns <code>true</code> if this Region has no bounding box, or if its bounding box is in the
      * viewing frustum and this Region has no lod criteria.
      *
@@ -476,7 +476,7 @@ public class KMLRegion extends KMLAbstractObject
     /**
      * Indicates whether this Region's data must be recomputed, either as a result of a change in the
      * <code>Globe's</code> state or the expiration of the geometry regeneration interval.
-     * <p/>
+     * <p>
      * A <code>{@link gov.nasa.worldwind.ogc.kml.KMLRegion.RegionData}</code> must be current when this method is
      * called.
      *
@@ -703,7 +703,7 @@ public class KMLRegion extends KMLAbstractObject
     /**
      * Indicates whether this Region intersects the viewing frustum for the specified <code>DrawContext</code>. A
      * <code>{@link gov.nasa.worldwind.ogc.kml.KMLRegion.RegionData}</code> must be current when this method is called.
-     * <p/>
+     * <p>
      * This returns <code>true</code> if this Region has no bounding box, or if its bounding box cannot be computed for
      * any reason.
      *
@@ -727,7 +727,7 @@ public class KMLRegion extends KMLAbstractObject
     /**
      * Indicates whether the specified <code>DrawContext</code> meets this Region's level of detail criteria. A
      * <code>{@link gov.nasa.worldwind.ogc.kml.KMLRegion.RegionData}</code> must be current when this method is called.
-     * <p/>
+     * <p>
      * This returns <code>true</code> if this Region has no level of criteria, or if its level of detail cannot be
      * compared against the bounding box for any reason.
      *

--- a/src/gov/nasa/worldwind/ogc/kml/KMLRoot.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLRoot.java
@@ -132,7 +132,7 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
      * a {@link InputStream}, or a {@link String} identifying either a file path or a URL. For all types other than
      * <code>InputStream</code> an attempt is made to determine whether the source is KML or KMZ; KML is assumed if the
      * test is not definitive. Null is returned if the source type is not recognized.
-     * <p/>
+     * <p>
      * Note: Because there are so many incorrectly formed KML files in distribution, it's often not possible to parse
      * with a namespace aware parser. This method first tries to use a namespace aware parser, but if a severe problem
      * occurs during parsing, it will try again using a namespace unaware parser. Namespace unaware parsing typically
@@ -490,7 +490,7 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
     /**
      * Specifies the object to receive notifications of important occurrences during parsing, such as exceptions and the
      * occurrence of unrecognized element types.
-     * <p/>
+     * <p>
      * The default notification listener writes a message to the log, and otherwise does nothing.
      *
      * @param listener the listener to receive notifications. Specify null to indicate no listener.
@@ -547,13 +547,13 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
     /**
      * Resolves a reference to a remote or local element of the form address#identifier, where "address" identifies a
      * local or remote document, including the current document, and and "identifier" is the id of the desired element.
-     * <p/>
+     * <p>
      * If the address part identifies the current document, the document is searched for the specified identifier.
      * Otherwise the document is retrieved, opened and searched for the identifier. If the address refers to a remote
      * document and the document has not previously been retrieved and cached locally, retrieval is initiated and this
      * method returns <code>null</code>. Once the document is successfully retrieved, subsequent calls to this method
      * return the identified element, if it exists.
-     * <p/>
+     * <p>
      * If the link does not contain an identifier part, this initiates a retrieval for document referenced by the
      * address part and returns <code>null</code>. Once the document is retrieved this opens the the document as a
      * <code>KMLRoot</code>. Subsequent calls to this method return the opened document, if it exists.
@@ -592,17 +592,17 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
     /**
      * Resolves a reference to a remote or local element of the form address#identifier, where "address" identifies a
      * local or remote document, including the current document, and and "identifier" is the id of the desired element.
-     * <p/>
+     * <p>
      * If the address part identifies the current document, the document is searched for the specified identifier.
      * Otherwise the document is retrieved, opened and searched for the identifier. If the address refers to a remote
      * document and the document has not previously been retrieved and cached locally, retrieval is initiated and this
      * method returns <code>null</code>. Once the document is successfully retrieved, subsequent calls to this method
      * return the identified element, if it exists.
-     * <p/>
+     * <p>
      * If the link does not contain an identifier part, this initiates a retrieval for document referenced by the
      * address part and returns <code>null</code>. Once the document is retrieved this opens the the document as a
      * <code>KMLRoot</code>. Subsequent calls to this method return the opened document, if it exists.
-     * <p/>
+     * <p>
      * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote document in the World
      * Wind cache or in a temporary location. This parameter has no effect if the document exists locally. The temporary
      * location for a retrieved document does not persist between runtime sessions, and subsequent invocations of this
@@ -678,11 +678,11 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
     /**
      * Resolves a reference to a local element identified by address and identifier, where {@code linkBase} identifies a
      * document, including the current document, and {@code linkRef} is the id of the desired element.
-     * <p/>
+     * <p>
      * If {@code linkBase} refers to a local KML or KMZ file and {@code linkRef} is non-null, the return value is the
      * element identified by {@code linkRef}. If {@code linkRef} is null, the return value is a parsed {@link KMLRoot}
      * for the KML file identified by {@code linkBase}.
-     * <p/>
+     * <p>
      * If {@code linkBase} refers a local file that is not a KML or KMZ file then {@code linkBase} is returned. If
      * {@code linkBase} cannot be resolved to a local file then null is returned.
      *
@@ -738,7 +738,7 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
      * Resolves a reference to a remote element identified by address and identifier, where {@code linkBase} identifies
      * a remote document, and {@code linkRef} is the id of the desired element. This method retrieves resources
      * asynchronously using the {@link gov.nasa.worldwind.cache.FileStore}.
-     * <p/>
+     * <p>
      * The return value is null if the file is not yet available in the FileStore. If {@code linkBase} refers to a KML
      * or KMZ file and {@code linkRef} is non-null, the return value is the element identified by {@code linkRef}. If
      * {@code linkBase} refers to a KML or KMZ and {@code linkRef} is null, the return value is a parsed {@link KMLRoot}
@@ -771,13 +771,13 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
      * Resolves a reference to a remote element identified by address and identifier, where {@code linkBase} identifies
      * a remote document, and {@code linkRef} is the id of the desired element. This method retrieves resources
      * asynchronously using the {@link gov.nasa.worldwind.cache.FileStore}.
-     * <p/>
+     * <p>
      * The return value is null if the file is not yet available in the FileStore. If {@code linkBase} refers to a KML
      * or KMZ file and {@code linkRef} is non-null, the return value is the element identified by {@code linkRef}. If
      * {@code linkBase} refers to a KML or KMZ and {@code linkRef} is null, the return value is a parsed {@link KMLRoot}
      * for the KML file identified by {@code linkBase}. Otherwise the return value is a {@link URL} to the file in the
      * file cache or a temporary location, depending on the value of <code>cacheRemoteFile</code>.
-     * <p/>
+     * <p>
      * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the WorldWind
      * cache or in a temporary location. This parameter has no effect if the file exists locally. The temporary location
      * for a retrieved file does not persist between runtime sessions, and subsequent invocations of this method may not
@@ -863,10 +863,10 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
     /**
      * Resolves a NetworkLink to a local or remote KML document. This method retrieves remote resources asynchronously
      * using the {@link gov.nasa.worldwind.cache.FileStore}.
-     * <p/>
+     * <p>
      * The return value is a parsed KMLRoot representing the linked document. The return value is null if the linked
      * file is not a KML file, or is not yet available in the FileStore.
-     * <p/>
+     * <p>
      * The <code>cacheRemoteFile</code> parameter specifies whether to store a retrieved remote file in the WorldWind
      * cache or in a temporary location. This parameter has no effect if the file exists locally. The temporary location
      * for a retrieved file does not persist between runtime sessions, and subsequent invocations of this method may not
@@ -1207,7 +1207,7 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
      * detail to appear at higher resolution at greater distances than normal, but at an increased performance cost.
      * Values less than 0 decrease the default resolution at any given distance. The default value is 0. Values
      * typically range between -0.5 and 0.5.
-     * <p/>
+     * <p>
      * The top level KML root's detail hint is inherited by all KML elements beneath that root, including any descendant
      * KML roots loaded by network links. If this KML root has been loaded by a network link, its detail hint is
      * ignored.
@@ -1245,7 +1245,7 @@ public class KMLRoot extends KMLAbstractObject implements KMLRenderable
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to forward the message to the root feature.
      *
      * @param msg The message that was received.

--- a/src/gov/nasa/worldwind/ogc/kml/KMLStyleMap.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLStyleMap.java
@@ -102,7 +102,7 @@ public class KMLStyleMap extends KMLAbstractStyleSelector
      * Obtains the map's effective style for a specified style type (<i>IconStyle</i>, <i>ListStyle</i>, etc.) and state
      * (<i>normal</i> or <i>highlight</i>). The returned style is the result of merging values from the map's style
      * selectors and style URL for the indicated sub-style type, with precedence given to style selectors.
-     * <p/>
+     * <p>
      * Remote <i>styleUrls</i> that have not yet been resolved are not included in the result. In this case the returned
      * sub-style is marked with the value {@link gov.nasa.worldwind.avlist.AVKey#UNRESOLVED}.
      *

--- a/src/gov/nasa/worldwind/ogc/kml/KMLStyleUrl.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLStyleUrl.java
@@ -27,7 +27,7 @@ public class KMLStyleUrl extends KMLAbstractObject
 
     /**
      * Resolves a <i>styleUrl</i> to a style selector, which is either a style or style map.
-     * <p/>
+     * <p>
      * If the url refers to a remote resource and the resource has not been retrieved and cached locally, this method
      * returns null and initiates a retrieval.
      *

--- a/src/gov/nasa/worldwind/ogc/kml/impl/KMLAbstractBalloon.java
+++ b/src/gov/nasa/worldwind/ogc/kml/impl/KMLAbstractBalloon.java
@@ -26,11 +26,10 @@ import java.util.regex.*;
  * implementing the Balloon interface, this class provides a thin wrapper around another Balloon implementation and adds
  * the logic for styling the Balloon according to the KML style. All Balloon methods on this class pass through to the
  * contained Balloon.
- * <p/>
+ * <p>
  * To use KML Balloon, first create a Balloon of the desired type, and then create the KML Balloon. For example:
- * <p/>
- * <code>
  * <pre>
+ * {@code 
  *   KMLPlacemark myPlacemark = ...;
  *   Position placemarkPosition = ...;
  *
@@ -39,8 +38,8 @@ import java.util.regex.*;
  *
  *   // Create a KML Balloon to apply the placemark's KML BalloonStyle to the browser balloon.
  *   KMLGlobeBalloonImpl kmlBalloon = new KMLGlobeBalloonImpl(globeBalloon, myPlacemark);
+ * }
  * </pre>
- * </code>
  *
  * @author pabercrombie
  * @version $Id: KMLAbstractBalloon.java 1555 2013-08-20 13:33:12Z pabercrombie $
@@ -267,7 +266,7 @@ public abstract class KMLAbstractBalloon implements Balloon, WebResourceResolver
      */
     protected void createDefaultExtendedDataText(StringBuilder sb, List<KMLData> data)
     {
-        sb.append("<p/><table border=\"1\">");
+        sb.append("<p><table border=\"1\">");
         for (KMLData item : data)
         {
             String value = item.getValue();
@@ -290,7 +289,7 @@ public abstract class KMLAbstractBalloon implements Balloon, WebResourceResolver
      */
     protected void createDefaultSchemaDataText(StringBuilder sb, List<KMLSchemaData> data)
     {
-        sb.append("<p/><table border=\"1\">");
+        sb.append("<p><table border=\"1\">");
         for (KMLSchemaData schemaData : data)
         {
             KMLSchema schema = (KMLSchema) this.parent.getRoot().resolveReference(schemaData.getSchemaUrl());
@@ -339,7 +338,7 @@ public abstract class KMLAbstractBalloon implements Balloon, WebResourceResolver
     /**
      * Add hyperlink tags to URLs in the balloon text. The text may include some simple HTML markup. This method
      * attempts to identify URLs in the text while not altering URLs that are already linked.
-     * <p/>
+     * <p>
      * This method is conservative about what is identified as a URL, in order to avoid adding links to text that the
      * user did not intend to be linked. Only HTTP and HTTPS URLs are recognised, as well as text that begins with www.
      * (in which case a http:// prefix will be prepended). Some punctuation characters that are valid URL characters
@@ -486,12 +485,12 @@ public abstract class KMLAbstractBalloon implements Balloon, WebResourceResolver
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * This implementation resolves relative resource paths by calling <code>{@link
      * gov.nasa.worldwind.ogc.kml.io.KMLDoc#getSupportFilePath(String)}</code> on the parent
      * <code>KMLAbstractFeature's</code> <code>KMLDoc</code>. This is necessary to correctly resolve relative references
      * in a KMZ archive.
-     * <p/>
+     * <p>
      * This returns <code>null</code> if the specified <code>address</code> is <code>null</code>.
      */
     public URL resolve(String address)

--- a/src/gov/nasa/worldwind/ogc/kml/impl/KMLExportUtil.java
+++ b/src/gov/nasa/worldwind/ogc/kml/impl/KMLExportUtil.java
@@ -169,7 +169,7 @@ public class KMLExportUtil
      *
      * @param hexString String to manipulate.
      *
-     * @return The portion of {@code hexString} after the 0X. For example: "0X00FF00" => "00FF00". If the string does
+     * @return The portion of {@code hexString} after the 0X. For example: {@code "0X00FF00" => "00FF00"}. If the string does
      *         not begin with 0X, {@code hexString} is returned. The comparison is not case sensitive.
      */
     public static String stripHexPrefix(String hexString)

--- a/src/gov/nasa/worldwind/ogc/kml/impl/KMLModelPlacemarkImpl.java
+++ b/src/gov/nasa/worldwind/ogc/kml/impl/KMLModelPlacemarkImpl.java
@@ -217,7 +217,7 @@ public class KMLModelPlacemarkImpl extends WWObjectImpl implements KMLRenderable
      * resources will be resolved relative to the .dae file within the archive. Normally references in a KMZ are
      * resolved relative to the root of the archive, but Model references are an exception. See
      * https://developers.google.com/kml/documentation/kmzarchives and https://developers.google.com/kml/documentation/kmlreference#model
-     * <p/>
+     * <p>
      * {@inheritDoc}.
      */
     public String resolveFilePath(String path) throws IOException
@@ -300,10 +300,12 @@ public class KMLModelPlacemarkImpl extends WWObjectImpl implements KMLRenderable
      * calls <code>{@link #setColladaRoot(ColladaRoot)}</code> to specify this link's new network resource, and sends an
      * <code>{@link gov.nasa.worldwind.avlist.AVKey#RETRIEVAL_STATE_SUCCESSFUL}</code> property change event to this
      * link's property change listeners.
-     * <p/>
+     * <p>
      * This does nothing if this <code>KMLNetworkLink</code> has no <code>KMLLink</code>.
      *
      * @param address the address of the resource to retrieve
+     * @throws java.io.IOException if an error occurs
+     * @throws javax.xml.stream.XMLStreamException if an error occurs
      */
     protected void retrieveModel(String address) throws IOException, XMLStreamException
     {

--- a/src/gov/nasa/worldwind/ogc/kml/impl/KMLScreenImageImpl.java
+++ b/src/gov/nasa/worldwind/ogc/kml/impl/KMLScreenImageImpl.java
@@ -188,9 +188,11 @@ public class KMLScreenImageImpl extends ScreenImage implements KMLRenderable
     /**
      * Get the size mode for a size parameter. The KML size tag takes a numeric size attribute, but certain values of
      * this attribute change the interpretation of the tag.
-     * <p/>
-     * <ul> <li> A value of -1 indicates to use the native dimension</li>. <li> A value of 0 indicates to maintain the
-     * aspect ratio</li>. <li> A value of n sets the value of the dimension</li>. </ul>
+     * <ul> 
+     * <li> A value of -1 indicates to use the native dimension.</li> 
+     * <li> A value of 0 indicates to maintain the aspect ratio.</li> 
+     * <li> A value of n sets the value of the dimension.</li> 
+     * </ul>
      *
      * @param size The KML size attribute
      *

--- a/src/gov/nasa/worldwind/ogc/kml/io/KMLDoc.java
+++ b/src/gov/nasa/worldwind/ogc/kml/io/KMLDoc.java
@@ -20,7 +20,7 @@ public interface KMLDoc
     /**
      * Returns an {@link InputStream} to the associated KML document within either a KML file or stream or a KMZ file or
      * stream.
-     * <p/>
+     * <p>
      * Implementations of this interface do not close the stream; the user of the class must close the stream.
      *
      * @return an input stream positioned to the head of the KML document.

--- a/src/gov/nasa/worldwind/ogc/kml/io/KMLFile.java
+++ b/src/gov/nasa/worldwind/ogc/kml/io/KMLFile.java
@@ -12,7 +12,7 @@ import java.io.*;
 
 /**
  * Implements the {@link KMLDoc} interface for KML files located within a computer's file system.
- * <p/>
+ * <p>
  * Note: This class does not resolve references to files in KMZ archives. For example, it does not resolve references
  * like this: <i>../other.kmz/file.png</i>.
  *

--- a/src/gov/nasa/worldwind/ogc/kml/io/KMZFile.java
+++ b/src/gov/nasa/worldwind/ogc/kml/io/KMZFile.java
@@ -14,7 +14,7 @@ import java.util.zip.*;
 
 /**
  * Implements the {@link KMLDoc} interface for KMZ files located within a computer's file system.
- * <p/>
+ * <p>
  * Note: This class does not yet resolve references to files in other KMZ archives. For example, it does not resolve
  * references like this: <i>../other.kmz/file.png</i>.
  *
@@ -87,7 +87,7 @@ public class KMZFile implements KMLDoc
     /**
      * Returns an {@link InputStream} to a specified file within the KMZ file. The file's path is resolved relative to
      * the internal root of the KMZ file.
-     * <p/>
+     * <p>
      * Note: This class does not yet resolve references to files in other KMZ archives. For example, it does not resolve
      * references like this: <i>../other.kmz/file.png</i>.
      *
@@ -128,7 +128,7 @@ public class KMZFile implements KMLDoc
     /**
      * Returns an absolute path to a specified file within the KMZ file. The file's path is resolved relative to the
      * internal root of the KMZ file.
-     * <p/>
+     * <p>
      * Note: This class does not yet resolve references to files in other KMZ archives. For example, it does not resolve
      * references like this: <i>../other.kmz/file.png</i>. // TODO
      *

--- a/src/gov/nasa/worldwind/ogc/kml/io/KMZInputStream.java
+++ b/src/gov/nasa/worldwind/ogc/kml/io/KMZInputStream.java
@@ -110,7 +110,7 @@ public class KMZInputStream implements KMLDoc
     /**
      * Returns an {@link InputStream} to a specified file within the KMZ stream. The file's path is resolved relative to
      * the internal root of the KMZ file represented by the stream.
-     * <p/>
+     * <p>
      * Note: Since relative references to files outside the stream have no meaning, this class does not resolve relative
      * references to files in other KMZ archives. For example, it does not resolve references like this:
      * <i>../other.kmz/file.png</i>.
@@ -157,7 +157,7 @@ public class KMZInputStream implements KMLDoc
     /**
      * Returns an absolute path to a specified file within the KMZ stream. The file's path is resolved relative to the
      * internal root of the KMZ file represented by the stream.
-     * <p/>
+     * <p>
      * Note: Since relative references to files outside the stream have no meaning, this class does not resolve relative
      * references to files in other KMZ archives. For example, it does not resolve references like this:
      * <i>../other.kmz/file.png</i>.
@@ -205,7 +205,7 @@ public class KMZInputStream implements KMLDoc
     /**
      * Copies a file from the input stream to the temporary area created to represent the KMZ contents. If that area
      * does not yet exists, it is created.
-     * <p/>
+     * <p>
      * Note: This method should be called only by another synchronized method of this instance.
      *
      * @throws IOException if an error occurs during the copy.

--- a/src/gov/nasa/worldwind/ogc/wcs/wcs100/WCS100Capabilities.java
+++ b/src/gov/nasa/worldwind/ogc/wcs/wcs100/WCS100Capabilities.java
@@ -33,7 +33,7 @@ public class WCS100Capabilities extends AbstractXMLEventParser
      * @param uri The URI of the server.
      *
      * @return The WCS capabilities document for the specified server.
-     *
+     * @throws java.lang.Exception if an error occurs
      * @throws IllegalArgumentException if the specified URI is invalid.
      * @throws gov.nasa.worldwind.exception.WWRuntimeException
      *                                  if an error occurs retrieving the document.

--- a/src/gov/nasa/worldwind/ogc/wms/WMSCapabilities.java
+++ b/src/gov/nasa/worldwind/ogc/wms/WMSCapabilities.java
@@ -33,7 +33,7 @@ public class WMSCapabilities extends OGCCapabilities
      * @param uri The URI of the server.
      *
      * @return The WMS capabilities document for the specified server.
-     *
+     * @throws java.lang.Exception if an error occurs
      * @throws IllegalArgumentException if the specified URI is invalid.
      * @throws gov.nasa.worldwind.exception.WWRuntimeException
      *                                  if an error occurs retrieving the document.

--- a/src/gov/nasa/worldwind/pick/PickSupport.java
+++ b/src/gov/nasa/worldwind/pick/PickSupport.java
@@ -106,7 +106,7 @@ public class PickSupport
      * Adds picked object registered with this PickSupport that are drawn at the specified pick point or intersect the
      * draw context's pick rectangle to the draw context's list of picked objects. This clears any registered picked
      * objects upon returning.
-     * <p/>
+     * <p>
      * If this pick point is <code>null</code>, this ignores the pick point and does not attempt to determine which
      * picked objects are drawn there. If the draw context's pick rectangle is <code>null</code>, this ignores the pick
      * rectangle and does not attempt to determine which picked objects intersect it. This does nothing if no picked
@@ -208,7 +208,7 @@ public class PickSupport
      * green, and blue components are each stored as an 8-bit unsigned integer, and packed into bits 0-23 of the
      * returned integer as follows: bits 16-23 are red, bits 8-15 are green, and bits 0-7 are blue. This format is
      * consistent with the RGB integers used to create the pick colors.
-     * <p/>
+     * <p>
      * This returns 0 if the point is <code>null</code>, if the point contains the clear color, or if the point is
      * outside the draw context's drawable area.
      *

--- a/src/gov/nasa/worldwind/pick/PickedObjectFactory.java
+++ b/src/gov/nasa/worldwind/pick/PickedObjectFactory.java
@@ -7,7 +7,7 @@ package gov.nasa.worldwind.pick;
 
 /**
  * PickedObjectFactory provides an interface for lazily creating PickedObject instances.
- * <p/>
+ * <p>
  * This interface is used by PickSupport to associate a collection of picked objects with a range of pick colors.
  * PickSupport uses this factory to delay PickedObject construction until a matching pick color is identified. This
  * eliminates the overhead of creating and managing a large collection of PickedObject instances when only a few may

--- a/src/gov/nasa/worldwind/poi/POIUtils.java
+++ b/src/gov/nasa/worldwind/poi/POIUtils.java
@@ -28,7 +28,7 @@ public class POIUtils
      *
      * @param urlString the URL to use to invoke the service.
      * @return the service results.
-     * @throws NoItemException  if <code>HTTP_BAD_REQUEST<code> is returned from the service.
+     * @throws NoItemException  if <code>HTTP_BAD_REQUEST</code> is returned from the service.
      * @throws ServiceException if there is a problem invoking the service or retrieving its results.
      */
     public static String callService(String urlString) throws NoItemException, ServiceException

--- a/src/gov/nasa/worldwind/render/AbstractAnnotation.java
+++ b/src/gov/nasa/worldwind/render/AbstractAnnotation.java
@@ -16,13 +16,14 @@ import java.awt.*;
 
 /**
  * An {@link Annotation} represent a text label and its rendering attributes. Annotations must be attached either to a
- * globe <code>Position</code> ({@link GlobeAnnotation}) or a viewport <code>Point</code> (ScreenAnnotation). <p/>
+ * globe <code>Position</code> ({@link GlobeAnnotation}) or a viewport <code>Point</code> (ScreenAnnotation). 
  * <pre>
  * GlobeAnnotation ga = new  GlobeAnnotation("Lat-Lon zero", Position.fromDegrees(0, 0, 0)));
  * ScreenAnnotation sa = new ScreenAnnotation("Message...", new Point(10,10));
  * </pre>
  * <p> Each Annotation refers to an {@link AnnotationAttributes} object which defines how the text will be rendered.
- * </p> Rendering attributes allow to set: <ul> <li>the size of the bounding rectangle into which the text will be
+ * </p> 
+ * <p>Rendering attributes allow to set: <ul> <li>the size of the bounding rectangle into which the text will be
  * displayed</li> <li>its frame shape, border color, width and stippling pattern</li> <li>the text font, size, style and
  * color</li> <li>the background color or image</li> <li>how much an annotation scales and fades with distance</li>
  * </ul>
@@ -31,42 +32,42 @@ import java.awt.*;
  * ga.getAttributes().setFont(Font.decode("Arial-BOLD-24");
  * ...
  * </pre>
- * <p/> Annotations are usually handled by an {@link gov.nasa.worldwind.layers.AnnotationLayer}. Although they also
+ * <p> Annotations are usually handled by an {@link gov.nasa.worldwind.layers.AnnotationLayer}. Although they also
  * implement the {@link Renderable} interface and thus can be handled by a {@link gov.nasa.worldwind.layers.RenderableLayer}
- * too. <p/>
+ * too. </p>
  * <pre>
  * AnnotationLayer layer = new AnnotationLayer();
  * layer.addAnnotation(new GlobeAnnotation("Text...", Position.fromDegrees(0, 0, 0)));
  * </pre>
- * <p/> Each Annotation starts its life with a fresh attribute set that can be altered to produce the desired effect.
+ * <p> Each Annotation starts its life with a fresh attribute set that can be altered to produce the desired effect.
  * However, <code>AnnotationAttributes</code> can be set and shared between annotations allowing to control the
- * rendering attributes of many annotations from a single <code>AnnotationAttributes</code> object. <p/>
+ * rendering attributes of many annotations from a single <code>AnnotationAttributes</code> object. </p>
  * <pre>
  * AnnotationAttributes attr = new AnnotationAttributes();
  * attr.setTextColor(Color.WHITE);
  * attr.setFont(Font.decode("Arial-BOLD-24");
  * ga.setAttributes(attr);
  * </pre>
- * <p/> In the above example changing the text color of the attributes set will affect all annotations referring it.
+ * <p> In the above example changing the text color of the attributes set will affect all annotations referring it.
  * However, changing the text color of one of those annotations will also affect all others since it will in fact change
- * the common attributes set. <p> To use an attributes object only as default values for a series of annotations use:
+ * the common attributes set. </p> <p>To use an attributes object only as default values for a series of annotations use:
  * </p>
  * <pre>
  * ga.getAttributes().setDefaults(attr);
  * </pre>
- * <p/> which can also be done in the Annotation constructor: <p/>
+ * <p> which can also be done in the Annotation constructor: </p>
  * <pre>
  * GlobeAnnotation ga = new GlobeAnnotation(text, position, attr);
  * </pre>
- * <p/> Finer control over attributes inheritance can be achieved using default or fallback attributes set. <p> Most
+ * <p> Finer control over attributes inheritance can be achieved using default or fallback attributes set. <p> Most
  * attributes can be set to a 'use default' value which is minus one for numeric values and <code>null</code> for
  * attributes referring objects (colors, dimensions, insets..). In such a case the value of an attribute will be that of
  * the default attribute set. New annotations have all their attributes set to use default values. </p>
- * <p/>
+ * <p>
  * Each <code>AnnotationAttributes</code> object points to a default static attributes set which is the fallback source
  * for attributes with  <code>null</code> or <code>-1</code> values. This default attributes set can be set to any
  * attributes object other than the static one.
- * <p/>
+ * 
  * <pre>
  * AnnotationAttributes geoFeature = new AnnotationAttributes();
  * geoFeature.setFrameShape(AVKey.SHAPE_ELLIPSE);
@@ -83,12 +84,12 @@ import java.awt.*;
  * layer.addAnnotation(new GlobeAnnotation("Spirit Lake", Position.fromDegrees(46.26, -122.15), waterBody);
  * layer.addAnnotation(new GlobeAnnotation("Mt St-Helens", Position.fromDegrees(46.20, -122.19), mountain);
  * </pre>
- * <p/>
+ * <p>
  * In the above example all geographic features have an ellipse shape, water bodies and mountains use that attributes
  * set has defaults and have their own text colors. They are in turn used as defaults by the two annotations. Mount
  * Saint Helens attributes could be changed without affecting other mountains. However, changes on the geoFeatures
  * attributes would affect all mountains and lakes.
- * <p/>
+ * <p>
  * Background images are specified by setting the Annotation attribute {@link gov.nasa.worldwind.render.AnnotationAttributes#setImageSource(Object)}.
  * The source can be either a path to a valid image file, or a {@link java.awt.image.BufferedImage}. By default,
  * background images are aligned with the annotation as follows: the image's upper left corner is aligned with the
@@ -102,19 +103,19 @@ import java.awt.*;
  * background image's magnification or minification factor relative to the annotation. For example, a scale of
  * <code>0.5</code> indicates the image should be 1/2 its original size relative to the annotation, while a scale of
  * <code>2.0</code> indicates the image should be 2x its original size.
- * <p/>
+ * <p>
  * <strong>Warning:</strong> For compatibility across the myriad of graphics hardware, background images must have
  * power-of-two dimensions. Non-power-of-two images are handled inconsistently by graphics hardware. Not all hardware
  * supports them, and many that do lack full support for the features available when using power-of-two images. Proper
  * conversion from a non-power-of-two image to a power-of-two image depends on the image's intended use. However, the
  * following two step solution works for most applications: <ol> <li>Create a transparent power-of-two image larger than
  * the original image. The utility method {@link gov.nasa.worldwind.util.WWMath#powerOfTwoCeiling(int)} is useful for
- * computing power-of-two dimensions: <code> <br/><br/> int newWidth = WWMath.powerOfTwoCeiling(originalWidth);<br/> int
- * newHeight = WWMath.powerOfTwoCeiling(originalHeight); <br/><br/> </code> </li> <li>Copy the original image contents
+ * computing power-of-two dimensions: <code> <br><br> int newWidth = WWMath.powerOfTwoCeiling(originalWidth);<br> int
+ * newHeight = WWMath.powerOfTwoCeiling(originalHeight); <br><br> </code> </li> <li>Copy the original image contents
  * into the empty power-of-two image. Any pixels not covered by the original image are left completely transparent:
- * <code> <br/><br/> BufferedImage newImage = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_ARGB);<br/>
- * Graphics2D g2d = newImage.createGraphics();<br/> try<br/> {<br/> &nbsp;&nbsp;g2d.drawImage(originalImage, 0, 0,
- * null);<br/> }<br/> finally<br/> {<br/> &nbsp;&nbsp;g2d.dispose();<br/> }<br/><br/> </code></li> </ol> When used as an
+ * <code> <br><br> BufferedImage newImage = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_ARGB);<br>
+ * Graphics2D g2d = newImage.createGraphics();<br> try<br> {<br> &nbsp;&nbsp;g2d.drawImage(originalImage, 0, 0,
+ * null);<br> }<br> finally<br> {<br> &nbsp;&nbsp;g2d.dispose();<br> }<br><br> </code></li> </ol> When used as an
  * Annotation background image, the new power-of-two image appears identical to its original non-power-of-two
  * counterpart, except that the new image is now compatible with most graphics hardware.
  *
@@ -493,7 +494,7 @@ public abstract class AbstractAnnotation extends AVListImpl implements Annotatio
     /**
      * Get the annotation bounding {@link java.awt.Rectangle} using OGL coordinates - bottom-left corner x and y
      * relative to the {@link WorldWindow} bottom-left corner, and the annotation callout width and height.
-     * <p/>
+     * <p>
      * The annotation offset from it's reference point is factored in such that the callout leader shape and reference
      * point are included in the bounding rectangle.
      *

--- a/src/gov/nasa/worldwind/render/AbstractBrowserBalloon.java
+++ b/src/gov/nasa/worldwind/render/AbstractBrowserBalloon.java
@@ -34,9 +34,9 @@ import java.util.List;
  * java.net.URL}</code>, or a <code>String</code> containing a valid URL description. If a browser balloon's resource
  * resolver is <code>null</code> or is an unrecognized type, the browser interprets relative <code>URLs</code> as
  * unresolved references.
- * <p/>
+ * <p>
  * <b>Browser Controls</b>
- * <p/>
+ * <p>
  * Browser balloons display three default browser controls that enable users to navigate the browser's history back and
  * forward, and to close the balloon. When the user selects one of these controls, a <code>SelectEvent</code> is
  * generated with the <code>PickedObject's</code> <code>AVKey.ACTION</code> value set to one of
@@ -44,17 +44,17 @@ import java.util.List;
  * disabled by calling <code>setDrawBrowserControls</code> (they are enabled by default), and may be customized by
  * adding or removing controls from the browser balloon. See <code>getBrowserControls</code>,
  * <code>addBrowserControl</code>, and <code>removeBrowserControl</code>.
- * <p/>
+ * <p>
  * <b>Resize Control</b>
- * <p/>
+ * <p>
  * Browser balloons provide a default resize control that is activated by dragging the balloon's border. When the user
  * drags the border, a <code>SelectEvent</code> is generated with the PickedObject's <code>AVKey.ACTION</code> value set
  * to <code>AVKey.RESIZE</code>. The <code>PickedObject's</code> <code>AVKey.BOUNDS</code> value holds the Balloon's
  * screen bounds in AWT coordinates (origin at the upper left corner) as a <code>java.awt.Rectangle</code>.  The resize
  * control may be enabled or disabled by calling <code>setDrawResizeControl</code> (it is enabled by default).
- * <p/>
+ * <p>
  * <b>Balloon Size</b>
- * <p/>
+ * <p>
  * The browser balloon's screen width and height are specified as a <code>{@link gov.nasa.worldwind.render.Size}</code>
  * object in its <code>BalloonAttributes</code>. This size may configured in one of the following three modes: <ul>
  * <li>Explicit size in pixels.</li> <li>Fraction of the <code>WorldWindow</code> size.</li> <li>Fit to the balloon's
@@ -63,23 +63,23 @@ import java.util.List;
  * <code>Size</code> object in its <code>BalloonAttributes</code>. If the maximum size is <code>null</code>, the
  * balloon's width and height are unlimited. The space provided for the balloon's HTML content equal to the balloon's
  * screen width and height minus the balloon's insets, also specified in its <code>BalloonAttributes</code>
- * <p/>
+ * <p>
  * The balloon's width or height (or both) may be configured to fit to the balloon's HTML content by configuring its
  * <code>BalloonAttributes</code> with a <code>Size</code> who's width or height mode is
  * <code>Size.NATIVE_DIMENSION</code> or <code>Size.MAINTAIN_ASPECT_RATIO</code>. When configured in this mode, the
  * browser balloon's size always fits the HTML content specified at construction or by calling <code>setText</code>. If
  * a user action causes the balloon to navigate to another page, the balloon continues to fit to its current HTML
  * content.
- * <p/>
+ * <p>
  * The balloon frame's corner radius and leader width specified in its <code>BalloonAttributes</code> are limited by the
  * balloon's size. The corner radius is first limited by the balloon's width and height, then the leader width is
  * limited by the balloon's width and height minus space taken by rounded corners. For example, if the corner radius is
  * 100 and the width and height are 50 and 100, the actual corner radius used is 25 - half of the rectangle's smallest
  * dimension. Similarly, if the leader is attached to the rectangle's bottom, its width is limited by the rectangle's
  * width minus any space used by the balloon's rounded corners.
- * <p/>
+ * <p>
  * <b>Hiding the balloon</b>
- * <p/>
+ * <p>
  * The balloon can be made visible or invisible by calling {@link #setVisible(boolean) setVisible}. The balloon's {@code
  * visibilityAction} determines what happens to the native web browser when the balloon is invisible. The balloon can
  * either release its native web browser, preventing the native browser from consuming system resources while the
@@ -352,8 +352,8 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
 
     /**
      * Returns a list containing the browser balloon's three default browser controls, configured as follows:
-     * <p/>
-     * <table> <tr><th>Control</th><th>Action</th><th>Offset</th><th>Size</th><th>Image Source</th></tr>
+     * <table><caption>Controls</caption>
+     * <tr><th>Control</th><th>Action</th><th>Offset</th><th>Size</th><th>Image Source</th></tr>
      * <tr><td>Close</td><td><code>AVKey.CLOSE</code></td><td>(30, 25) pixels inset from the balloon's upper right
      * corner</td><td>Image source's native size in pixels (16x16)</td><td>images/browser-close-16x16.gif</td></tr>
      * <tr><td>Back</td><td><code>AVKey.BACK</code></td><td>(15, 25) pixels inset from the balloon's upper left
@@ -438,6 +438,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * Computes and stores the balloon's model-coordinate and screen-coordinate points.
      *
      * @param dc the current draw context.
+     * @param obb the ordered browser balloon.
      */
     protected abstract void computeBalloonPoints(DrawContext dc, OrderedBrowserBalloon obb);
 
@@ -484,7 +485,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * When this balloon is set to invisible, the {@code visibilityAction} determines what happens to the native web
      * browser that backs the balloon. By default, the browser resources are released when the balloon is not visible.
      *
@@ -520,7 +521,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * Specifies the outline line width (in pixels) to use during picking. The specified <code>width</code> must be zero
      * or a positive integer. Specifying a pick width of zero effectively disables the picking of the balloon's outline
      * and its resize control. A larger width than normal typically makes the outline easier to pick.
-     * <p/>
+     * <p>
      * When the the balloon's resize control is enabled, the outline becomes the resize control and is drawn in the
      * specified <code>width</code>. Therefore this value also controls the balloon's resize control width. If the
      * resize control is disabled by calling <code>{@link #setDrawResizeControl(boolean)}</code> with a value of
@@ -665,10 +666,12 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
     /**
      * Specifies a the object to use when resolving relative resource paths in this browser balloon's HTML content. The
      * <code>resourceResolver</code> may be one of the following:
-     * <p/>
-     * <ul> <li>a <code>{@link gov.nasa.worldwind.util.webview.WebResourceResolver}</code></li> <li>a <code>{@link
-     * java.net.URL}</code></li> <li>a <code>{@link String}</code> containing a valid URL description</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>a <code>{@link gov.nasa.worldwind.util.webview.WebResourceResolver}</code></li> 
+     * <li>a <code>{@link java.net.URL}</code></li> 
+     * <li>a <code>{@link String}</code> containing a valid URL description</li> 
+     * </ul>
+     * <p>
      * If the <code>resourceResolver</code> is <code>null</code> or is not one of the recognized types, this browser
      * balloon interprets relative resource paths as unresolved references.
      *
@@ -742,7 +745,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to suppress <code>AVKey.REPAINT</code> property change events sent by the balloon's internal
      * <code>{@link gov.nasa.worldwind.util.webview.WebView}</code> when <code>isVisible</code> returns
      * <code>false</code>.
@@ -824,7 +827,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * balloon. This queues an ordered renderable if the balloon intersects the current viewing frustum, and if the
      * balloon's internal rendering state can be computed. This updates the balloon's rendering state by calling
      * <code>updateRenderStateIfNeeded</code>, and updates its geometry by calling <code>computeGeometry</code>.
-     * <p/>
+     * <p>
      * BrowserBalloon separates render state updates from geometry updates for two reasons: <ul> <li>Geometry may be
      * updated based on different conditions.</li> <li>Rendering state potentially needs to be updated in
      * getBounds.</li> </ul>
@@ -898,6 +901,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * </ul>
      *
      * @param dc the current draw context.
+     * @param obb the ordered browser balloon to update.
      */
     protected void updateRenderStateIfNeeded(DrawContext dc, OrderedBrowserBalloon obb)
     {
@@ -977,6 +981,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * Indicates whether this balloon's screen-coordinate geometry must be recomputed as a result of a balloon attribute
      * changing.
      *
+     * @param obb the ordered browser balloon
      * @return <code>true</code> if this balloon's geometry must be recomputed, otherwise <code>false</code>.
      */
     protected boolean mustRegenerateGeometry(OrderedBrowserBalloon obb)
@@ -997,6 +1002,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
     /**
      * Updates the balloon's screen-coordinate geometry in <code>frameInfo</code> according to the current screen
      * bounds, screen offset, and active attributes.
+     * @param obb the ordered browser balloon.
      */
     protected void computeGeometry(OrderedBrowserBalloon obb)
     {
@@ -1023,6 +1029,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
     /**
      * Creates the balloon's frame vertex buffer according to the active attributes.
      *
+     * @param obb the ordered browser balloon.
      * @return a buffer containing the frame's x and y locations.
      */
     protected FloatBuffer createFrameVertices(OrderedBrowserBalloon obb)
@@ -1115,6 +1122,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * Determines whether the balloon intersects the view frustum.
      *
      * @param dc the current draw context.
+     * @param obb the ordered browser balloon.
      *
      * @return <code>true</code> If the balloon intersects the frustum, otherwise <code>false</code>.
      */
@@ -1309,15 +1317,16 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * representation applied as an OpenGL decal. OpenGL's texture decal mode uses the texture color where the texture's
      * alpha is 1, and uses the balloon's background color where it's 0. The texture's internal format must be RGBA to
      * work correctly, and this assumes that the WebView's texture format is RGBA.
-     * <p/>
+     * <p>
      * If the <code>WebView's</code> texture cannot be created or cannot be applied for any reason, this displays the
      * balloon's interior geometry in the balloon's background color without applying the <code>WebView's</code>
      * texture.
-     * <p/>
+     * <p>
      * If the specified draw context is in picking mode, this draws the balloon's interior geometry in the current color
      * and does not apply the <code>WebView's</code> texture.
      *
      * @param dc the current draw context.
+     * @param obb the ordered browser balloon.
      */
     protected void drawFrameInterior(DrawContext dc, OrderedBrowserBalloon obb)
     {
@@ -1689,6 +1698,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * Draw pickable regions for the resize controls. A pickable region is drawn along the frame outline.
      *
      * @param dc Draw context.
+     * @param obb the ordered browser balloon.
      */
     protected void drawResizeControl(DrawContext dc, OrderedBrowserBalloon obb)
     {
@@ -1994,7 +2004,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * Forwards the mouse moved event to the balloon's internal <code>{@link gov.nasa.worldwind.util.webview.WebView}</code>.
      * This does not consume the event, because the <code>{@link gov.nasa.worldwind.event.InputHandler}</code>
      * implements the policy for consuming or forwarding mouse moved events to other objects.
-     * <p/>
+     * <p>
      * Unlike mouse clicked, mouse pressed, and mouse dragged events, mouse move events cannot be forwarded to the
      * WebView via SelectEvents in <code>selected</code>, because mouse movement events are not selection events.
      *
@@ -2012,7 +2022,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
      * Forwards the mouse wheel event to the balloon's internal <code>{@link gov.nasa.worldwind.util.webview.WebView}</code>
      * and consumes the event. This consumes the event so the <code>{@link gov.nasa.worldwind.View}</code> doesn't
      * respond to it.
-     * <p/>
+     * <p>
      * Unlike mouse clicked, mouse pressed, and mouse dragged events, mouse wheel events cannot be forwarded to the
      * WebView via SelectEvents in <code>selected</code>, because mouse wheel events are not selection events.
      *
@@ -2129,7 +2139,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
 
     /**
      * Sends the specified <code>KeyEvent</code> to the balloon's internal <code>WebView</code>.
-     * <p/>
+     * <p>
      * This does nothing if the balloon's internal <code>WebView</code> is uninitialized.
      *
      * @param event the event to send.
@@ -2143,7 +2153,7 @@ public abstract class AbstractBrowserBalloon extends AbstractBalloon implements 
     /**
      * Sends the specified <code>MouseEvent</code> to the balloon's internal <code>WebView</code>. The event's point is
      * converted from AWT coordinates to the WebView's local coordinate system.
-     * <p/>
+     * <p>
      * This does nothing if the balloon's internal <code>WebView</code> is uninitialized.
      *
      * @param event the event to send.

--- a/src/gov/nasa/worldwind/render/AbstractGeneralShape.java
+++ b/src/gov/nasa/worldwind/render/AbstractGeneralShape.java
@@ -20,18 +20,18 @@ import java.util.Map;
  * models imported from COLLADA and other 3D file formats. The model's geometry is defined in its own coordinate system;
  * properties of this shape place and orient the model geographically. Specific model types subclass this class to
  * provide their implementation and any additional properties.
- * <p/>
+ * <p>
  * This class also accepts a resource map to independently link resources named in the model definition (the defining
  * model file) to actual resources. Each map entry's key is a resource name as expressed in the model definition. Each
  * map entry's value is the reference to the actual resource. The reference is interpreted by rules specific to the
  * model format, but typically may be a relative or absolute file reference or a URL to a local or remote resource. If
  * the map or an entry referred to by the model definition is not defined, resource references are typically considered
  * relative to the location of the model definition's location.
- * <p/>
+ * <p>
  * In the case of a COLLADA file referenced from a KML file, relative references are considered relative to the location
  * of the KML file. If the file is KMZ, relative references are considered references to resources within the KMZ
  * archive.
- * <p/>
+ * <p>
  * This class applies {@link ShapeAttributes} to the shape, but the effect of some of those attributes, such as {@link
  * ShapeAttributes#isDrawOutline()} is dependent on the specific implementation of this <code>AbstractGeneralShape</code>. See
  * the class description of those shapes to determine how shape attributes are applied.
@@ -253,7 +253,7 @@ public abstract class AbstractGeneralShape extends AbstractShape
 
     /**
      * Computes the minimum distance between this shape and the eye point.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc        the current draw context.

--- a/src/gov/nasa/worldwind/render/AbstractShape.java
+++ b/src/gov/nasa/worldwind/render/AbstractShape.java
@@ -27,7 +27,7 @@ import java.io.*;
 /**
  * Provides a base class form several geometric {@link gov.nasa.worldwind.render.Renderable}s. Implements common
  * attribute handling and rendering flow for outlined shapes. Provides common defaults and common export code.
- * <p/>
+ * <p>
  * In order to support simultaneous use of this shape with multiple globes (windows), this shape maintains a cache of
  * data computed relative to each globe. During rendering, the data for the currently active globe, as indicated in the
  * draw context, is made current. Subsequently called methods rely on the existence of this current data cache entry.
@@ -91,7 +91,7 @@ public abstract class AbstractShape extends WWObjectImpl
     /**
      * Indicates whether texture should be applied to this shape. Called during rendering to determine whether texture
      * state should be established during preparation for interior drawing.
-     * <p/>
+     * <p>
      * Note: This method always returns false during the pick pass.
      *
      * @param dc the current draw context
@@ -131,7 +131,7 @@ public abstract class AbstractShape extends WWObjectImpl
      * Draws this shape's outline. Called immediately after calling {@link #prepareToDrawOutline(DrawContext,
      * ShapeAttributes, ShapeAttributes)}, which establishes OpenGL state for lighting, blending, pick color and line
      * attributes. Subclasses should execute the drawing commands specific to the type of shape.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -142,7 +142,7 @@ public abstract class AbstractShape extends WWObjectImpl
      * Draws this shape's interior. Called immediately after calling {@link #prepareToDrawInterior(DrawContext,
      * ShapeAttributes, ShapeAttributes)}, which establishes OpenGL state for lighting, blending, pick color and
      * interior attributes. Subclasses should execute the drawing commands specific to the type of shape.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -151,7 +151,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Fill this shape's vertex buffer objects. If the vertex buffer object resource IDs don't yet exist, create them.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -463,9 +463,9 @@ public abstract class AbstractShape extends WWObjectImpl
     /**
      * Specifies this shape's altitude mode, one of {@link WorldWind#ABSOLUTE}, {@link WorldWind#RELATIVE_TO_GROUND} or
      * {@link WorldWind#CLAMP_TO_GROUND}.
-     * <p/>
+     * <p>
      * Note: If the altitude mode is unrecognized, {@link WorldWind#ABSOLUTE} is used.
-     * <p/>
+     * <p>
      * Note: Subclasses may recognize additional altitude modes or may not recognize the ones described above.
      *
      * @param altitudeMode the altitude mode. The default value is {@link WorldWind#ABSOLUTE}.
@@ -489,7 +489,7 @@ public abstract class AbstractShape extends WWObjectImpl
      *
      * @return true if batch rendering is enabled, otherwise false.
      *
-     * @see #setEnableBatchRendering(boolean).
+     * @see #setEnableBatchRendering(boolean)
      */
     public boolean isEnableBatchRendering()
     {
@@ -513,7 +513,7 @@ public abstract class AbstractShape extends WWObjectImpl
      *
      * @return true if batch rendering is enabled, otherwise false.
      *
-     * @see #setEnableBatchPicking(boolean).
+     * @see #setEnableBatchPicking(boolean)
      */
     public boolean isEnableBatchPicking()
     {
@@ -525,7 +525,7 @@ public abstract class AbstractShape extends WWObjectImpl
      * together if they are contained in the same layer. This increases performance but allows only the top-most of the
      * polygons to be reported in a {@link gov.nasa.worldwind.event.SelectEvent} even if several of the polygons are at
      * the pick position.
-     * <p/>
+     * <p>
      * Batch rendering ({@link #setEnableBatchRendering(boolean)}) must be enabled in order for batch picking to occur.
      *
      * @param enableBatchPicking true to enable batch rendering, otherwise false.
@@ -549,7 +549,7 @@ public abstract class AbstractShape extends WWObjectImpl
     /**
      * Specifies the outline line width to use during picking. A larger width than normal typically makes the outline
      * easier to pick.
-     * <p/>
+     * <p>
      * Note that the size of the pick aperture also affects the precision necessary to pick.
      *
      * @param outlinePickWidth the outline pick width. The default is 10.
@@ -733,7 +733,7 @@ public abstract class AbstractShape extends WWObjectImpl
     /**
      * Indicates whether this shape's renderable geometry must be recomputed, either as a result of an attribute or
      * property change or the expiration of the geometry regeneration interval.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -978,7 +978,7 @@ public abstract class AbstractShape extends WWObjectImpl
     /**
      * Determines whether to add this shape to the draw context's ordered renderable list. Creates this shapes
      * renderable geometry.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1091,7 +1091,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Determines whether this shape intersects the view frustum.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1111,7 +1111,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Draws this shape as an ordered renderable.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1135,7 +1135,7 @@ public abstract class AbstractShape extends WWObjectImpl
     /**
      * Draws this ordered renderable and all subsequent Path ordered renderables in the ordered renderable list. If the
      * current pick mode is true, only shapes within the same layer are drawn as a batch.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1183,7 +1183,7 @@ public abstract class AbstractShape extends WWObjectImpl
      * {@link PickSupport}. The <code>PickSupport</code> may not be the one associated with this instance. During batch
      * picking the <code>PickSupport</code> of the instance initiating the batch picking is used so that all shapes
      * rendered in batch are added to the same pick list.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc             the current draw context.
@@ -1239,7 +1239,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Establish the OpenGL state needed to draw this shape.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc       the current draw context.
@@ -1292,7 +1292,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Pop the state set in {@link #beginDrawing(DrawContext, int)}.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1317,7 +1317,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Draws this shape's outline.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1393,7 +1393,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Draws this shape's interior.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1540,7 +1540,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Get or create OpenGL resource IDs for the current data cache entry.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.
@@ -1555,7 +1555,7 @@ public abstract class AbstractShape extends WWObjectImpl
 
     /**
      * Removes from the GPU resource cache the entry for the current data cache entry's VBOs.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.

--- a/src/gov/nasa/worldwind/render/AbstractSurfaceObject.java
+++ b/src/gov/nasa/worldwind/render/AbstractSurfaceObject.java
@@ -27,7 +27,7 @@ import java.util.List;
  * building the composite representation the SceneController invokes {@link #render(DrawContext)} in ordered rendering
  * mode. To avoid overloading the purpose of the render method, AbstractSurfaceObject does not add itself to the
  * DrawContext's ordered surface renderable queue during rendering.
- * <p/>
+ * <p>
  * Subclasses that do not wish to participate in this composite representation can override this behavior as follows:
  * <ol> <li>Override {@link #makeOrderedPreRenderable(DrawContext)}; do not add this object to the draw context's
  * ordered renderable queue. Perform any preRender processing necessary for the subclass to pick and render itself.</li>
@@ -443,7 +443,7 @@ public abstract class AbstractSurfaceObject extends WWObjectImpl implements Surf
      * DrawContext's ordered surface renderable list. Additionally, this prepares the SurfaceObject's pickable
      * representation if the SurfaceObject's containing layer is enabled for picking and the SurfaceObject intersects
      * one of the DrawContext's picking frustums.
-     * <p/>
+     * <p>
      * During ordered preRendering, the {@link gov.nasa.worldwind.SceneController} builds a composite representation of
      * this SurfaceObject and any other SurfaceObject on the DrawContext's ordered surface renderable list. The
      * SceneController causes each SurfaceObject's to draw itself into the composite representation by calling its
@@ -479,7 +479,7 @@ public abstract class AbstractSurfaceObject extends WWObjectImpl implements Surf
      * DrawContext's ordered surface renderable list. We ignore this call during rendering mode to suppress calls to
      * {@link #render(DrawContext)} during ordered rendering mode. The SceneController already invokes render during
      * ordered picking mode to build a composite representation of the SurfaceObjects.
-     * <p/>
+     * <p>
      * During ordered picking, the {@link gov.nasa.worldwind.SceneController} invokes the SurfaceObject's {@link
      * #pick(DrawContext, java.awt.Point)} method.
      *
@@ -714,7 +714,7 @@ public abstract class AbstractSurfaceObject extends WWObjectImpl implements Surf
     /**
      * Causes this SurfaceObject to render its bounding sectors to the specified region in geographic coordinates. The
      * specified viewport denotes the geographic region and its corresponding screen viewport.
-     * <p/>
+     * <p>
      * The bounding sectors are rendered as a 1 pixel wide green outline.
      *
      * @param dc  the current DrawContext.
@@ -777,7 +777,7 @@ public abstract class AbstractSurfaceObject extends WWObjectImpl implements Surf
      * Represents a surface object's current state. StateKey uniquely identifies a surface object's current state as
      * follows: <ul> <li>The StateKey class distinguishes the key from other object types.</li> <li>The object's unique
      * ID distinguishes one surface object instances from another.</li> <li>The object's modified time distinguishes an
-     * object's internal state from any of its previous states.</li> Using the unique ID to distinguish between objects
+     * object's internal state from any of its previous states.</li></ul> Using the unique ID to distinguish between objects
      * ensures that the StateKey does not store dangling references to the surface object itself. Should the StateKey
      * live longer than the surface object that created it, the StateKey does not prevent the object from being garbage
      * collected.

--- a/src/gov/nasa/worldwind/render/AbstractSurfaceShape.java
+++ b/src/gov/nasa/worldwind/render/AbstractSurfaceShape.java
@@ -30,11 +30,11 @@ import java.util.List;
  * Common superclass for surface conforming shapes such as {@link gov.nasa.worldwind.render.SurfacePolygon}, {@link
  * gov.nasa.worldwind.render.SurfacePolyline}, {@link gov.nasa.worldwind.render.SurfaceEllipse}, {@link
  * gov.nasa.worldwind.render.SurfaceQuad}, and {@link gov.nasa.worldwind.render.SurfaceSector}.
- * <p/>
+ * <p>
  * SurfaceShapes have separate attributes for normal display and highlighted display. If no attributes are specified,
  * default attributes are used. See {@link #DEFAULT_INTERIOR_MATERIAL}, {@link #DEFAULT_OUTLINE_MATERIAL}, and {@link
  * #DEFAULT_HIGHLIGHT_MATERIAL}.
- * <p/>
+ * <p>
  * AbstractSurfaceShape extends from {@link gov.nasa.worldwind.render.AbstractSurfaceObject}, and therefore inherits
  * AbstractSurfaceObject's batch rendering capabilities.
  *
@@ -228,7 +228,7 @@ public abstract class AbstractSurfaceShape extends AbstractSurfaceObject impleme
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * The returned state key is constructed the SurfaceShape's unique ID, last modified time, and its active
      * attributes. The returned state key has no dependency on the {@link gov.nasa.worldwind.globes.Globe}. Subclasses
      * that depend on the Globe should return a state key that include the globe's state key.
@@ -605,7 +605,7 @@ public abstract class AbstractSurfaceShape extends AbstractSurfaceObject impleme
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to clear this SurfaceShape's internal sector and geometry caches.
      */
     @Override
@@ -1660,7 +1660,7 @@ public abstract class AbstractSurfaceShape extends AbstractSurfaceObject impleme
      * Represents a surface shapes's current state. SurfaceShapeStateKey extends {@link
      * gov.nasa.worldwind.render.AbstractSurfaceObject.SurfaceObjectStateKey} by adding the shape's current {@link
      * gov.nasa.worldwind.render.ShapeAttributes} and the globe's state key.
-     * <p/>
+     * <p>
      * SurfaceShapeStateKey uniquely identifies a surface shapes's current state exactly as SurfaceObjectStateKey does,
      * but also distinguishes the shape's active ShapeAttributes from any previous attributes, and distinguishes between
      * different globes via the globe state key.
@@ -1787,7 +1787,6 @@ public abstract class AbstractSurfaceShape extends AbstractSurfaceObject impleme
     /**
      * Export the Polygon. The {@code output} object will receive the exported data. The type of this object depends on
      * the export format. The formats and object types supported by this class are:
-     * <p/>
      * <pre>
      * Format                                         Supported output object types
      * ================================================================================

--- a/src/gov/nasa/worldwind/render/Annotation.java
+++ b/src/gov/nasa/worldwind/render/Annotation.java
@@ -111,7 +111,7 @@ public interface Annotation extends Renderable, Disposable, Restorable
     /**
      * Get the annotation bounding {@link java.awt.Rectangle} using OGL coordinates - bottom-left corner x and y
      * relative to the {@link WorldWindow} bottom-left corner, and the annotation callout width and height.
-     * <p/>
+     * <p>
      * The annotation offset from it's reference point is factored in such that the callout leader shape and reference
      * point are included in the bounding rectangle.
      *

--- a/src/gov/nasa/worldwind/render/AnnotationAttributes.java
+++ b/src/gov/nasa/worldwind/render/AnnotationAttributes.java
@@ -844,7 +844,7 @@ public class AnnotationAttributes implements Restorable
     }
 
     /**
-     * Specifies whether one or more fields of <i>this</> remain unresolved because they must be retrieved from an
+     * Specifies whether one or more fields of <i>this</i> remain unresolved because they must be retrieved from an
      * external source.
      *
      * @param unresolved true if there are unresolved fields, false if no fields remain unresolved.

--- a/src/gov/nasa/worldwind/render/Balloon.java
+++ b/src/gov/nasa/worldwind/render/Balloon.java
@@ -140,7 +140,7 @@ public interface Balloon extends Renderable, Highlightable, AVList
     /**
      * Get the balloon bounding {@link java.awt.Rectangle} using OGL coordinates - bottom-left corner x and y relative
      * to the {@link gov.nasa.worldwind.WorldWindow} bottom-left corner, and the balloon callout width and height.
-     * <p/>
+     * <p>
      * The balloon offset from it's reference point is factored in such that the callout leader shape and reference
      * point are included in the bounding rectangle.
      *

--- a/src/gov/nasa/worldwind/render/BalloonAttributes.java
+++ b/src/gov/nasa/worldwind/render/BalloonAttributes.java
@@ -35,7 +35,7 @@ public interface BalloonAttributes extends ShapeAttributes
      * <code>AVKey.SHAPE_RECTANGLE</code>, then <code>size</code> specifies the rectangle's width and height. If the
      * balloon's shape is <code>AVKey.SHAPE_ELLIPSE</code>, then <code>size</code> specifies the ellipse's x- and
      * y-radii.
-     * <p/>
+     * <p>
      * The balloon's content area is the rectangle obtained by taking the balloon's <code>size</code> and shrinking it
      * by the balloon's insets.
      *
@@ -87,11 +87,11 @@ public interface BalloonAttributes extends ShapeAttributes
      * of (0, 0) pixels causes the balloon's lower left corner to be placed at the screen reference point. An
      * <code>offset</code> of (1, 1) in fraction units causes the balloon's upper right corner to be placed at the
      * screen reference point.
-     * <p/>
+     * <p>
      * If the balloon is attached to the globe, the screen reference point is the projection of its geographic position
      * into the viewport. If the balloon is attached to the screen, the screen reference point is the balloon's screen
      * point.
-     * <p/>
+     * <p>
      * If the balloon has a leader shape, the leader extends from one side of the balloon's frame and points to the
      * screen reference point.
      *
@@ -116,10 +116,10 @@ public interface BalloonAttributes extends ShapeAttributes
      * Specifies the amount of space (in pixels) between the balloon's content and the edges of the balloon's frame. The
      * balloon's content area decreases to account for the specified <code>insets</code>. If the balloon's size and
      * insets cause the content width or height to become less than 1, then the balloon's content is not displayed.
-     * <p/>
+     * <p>
      * If the balloon's shape is <code>AVKey.SHAPE_RECTANGLE</code>, <code>insets</code> specifies the padding between
      * the balloon's content area and the rectangle's top, left, bottom, and right.
-     * <p/>
+     * <p>
      * If the balloon's shape is <code>AVKey.SHAPE_ELLIPSE</code>, <code>insets</code> specifies the padding between the
      * balloon's content area and the ellipse's top, left, bottom, and right apexes.
      *
@@ -144,16 +144,16 @@ public interface BalloonAttributes extends ShapeAttributes
      * Specifies the shape of the balloon's frame. The <code>shape</code> may be one of the following: <ul> <li>{@link
      * gov.nasa.worldwind.avlist.AVKey#SHAPE_NONE}</li> <li>{@link gov.nasa.worldwind.avlist.AVKey#SHAPE_RECTANGLE}</li>
      * <li>{@link gov.nasa.worldwind.avlist.AVKey#SHAPE_ELLIPSE}</li> </ul>
-     * <p/>
+     * <p>
      * If the <code>shape</code> is <code>AVKey.SHAPE_NONE</code>, the balloon's content is displayed in a rectangle in
      * the viewport without any decoration. The rectangle's dimension in the viewport are specified by calling {@link
      * #setSize(Size)}.
-     * <p/>
+     * <p>
      * If the <code>shape</code> is <code>AVKey.SHAPE_RECTANGLE</code>, the balloon is displayed as a rectangle in the
      * viewport with optionally rounded corners. The rectangle's dimension in the viewport are specified by calling
      * {@link #setSize(Size)}. The rectangle's corner radius in pixels is specified by calling {@link
      * #setCornerRadius(int)}.
-     * <p/>
+     * <p>
      * If the <code>shape</code> is <code>AVKey.SHAPE_ELLIPSE</code>, the balloon is displayed as an ellipse in the
      * viewport. The ellipse's x- and y-radii are specified by calling {@link #setSize(Size)}. The balloon's corner
      * radius attribute is ignored.
@@ -180,9 +180,9 @@ public interface BalloonAttributes extends ShapeAttributes
      * Specifies the shape of the balloon's leader. The <code>shape</code> may be one of the following: <ul> <li>{@link
      * gov.nasa.worldwind.avlist.AVKey#SHAPE_NONE}</li> <li>{@link gov.nasa.worldwind.avlist.AVKey#SHAPE_TRIANGLE}</li>
      * </ul>
-     * <p/>
+     * <p>
      * If the <code>shape</code> is <code>AVKey.SHAPE_NONE</code>, the leader is disabled and does not display.
-     * <p/>
+     * <p>
      * If the <code>shape</code> is <code>AVKey.SHAPE_TRIANGLE</code>, the leader extends from one side of the balloon's
      * frame and points to the balloon's screen reference point. The width of the leader (in pixels) where it intersects
      * the balloon's frame is specified by calling {@link #setLeaderWidth(int)}.
@@ -207,9 +207,9 @@ public interface BalloonAttributes extends ShapeAttributes
     /**
      * Specifies the width of the balloon's leader, in pixels. The specified <code>width</code> must be zero or a
      * positive integer. Specifying a <code>width</code> of zero disables the balloon's leader.
-     * <p/>
+     * <p>
      * This does nothing if the balloon's leader shape is <code>AVKey.SHAPE_NONE</code>.
-     * <p/>
+     * <p>
      * If the balloon's leader shape is <code>AVKey.SHAPE_TRIANGLE</code>, this specifies the size of the leader where
      * it intersects the balloon's frame.
      *
@@ -344,10 +344,10 @@ public interface BalloonAttributes extends ShapeAttributes
      * following: <ul> <li>{@link gov.nasa.worldwind.avlist.AVKey#REPEAT_NONE}</li> <li>{@link
      * gov.nasa.worldwind.avlist.AVKey#REPEAT_X}</li> <li>{@link gov.nasa.worldwind.avlist.AVKey#REPEAT_Y}</li>
      * <li>{@link gov.nasa.worldwind.avlist.AVKey#REPEAT_XY}</li> </ul>
-     * <p/>
+     * <p>
      * If <code>repeat</code> is <code>AVKey.REPEAT_NONE</code>, the balloon's texture is displayed according to its
      * offset and scale without any repeating pattern.
-     * <p/>
+     * <p>
      * If <code>repeat</code> is <code>AVKey.REPEAT_X</code>, <code>AVKey.REPEAT_Y</code>, or
      * <code>AVKey.REPEAT_XY</code>, the balloon's texture is repeated along the X axis, along the Y axis, or along both
      * the X and Y axes, respectively. The texture is repeated after its offset and scale are applied.

--- a/src/gov/nasa/worldwind/render/BasicBalloonAttributes.java
+++ b/src/gov/nasa/worldwind/render/BasicBalloonAttributes.java
@@ -52,8 +52,8 @@ public class BasicBalloonAttributes extends BasicShapeAttributes implements Ball
     /**
      * Creates a new <code>BasicBalloonAttributes</code> with the default attributes. The default attributes are as
      * follows:
-     * <p/>
-     * <table> <tr><th>Attribute</th><th>Default Value</th></tr> <tr><td>unresolved</td><td><code>true</code></td></tr>
+     * <table> <caption>Attributes</caption>
+     * <tr><th>Attribute</th><th>Default Value</th></tr> <tr><td>unresolved</td><td><code>true</code></td></tr>
      * <tr><td>drawInterior</td><td><code>true</code></td></tr> <tr><td>drawOutline</td><td><code>true</code></td></tr>
      * <tr><td>enableAntialiasing</td><td><code>true</code></td></tr> <tr><td>enableLighting</td><td><code>false</code></td></tr>
      * <tr><td>interiorMaterial</td><td>{@link gov.nasa.worldwind.render.Material#WHITE}</td></tr>
@@ -63,11 +63,11 @@ public class BasicBalloonAttributes extends BasicShapeAttributes implements Ball
      * <tr><td>outlineStipplePattern</td><td>0xF0F0</td></tr> <tr><td>interiorImageSource</td><td><code>null</code></td></tr>
      * <tr><td>interiorImageScale</td><td>1.0</td></tr> <tr><td>size</td><td>350x350 pixels (width x height)</td></tr>
      * <tr><td>maximumSize</td><td><code>null</code></td></tr> <tr><td>offset</td><td>40,60 pixels (x,
-     * y)</code></td></tr> <tr><td>insets</td><td>30,15,15,15 (top, left, bottom, right)</td></tr>
+     * y)</td></tr> <tr><td>insets</td><td>30,15,15,15 (top, left, bottom, right)</td></tr>
      * <tr><td>balloonShape</td><td>{@link AVKey#SHAPE_RECTANGLE}</td></tr> <tr><td>leaderShape</td><td>{@link
      * AVKey#SHAPE_TRIANGLE}</td></tr> <tr><td>leaderWidth</td><td>40.0</td></tr> <tr><td>cornerRadius</td><td>20.0</td></tr>
      * <tr><td>font</td><td>Arial Plain 12</td></tr> <tr><td>textColor</td><td>{@link java.awt.Color#BLACK}</td></tr>
-     * <tr><td>imageOffset</td><td>0,0 (x, y)</code></td></tr> <tr><td>imageOpacity</td><td>1</td></tr>
+     * <tr><td>imageOffset</td><td>0,0 (x, y)</td></tr> <tr><td>imageOpacity</td><td>1</td></tr>
      * <tr><td>imageRepeat</td><td>{@link gov.nasa.worldwind.avlist.AVKey#REPEAT_XY}</td></tr> </table>
      */
     public BasicBalloonAttributes()
@@ -114,7 +114,7 @@ public class BasicBalloonAttributes extends BasicShapeAttributes implements Ball
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overrides the superclass' behavior to return a new <code>BasicBalloonAttributes</code>.
      */
     public ShapeAttributes copy()
@@ -124,7 +124,7 @@ public class BasicBalloonAttributes extends BasicShapeAttributes implements Ball
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Extends the superclass' behavior to copy <code>BalloonAttributes</code> if the specified <code>attributes</code>
      * is an instance of <code>BalloonAttributes</code>.
      */

--- a/src/gov/nasa/worldwind/render/BasicShapeAttributes.java
+++ b/src/gov/nasa/worldwind/render/BasicShapeAttributes.java
@@ -56,8 +56,8 @@ public class BasicShapeAttributes implements ShapeAttributes
     /**
      * Creates a new <code>BasicShapeAttributes</code> with the default attributes. The default attributes are as
      * follows:
-     * <p/>
-     * <table> <tr><th>Attribute</th><th>Default Value</th></tr> <tr><td>unresolved</td><td><code>true</code></td></tr>
+     * <table><caption>Attributes</caption>
+     * <tr><th>Attribute</th><th>Default Value</th></tr> <tr><td>unresolved</td><td><code>true</code></td></tr>
      * <tr><td>drawInterior</td><td><code>true</code></td></tr> <tr><td>drawOutline</td><td><code>true</code></td></tr>
      * <tr><td>enableAntialiasing</td><td><code>true</code></td></tr> <tr><td>enableLighting</td><td><code>false</code></td></tr>
      * <tr><td>interiorMaterial</td><td>{@link gov.nasa.worldwind.render.Material#WHITE}</td></tr>
@@ -584,7 +584,10 @@ public class BasicShapeAttributes implements ShapeAttributes
 
     /**
      * Export the placemark attributes to KML as a {@code <Style>} element. The {@code output} object will receive the
-     * data. This object must be one of: java.io.Writer<br/> java.io.OutputStream<br/> javax.xml.stream.XMLStreamWriter
+     * data. This object must be one of: <br>
+     * java.io.Writer<br> 
+     * java.io.OutputStream<br> 
+     * javax.xml.stream.XMLStreamWriter
      *
      * @param output Object to receive the generated KML.
      *

--- a/src/gov/nasa/worldwind/render/BasicWWTexture.java
+++ b/src/gov/nasa/worldwind/render/BasicWWTexture.java
@@ -18,11 +18,11 @@ import java.net.URL;
 /**
  * Basic implementation of a texture derived from an image source such as an image file or a {@link
  * java.awt.image.BufferedImage}.
- * <p/>
+ * <p>
  * The interface contains a method, {@link #isTextureInitializationFailed()} to determine whether the instance failed to
  * convert an image source to a texture. If such a failure occurs, the method returns true and no further attempts are
  * made to create the texture.
- * <p/>
+ * <p>
  * This class retrieves its image source immediately during a call to {@link #bind(DrawContext)} or {@link
  * #applyInternalTransform(DrawContext)}.
  *
@@ -43,7 +43,7 @@ public class BasicWWTexture implements WWTexture
 
     /**
      * Constructs a texture object from an image source.
-     * <p/>
+     * <p>
      * The texture's image source is opened, if a file, only when the texture is displayed. If the texture is not
      * displayed the image source is not read.
      *
@@ -59,7 +59,7 @@ public class BasicWWTexture implements WWTexture
 
     /**
      * Constructs a texture object.
-     * <p/>
+     * <p>
      * The texture's image source is opened, if a file, only when the texture is displayed. If the texture is not
      * displayed the image source is not read.
      *

--- a/src/gov/nasa/worldwind/render/DrawContext.java
+++ b/src/gov/nasa/worldwind/render/DrawContext.java
@@ -30,7 +30,7 @@ import java.util.Queue;
 public interface DrawContext extends WWObject, Disposable
 {
     /**
-     * Assigns this <code>DrawContext</code> a new </code>com.jogamp.opengl.GLContext</code>. May throw a
+     * Assigns this <code>DrawContext</code> a new <code>com.jogamp.opengl.GLContext</code>. May throw a
      * <code>NullPointerException</code> if <code>glContext</code> is null.
      *
      * @param glContext the new <code>com.jogamp.opengl.GLContext</code>
@@ -41,10 +41,10 @@ public interface DrawContext extends WWObject, Disposable
     void setGLContext(GLContext glContext);
 
     /**
-     * Retrieves this <code>DrawContext</code>s </code>com.jogamp.opengl.GLContext</code>. If this method returns null,
+     * Retrieves this <code>DrawContext</code>s <code>com.jogamp.opengl.GLContext</code>. If this method returns null,
      * then there are potentially no active <code>GLContext</code>s and rendering should be aborted.
      *
-     * @return this <code>DrawContext</code>s </code>com.jogamp.opengl.GLContext</code>.
+     * @return this <code>DrawContext</code>s <code>com.jogamp.opengl.GLContext</code>.
      *
      * @since 1.5
      */
@@ -85,7 +85,7 @@ public interface DrawContext extends WWObject, Disposable
      * width is potentially different from the GL viewport width. If this DrawContext is associated with a
      * <code>GLJPanel</code>, the returned width is the power-of-two ceiling of the viewport, and is therefore almost
      * always larger than the GL viewport width.
-     * <p/>
+     * <p>
      * The GL viewport dimensions can be accessed by calling <code>getView().getViewport()</code> on this
      * <code>DrawContext</code>.
      *
@@ -98,7 +98,7 @@ public interface DrawContext extends WWObject, Disposable
      * height is potentially different from the GL viewport height. If this DrawContext is associated with a
      * <code>GLJPanel</code>, the returned height is the power-of-two ceiling of the viewport, and is therefore almost
      * always larger than the GL viewport height.
-     * <p/>
+     * <p>
      * The GL viewport dimensions can be accessed by calling <code>getView().getViewport()</code> on this
      * <code>DrawContext</code>.
      *
@@ -303,7 +303,7 @@ public interface DrawContext extends WWObject, Disposable
      * components represent an address to the beginning of a sequential range of pick color codes. This method is
      * similar to calling the no-argument {@link #getUniquePickColor} <code>count</code> times, but guarantees a
      * contiguous range of color codes and is more efficient when <code>count</code> is large.
-     * <p/>
+     * <p>
      * The number of pick colors is limited to a finite address space. This method returns null when there are fewer
      * than <code>count</code> remaining unique colors in the pick color address space, or when <code>count</code> is
      * less than 1.
@@ -327,7 +327,7 @@ public interface DrawContext extends WWObject, Disposable
      * green, and blue components are each stored as an 8-bit unsigned integer, and packed into bits 0-23 of the
      * returned integer as follows: bits 16-23 are red, bits 8-15 are green, and bits 0-7 are blue. This format is
      * consistent with the RGB integers used to create the pick colors in getUniquePickColor.
-     * <p/>
+     * <p>
      * This returns 0 if the point contains the clear color, or is outside this draw context's drawable area.
      *
      * @param point the point to return a color for, in AWT screen coordinates.
@@ -343,11 +343,11 @@ public interface DrawContext extends WWObject, Disposable
      * pick color codes. The red, green, and blue components are each stored as an 8-bit unsigned integer, and packed
      * into bits 0-23 of the returned integers as follows: bits 16-23 are red, bits 8-15 are green, and bits 0-7 are
      * blue. This format is consistent with the RGB integers used to create the pick colors in getUniquePickColor.
-     * <p/>
+     * <p>
      * The returned array contains one entry for each unique color. Points in the rectangle that contain the clear color
      * or are outside this draw context's drawable area are ignored. This returns <code>null</code> if the specified
      * rectangle is empty, or contains only the clear color.
-     * <p/>
+     * <p>
      * The minAndMaxColorCodes parameter limits the unique colors that this method returns to the specified range. The
      * minimum color must be stored in array index 0, and the maximum color must be stored in array index 1. These
      * values can be used to specify a small range of colors relative to the framebuffer contents, effectively culling
@@ -494,7 +494,7 @@ public interface DrawContext extends WWObject, Disposable
      * layers add each unique picked object to a PickedObjectList on this draw context by calling {@link
      * #addPickedObject(gov.nasa.worldwind.pick.PickedObject)}. This list can be accessed by calling {@link
      * #getPickedObjects()}.
-     * <p/>
+     * <p>
      * If the pick point is <code>null</code>, the pick point is ignored during each pick traversal, and the list of
      * objects returned by getPickedObjects is empty.
      *
@@ -517,7 +517,7 @@ public interface DrawContext extends WWObject, Disposable
      * so, layers add each unique picked object to a PickedObjectList on this draw context by calling {@link
      * #addObjectInPickRectangle(gov.nasa.worldwind.pick.PickedObject)}. This is list can be accessed by calling {@link
      * #getObjectsInPickRectangle()}.
-     * <p/>
+     * <p>
      * If the pick rectangle is <code>null</code>, the pick rectangle is ignored during each pick traversal, and the
      * list of objects returned by getObjectsInPickRectangle is empty.
      *
@@ -681,7 +681,7 @@ public interface DrawContext extends WWObject, Disposable
      * Returns the visible sectors at one of several specified resolutions within a specified search sector. Several
      * sectors resolutions may be specified along with a time limit. The best resolution that can be determined within
      * the time limit is returned.
-     * <p/>
+     * <p>
      * Adherence to the time limit is not precise. The limit is checked only between full searches at each resolution.
      * The search may take more than the specified time, but will terminate if no time is left before starting a
      * higher-resolution search.
@@ -767,14 +767,14 @@ public interface DrawContext extends WWObject, Disposable
     /**
      * Creates a frustum around the current pick point and adds it to the current list of pick frustums. The frustum's
      * dimension is specified by calling {@link #setPickPointFrustumDimension(java.awt.Dimension)}.
-     * <p/>
+     * <p>
      * This does nothing if the current pick point is <code>null</code>.
      */
     void addPickPointFrustum();
 
     /**
      * Creates a frustum containing the current pick rectangle and adds it to the current list of pick frustums.
-     * <p/>
+     * <p>
      * This does nothing if the current pick rectangle is <code>null</code>.
      */
     void addPickRectangleFrustum();
@@ -815,10 +815,10 @@ public interface DrawContext extends WWObject, Disposable
      * Modifies the current projection matrix to slightly offset subsequently drawn objects toward or away from the eye
      * point. This gives those objects visual priority over objects at the same or nearly the same position. After the
      * objects are drawn, call {@link #popProjectionOffest()} to cancel the effect for subsequently drawn objects.
-     * <p/>
+     * <p>
      * <em>Note:</em> This capability is meant to be applied only within a single Renderable. It is not intended as a
      * means to offset a whole Renderable or collection of Renderables.
-     * <p/>
+     * <p>
      * See "Mathematics for Game Programming and 3D Computer Graphics, 2 ed." by  Eric Lengyel, Section 9.1, "Depth
      * Value Offset" for a description of this technique.
      *

--- a/src/gov/nasa/worldwind/render/Ellipsoid.java
+++ b/src/gov/nasa/worldwind/render/Ellipsoid.java
@@ -21,8 +21,8 @@ import java.nio.*;
 /**
  * A general ellipsoid volume defined by a center position and the three ellipsoid axis radii. If A is the radius in the
  * north-south direction, and b is the radius in the east-west direction, and c is the radius in the vertical direction
- * (increasing altitude), then A == B == C defines a sphere, A == B > C defines a vertically flattened spheroid
- * (disk-shaped), A == B < C defines a vertically stretched spheroid.
+ * (increasing altitude), then {@code A == B == C } defines a sphere, {@code A == B > C } defines a vertically flattened spheroid
+ * (disk-shaped), {@code A == B < C } defines a vertically stretched spheroid.
  *
  * @author tag
  * @version $Id: Ellipsoid.java 1171 2013-02-11 21:45:02Z dcollins $

--- a/src/gov/nasa/worldwind/render/ExtrudedPolygon.java
+++ b/src/gov/nasa/worldwind/render/ExtrudedPolygon.java
@@ -29,17 +29,17 @@ import java.util.*;
  * A multi-sided 3D shell formed by a base polygon in latitude and longitude extruded from the terrain to either a
  * specified height or an independent height per location. The base polygon may be complex with multiple internal but
  * not intersecting contours.
- * <p/>
+ * <p>
  * Extruded polygon boundaries may be specified using either {@link LatLon} locations or {@link Position} positions, but
  * all the shape's boundary vertices must be the same type.
- * <p/>
+ * <p>
  * Extruded polygons may optionally be textured. Textures may be applied to both the faces of the outer and inner
  * boundaries or just the outer boundaries. Texture can also be applied independently to the cap. Standard lighting is
  * optionally applied. Texture source images are lazily retrieved and loaded. This can cause a brief period in which the
  * texture is not displayed while it is retrieved from disk or network.
- * <p/>
+ * <p>
  * <code>ExtrudedPolygon</code> side faces and cap have independent attributes for both normal and highlighted drawing.
- * <p/>
+ * <p>
  * When specifying a single height (altitude mode {@link WorldWind#CONSTANT}, the height is relative to a reference
  * location designated by one of the specified polygon locations in the outer boundary. The default reference location
  * is the first one in the polygon's outer boundary. An alternative location may be specified by calling {@link
@@ -48,22 +48,22 @@ import java.util.*;
  * elevations other than that at the reference location, the distances from those points to the cap are adjusted so that
  * the adjacent sides precisely meet the cap. When specifying polygons using a single height, only the latitudes and
  * longitudes of polygon boundary positions must be specified.
- * <p/>
+ * <p>
  * Independent per-location heights may be specified via the <i>altitude</i> field of {@link Position}s defining the
  * polygon's inner and outer boundaries. Depending on the specified altitude mode, the position altitudes may be
  * interpreted as altitudes relative to mean sea level or altitudes above the ground at the associated latitude and
  * longitude locations.
- * <p/>
+ * <p>
  * Boundaries are required to be closed, their first location must be equal to their last location. Boundaries that are
  * not closed are explicitly closed by this shape when they are specified.
- * <p/>
+ * <p>
  * Extruded polygons are safe to share among WorldWindows. They should not be shared among layers in the same World
  * Window.
- * <p/>
+ * <p>
  * In order to support simultaneous use of this shape with multiple globes (windows), this shape maintains a cache of
  * data computed relative to each globe. During rendering, the data for the currently active globe, as indicated in the
  * draw context, is made current. Subsequently called methods rely on the existence of this current data cache entry.
- * <p/>
+ * <p>
  * When drawn on a 2D globe, this shape uses a {@link SurfacePolygon} to represent itself. Cap texture is not supported
  * in this case.
  *
@@ -1361,7 +1361,7 @@ public class ExtrudedPolygon extends AbstractShape
 
     /**
      * Draws the cap's outline.
-     * <p/>
+     * <p>
      * This base implementation draws the outline of the basic polygon. Subclasses should override it to draw their
      * outline or an alternate outline of the basic polygon.
      *
@@ -2400,7 +2400,7 @@ public class ExtrudedPolygon extends AbstractShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Note that this method overwrites the boundary locations lists, and therefore no longer refer to the originally
      * specified boundary lists.
      *

--- a/src/gov/nasa/worldwind/render/GLRuntimeCapabilities.java
+++ b/src/gov/nasa/worldwind/render/GLRuntimeCapabilities.java
@@ -15,7 +15,7 @@ import com.jogamp.opengl.*;
  * GLRuntimeCapabilities describes the GL capabilities supported by the current GL runtime. It provides the caller with
  * the current GL version, with information about which GL features are available, and with properties defining the
  * capabilities of those features.
- * <p/>
+ * <p>
  * For each GL feature, there are three key pieces of information available through GLRuntimeCapabilities: <ul> <li>The
  * property <code>is[Feature]Available</code> defines whether or not the feature is supported by the current GL runtime.
  * This is an attribute of the GL runtime, and is typically configured automatically by a call to {@link
@@ -23,7 +23,7 @@ import com.jogamp.opengl.*;
  * not this feature should be used, and must be configured by the caller. </li> <li>The convenience method
  * <code>isUse[Feature]()</code>. This returns whether or not the feature is available and is enabled for use (it is
  * simply a conjunction of the "available" and "enabled" properties).</li> </ul>
- * <p/>
+ * <p>
  * GLRuntimeCapabilities is designed to automatically configure itself with information about the current GL runtime. To
  * invoke this behavior, call {@link #initialize(com.jogamp.opengl.GLContext)} with a valid GLContext at the beginning
  * of each rendering pass.
@@ -54,7 +54,7 @@ public class GLRuntimeCapabilities
      * objects. Note that these properties are marked as enabled, but they are not known to be available yet. All other
      * properties are set to default values which may be set explicitly by the caller, or implicitly by calling {@link
      * #initialize(com.jogamp.opengl.GLContext)}.
-     * <p/>
+     * <p>
      * Note: The default vertex-buffer usage flag can be set via {@link gov.nasa.worldwind.Configuration} using the key
      * "gov.nasa.worldwind.avkey.VBOUsage". If that key is not specified in the configuration then vertex-buffer usage
      * defaults to <code>true</code>.
@@ -181,7 +181,7 @@ public class GLRuntimeCapabilities
     /**
      * Returns true if the OpenGL implementation is provided by the VMware SVGA 3D driver. Otherwise this returns
      * false.
-     * <p/>
+     * <p>
      * This flag is used to work around bugs and unusual behavior in the VMware SVGA 3D driver. For details on VMware
      * graphics drivers, see <a href="http://www.vmware.com/files/pdf/techpaper/vmware-horizon-view-graphics-acceleration-deployment.pdf">http://www.vmware.com/files/pdf/techpaper/vmware-horizon-view-graphics-acceleration-deployment.pdf</a>.
      *

--- a/src/gov/nasa/worldwind/render/GlobeAnnotation.java
+++ b/src/gov/nasa/worldwind/render/GlobeAnnotation.java
@@ -139,8 +139,9 @@ public class GlobeAnnotation extends AbstractAnnotation implements Locatable, Mo
     /**
      * Get the annotation's altitude mode. The altitude mode may be null, indicating that the legacy altitude mode
      * described below will be used.
-     * <p/>
-     * <b>Legacy altitude mode</b><br/>If the annotation Position elevation is lower then the highest elevation on the
+     * <p>
+     * <b>Legacy altitude mode</b><br>
+     * If the annotation Position elevation is lower then the highest elevation on the
      * globe, the annotation will be drawn above the ground using its elevation as an offset, scaled by the current
      * vertical exaggeration. Otherwise, the original elevation will be used. This functionality is supported for
      * backward compatibility. New code that uses Globe Annotation should specify an altitude mode.
@@ -175,7 +176,7 @@ public class GlobeAnnotation extends AbstractAnnotation implements Locatable, Mo
      * annotation will be scaled so as to maintain this fixed dimension, which makes it appear as part of the
      * surrounding terrain. This overrides min and max distance scaling - however min distance opacity is still accounted
      * for.
-     * <p/>
+     * <p>
      * If this dimension is zero, the annotation always maintains the same apparent size with possible scaling relative
      * to the viewport center point if min and max distance scale factors are not one.
      *
@@ -191,7 +192,7 @@ public class GlobeAnnotation extends AbstractAnnotation implements Locatable, Mo
      * annotation will be scaled so as to maintain this fixed dimension, which makes it appear as part of the
      * surrounding terrain. This overrides min and max distance scaling - however min distance opacity is still accounted
      * for.
-     * <p/>
+     * <p>
      * If this dimension is zero, the annotation always maintains the same apparent size with possible scaling relative
      * to the viewport center point if min and max distance scale factors are not one.
      *

--- a/src/gov/nasa/worldwind/render/GlobeBrowserBalloon.java
+++ b/src/gov/nasa/worldwind/render/GlobeBrowserBalloon.java
@@ -109,15 +109,18 @@ public class GlobeBrowserBalloon extends AbstractBrowserBalloon implements Globe
     /**
      * Computes and stores this balloon's model and screen coordinates. This assigns balloon coordinate properties as
      * follows:
-     * <p/>
-     * <ul> <li><code>placePoint</code> - this balloon's model-coordinate point, according to its altitude mode.</li>
+     * <ul>
+     * <li><code>placePoint</code> - this balloon's model-coordinate point, according to its altitude mode.</li>
      * <li><code>screenPlacePoint</code> - screen-space projection of the <code>placePoint</code>.</li>
      * <li><code>screenOffset</code> - the balloon frame's screen-coordinate offset from this balloon's
-     * <code>screenPlacePoint</code>.</li> <li><code>screenRect</code> - the balloon frame's screen-coordinate
-     * rectangle.</li> <li><code>screenExtent</code> - this balloon's screen-coordinate bounding rectangle.</li>
+     * <code>screenPlacePoint</code>.</li>
+     * <li><code>screenRect</code> - the balloon frame's screen-coordinate rectangle.</li>
+     * <li><code>screenExtent</code> - this balloon's screen-coordinate bounding rectangle.</li>
      * <li><code>screenPickExtent</code> - this balloon's screen-coordinate bounding rectangle, including area covered
-     * by the balloon's pickable outline.</li> <li><code>webViewRect</code> - the WebView's screen-coordinate content
-     * frame.</li> <li><code>eyeDistance</code> - always 0.</li>
+     * by the balloon's pickable outline.</li>
+     * <li><code>webViewRect</code> - the WebView's screen-coordinate content frame.</li>
+     * <li><code>eyeDistance</code> - always 0.</li>
+     * </ul>
      *
      * @param dc the current draw context.
      */
@@ -212,7 +215,7 @@ public class GlobeBrowserBalloon extends AbstractBrowserBalloon implements Globe
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to return <code>false</code> if the balloon's position is either behind the <code>View's</code> near
      * clipping plane or in front of the <code>View's</code> far clipping plane. Otherwise this delegates to the super
      * class' behavior.
@@ -239,7 +242,7 @@ public class GlobeBrowserBalloon extends AbstractBrowserBalloon implements Globe
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to use this balloon's position as the picked object's position.
      */
     @Override

--- a/src/gov/nasa/worldwind/render/IconRenderer.java
+++ b/src/gov/nasa/worldwind/render/IconRenderer.java
@@ -24,13 +24,13 @@ import java.util.logging.Level;
  * IconRenderer processes collections of {@link gov.nasa.worldwind.render.WWIcon} instances for picking and rendering.
  * IconRenderer applies batch processing techniques to improve the runtime performance of picking and rendering large
  * collections of icons.
- * <p/>
+ * <p>
  * During the draw pass, IconRenderer records feedback information for each WWIcon which has the property key {@link
  * gov.nasa.worldwind.avlist.AVKey#FEEDBACK_ENABLED} set to <code>true</code>. IconRenderer does not record any feedback
  * information during the pick pass. When feedback is enabled, IconRenderer puts properties which describe how each
  * WWIcon has been processed in key-value pairs attached to the WWIcon. Any of these properties may be null, indicating
  * that processing of the WWIcon was terminated before this information became available. The feedback properties for
- * WWIcon are as follows: <table> <tr><th>Key</th><th>Description</th></tr> <tr><td>{@link
+ * WWIcon are as follows: <table><caption>Feedback Properties</caption> <tr><th>Key</th><th>Description</th></tr> <tr><td>{@link
  * gov.nasa.worldwind.avlist.AVKey#FEEDBACK_REFERENCE_POINT}</td><td>The icon's reference point in model
  * coordinates.</td></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#FEEDBACK_SCREEN_BOUNDS}</td><td>The icon's
  * bounding rectangle in screen coordinates.</td></tr> </table>

--- a/src/gov/nasa/worldwind/render/LazilyLoadedTexture.java
+++ b/src/gov/nasa/worldwind/render/LazilyLoadedTexture.java
@@ -21,11 +21,11 @@ import java.net.URL;
 /**
  * Represents a texture derived from a lazily loaded image source such as an image file or a {@link
  * java.awt.image.BufferedImage}.
- * <p/>
+ * <p>
  * The interface contains a method, {@link #isTextureInitializationFailed()} to determine whether the instance failed to
  * convert an image source to a texture. If such a failure occurs, the method returns true and no further attempts are
  * made to create the texture.
- * <p/>
+ * <p>
  * This class performs lazy retrieval and loading of an image source, attempting to retrieve and load the image source
  * only when the {@link #bind(DrawContext)} or {@link #applyInternalTransform(DrawContext)} methods are called. If the
  * image source is a {@link BufferedImage} the associated {@link Texture} object is created and available immediately
@@ -165,7 +165,7 @@ public class LazilyLoadedTexture extends AVListImpl implements WWTexture
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * This method behaves identically to {@link #getWidth()}. The <code>DrawContext</code> argument is not used.
      *
      * @param dc this parameter is not used by this class.
@@ -179,7 +179,7 @@ public class LazilyLoadedTexture extends AVListImpl implements WWTexture
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * This method behaves identically to {@link #getHeight()}. The <code>DrawContext</code> argument is not used.
      *
      * @param dc this parameter is not used by this class.
@@ -271,7 +271,7 @@ public class LazilyLoadedTexture extends AVListImpl implements WWTexture
     /**
      * Returns this texture's texture data if it has been retrieved but a <code>Texture</code> has not yet been created
      * for it.
-     * <p/>
+     * <p>
      * If this object's texture data field is non-null, a new texture is created from the texture data when the tile is
      * next bound or otherwise initialized. This object's texture data field is then set to null.
      *
@@ -286,7 +286,7 @@ public class LazilyLoadedTexture extends AVListImpl implements WWTexture
     /**
      * Specifies texture data for the tile. If texture data is non-null, a new texture is created from the texture data
      * when the tile is next bound.
-     * <p/>
+     * <p>
      * When a texture is created from the texture data, the texture data field is set to null to indicate that the data
      * has been converted to a texture and its resources may be released.
      *
@@ -404,7 +404,7 @@ public class LazilyLoadedTexture extends AVListImpl implements WWTexture
     }
 
     /**
-     * Creates this instance's {@link Texture} if the image source is a <code>BufferedImage<code>.
+     * Creates this instance's {@link Texture} if the image source is a <code>BufferedImage</code>.
      *
      * @param dc the current draw context.
      *

--- a/src/gov/nasa/worldwind/render/MultiLineTextRenderer.java
+++ b/src/gov/nasa/worldwind/render/MultiLineTextRenderer.java
@@ -21,7 +21,7 @@ import java.util.regex.*;
  * (MLTR) handles wrapping, measuring and drawing of multiline text strings using Sun's JOGL {@link TextRenderer}. </p>
  * <p> A multiline text string is a character string containing new line characters in between lines. </p> <p> MLTR can
  * handle both regular text with new line separators and a very minimal implementation of HTML. Each type of text has
- * its own methods though. </p> <p/> <p><b>Usage:</b></p> <p/> <p>Instantiation:</p> <p> The MLTR needs a Font or a
+ * its own methods though. </p> <p><b>Usage:</b></p> <p>Instantiation:</p> <p> The MLTR needs a Font or a
  * TextRenderer to be instantiated. This will be the font used for text drawing, wrapping and measuring. For HTML
  * methods this font will be considered as the document default font. </p>
  * <pre>
@@ -33,41 +33,42 @@ import java.util.regex.*;
  * TextRenderer tr = new TextRenderer(Font.decode("Arial-PLAIN-10"));
  * MultiLineTextRenderer mltr = new MultiLineTextRenderer(tr);
  * </pre>
- * <p/> <p>Drawing regular text:</p>
+ * <p>Drawing regular text:</p>
  * <pre>
  * String text = "Line one.\nLine two.\nLine three...";
  * int x = 10;             // Upper left corner of text rectangle.
  * int y = 200;            // Origin at bottom left of screen.
  * int lineHeight = 14;    // Line height in pixels.
  * Color color = Color.RED;
- * <p/>
+ * 
  * mltr.setTextColor(color);
  * mltr.getTextRenderer().begin3DRendering();
  * mltr.draw(text, x, y, lineHeight);
  * mltr.getTextRenderer().end3DRendering();
  * </pre>
- * <p/> <p>Wrapping text to fit inside a width and optionally a height</p> <p> The MLTR wrap method will insert new line
+ * <p>Wrapping text to fit inside a width and optionally a height</p> <p> The MLTR wrap method will insert new line
  * characters inside the text so that it fits a given width in pixels. </p> <p> If a height dimension above zero is
  * specified too, the text will be truncated if needed, and a continuation string will be appended to the last line. The
  * continuation string can be set with mltr.setContinuationString(); </p>
  * <pre>
  * // Fit inside 300 pixels, no height constraint
  * String wrappedText = mltr.wrap(text, new Dimension(300, 0));
- * <p/>
+ * 
  * // Fit inside 300x400 pixels, text may be truncated
  * String wrappedText = mltr.wrap(text, new Dimension(300, 400));
  * </pre>
- * <p/> <p>Measuring text</p>
+ * <p>Measuring text</p>
  * <pre>
  * Rectangle2D textBounds = mltr.getBounds(text);
  * </pre>
  * <p> The textBounds rectangle returned contains the width and height of the text as it would be drawn with the current
  * font. </p> <p> Note that textBounds.minX is the number of lines found and textBounds.minY is the maximum line height
  * for the font used. This value can be safely used as the lineHeight argument when drawing - or can even be ommited
- * after a getBounds: draw(text, x, y); ... </p> <p/> <p><b>HTML support</b></p> <p> Supported tags are: <ul>
+ * after a getBounds: draw(text, x, y); ... </p> <p><b>HTML support</b></p> <p> Supported tags are: <ul>
  * <li>&lt;p&gt;&lt;/p&gt;, &lt;br&gt; &lt;br /&gt;</li> <li>&lt;b&gt;&lt;/b&gt;</li> <li>&lt;i&gt;&lt;/i&gt;</li>
- * <li>&lt;a href="..."&gt;&lt;/a&gt;</li> <li>&lt;font color="#ffffff"&gt;&lt;/font&gt;</li> </ul> </p> ... <p/> <p/>
- * <p/> <p> See {@link AbstractAnnotation}.drawAnnotation() for more usage details. </p>
+ * <li>&lt;a href="..."&gt;&lt;/a&gt;</li> <li>&lt;font color="#ffffff"&gt;&lt;/font&gt;</li> </ul> 
+ * ... 
+ * <p> See {@link AbstractAnnotation}.drawAnnotation() for more usage details. </p>
  *
  * @author Patrick Murris
  * @version $Id: MultiLineTextRenderer.java 2053 2014-06-10 20:16:57Z tgaskins $
@@ -299,10 +300,10 @@ public class MultiLineTextRenderer
 
     /**
      * Returns the bounding rectangle for a multi-line string.
-     * <p/>
+     * <p>
      * Note that the X component of the rectangle is the number of lines found in the text and the Y component of the
      * rectangle is the max line height encountered.
-     * <p/>
+     * <p>
      * Note too that this method will automatically set the current line height to the max height found.
      *
      * @param text the multi-line text to evaluate.
@@ -339,7 +340,7 @@ public class MultiLineTextRenderer
     /**
      * Draw a multi-line text string with bounding rectangle top starting at the y position. Depending on the current
      * textAlign, the x position is either the rectangle left side, middle or right side.
-     * <p/>
+     * <p>
      * Uses the current line height.
      *
      * @param text the multi-line text to draw.
@@ -354,7 +355,7 @@ public class MultiLineTextRenderer
     /**
      * Draw a multi-line text string with bounding rectangle top starting at the y position. Depending on the current
      * textAlign, the x position is either the rectangle left side, middle or right side.
-     * <p/>
+     * <p>
      * Uses the current line height and the given effect.
      *
      * @param text   the multi-line text to draw.
@@ -371,7 +372,7 @@ public class MultiLineTextRenderer
     /**
      * Draw a multi-line text string with bounding rectangle top starting at the y position. Depending on the current
      * textAlign, the x position is either the rectangle left side, middle or right side.
-     * <p/>
+     * <p>
      * Uses the given line height and effect.
      *
      * @param text           the multi-line text to draw.
@@ -412,7 +413,7 @@ public class MultiLineTextRenderer
     /**
      * Draw a multi-line text string with bounding rectangle top starting at the y position. Depending on the current
      * textAlign, the x position is either the rectangle left side, middle or right side.
-     * <p/>
+     * <p>
      * Uses the given line height.
      *
      * @param text           the multi-line text to draw.
@@ -534,10 +535,10 @@ public class MultiLineTextRenderer
     /**
      * Add 'new line' characters inside a string so that it's bounding rectangle tries not to exceed the given dimension
      * width.
-     * <p/>
+     * <p>
      * If the dimension height is more than zero, the text will be truncated accordingly and the continuation string
      * will be appended to the last line.
-     * <p/>
+     * <p>
      * Note that words will not be split and at least one word will be used per line so the longest word defines the
      * final width of the bounding rectangle. Each line is trimmed of leading and trailing spaces.
      *
@@ -859,10 +860,10 @@ public class MultiLineTextRenderer
     /**
      * Add 'new line' characters inside an html text string so that it's bounding rectangle tries not to exceed the
      * given dimension width.
-     * <p/>
+     * <p>
      * If the dimension height is more than zero, the text will be truncated accordingly and the continuation string
      * will be appended to the last line.
-     * <p/>
+     * <p>
      * Note that words will not be split and at least one word will be used per line so the longest word defines the
      * final width of the bounding rectangle. Each line is trimmed of leading and trailing spaces.
      *

--- a/src/gov/nasa/worldwind/render/MultiResolutionPath.java
+++ b/src/gov/nasa/worldwind/render/MultiResolutionPath.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
  * the application. The default algorithm skips up to four positions, depending on the eye distance from the positions.
  * Also, if the segment between any two positions is too small to be distinguished, it is not drawn. See {@link
  * #makePositions(DrawContext, gov.nasa.worldwind.render.Path.PathData)}.
- * <p/>
+ * <p>
  * NOTE: This shape does not draw correctly on a 2D globe when its positions span the dateline.
  *
  * @author tag
@@ -32,7 +32,7 @@ public class MultiResolutionPath extends Path
     /**
      * This interface provides the means for the application to specify the algorithm used to determine the number of
      * specified positions skipped during path tessellation.
-     * <p/>
+     * <p>
      * This class overrides the method {@link Path#makePositions(DrawContext, PathData)}.
      */
     public interface SkipCountComputer
@@ -106,7 +106,7 @@ public class MultiResolutionPath extends Path
      * Creates a path with specified positions. When the path is rendered, only path positions that are visually
      * distinct for the current viewing state are considered. The path adjusts the positions it uses as the view state
      * changes, using more of the specified positions as the eye point comes closer to the shape.
-     * <p/>
+     * <p>
      * Note: If fewer than two positions are specified, no path is drawn.
      *
      * @param positions the path positions. This reference is retained by this shape; the positions are not copied. If
@@ -125,7 +125,7 @@ public class MultiResolutionPath extends Path
      * positions that are visually distinct for the current viewing state are considered. The path adjusts the positions
      * it uses as the view state changes, using more of the specified positions as the eye point comes closer to the
      * shape.
-     * <p/>
+     * <p>
      * Note: If fewer than two positions are specified, no path is drawn.
      *
      * @param positions the path positions. This reference is retained by this shape; the positions are not copied. If
@@ -172,7 +172,7 @@ public class MultiResolutionPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to return a new instance of MultiResolutionPathData.
      */
     @Override
@@ -183,7 +183,7 @@ public class MultiResolutionPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to initialize and build the PathData's positionOrdinals buffer.
      */
     @Override
@@ -205,7 +205,7 @@ public class MultiResolutionPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to skip positions from this Path's original positions list. Positions are skipped first according to
      * this Path's skipCountComputer. The skipCountComputer determines how many positions this path skips between
      * tessellated positions. Any positions remaining after this step are skipped if the segment they are part of is
@@ -254,7 +254,7 @@ public class MultiResolutionPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to create a mapping between the current tessellated position and the specified ordinal, if the ordinal
      * is not null.
      */
@@ -273,7 +273,7 @@ public class MultiResolutionPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to use the MultiResolutionPathData's positionOrdinals buffer to map the specified position index to
      * its corresponding ordinal number.
      */

--- a/src/gov/nasa/worldwind/render/Offset.java
+++ b/src/gov/nasa/worldwind/render/Offset.java
@@ -15,12 +15,12 @@ import java.awt.*;
  * Defines the relationship of an image, label or other screen-space item relative to another screen-space item. An
  * offset contains an X coordinate, a Y coordinate, and for each of these a separate "units" string indicating the
  * coordinate units.
- * <p/>
+ * <p>
  * Recognized "units" values are {@link AVKey#PIXELS}, which indicates pixel units relative to the lower left corner of
  * the screen-space item, {@link AVKey#FRACTION}, which indicates that the units are fractions of the screen-space
  * item's width and height, relative to its lower left corner, and {@link AVKey#INSET_PIXELS}, which indicates units of
  * pixels but with origin at the screen-space item's upper right.
- * <p/>
+ * <p>
  * This class implements the functionality of a KML <i>Offset</i>.
  *
  * @author tag

--- a/src/gov/nasa/worldwind/render/OutlinedShape.java
+++ b/src/gov/nasa/worldwind/render/OutlinedShape.java
@@ -66,7 +66,7 @@ public interface OutlinedShape
 
     /**
      * Returns the depth-offset factor.
-     * <p/>
+     * <p>
      * The amount of depth offset when depth offset is enabled is computed by the formula <i>factor</i> * DZ + r *
      * <i>units</i>, where DZ is a measurement of the change in depth relative to the screen area of the shape, and r is
      * the smallest value guaranteed to produce a resolvable offset. <i>units</i> is the value return by {@link
@@ -81,7 +81,7 @@ public interface OutlinedShape
 
     /**
      * Returns the depth-offset units.
-     * <p/>
+     * <p>
      * The amount of depth offset when depth offset is enabled is computed by the formula <i>factor</i> * DZ + r *
      * <i>units</i>, where DZ is a measurement of the change in depth relative to the screen area of the shape, and r is
      * the smallest value guaranteed to produce a resolvable offset. <i>factor</i> is the value return by {@link

--- a/src/gov/nasa/worldwind/render/Path.java
+++ b/src/gov/nasa/worldwind/render/Path.java
@@ -36,22 +36,22 @@ import static gov.nasa.worldwind.ogc.kml.impl.KMLExportUtil.kmlBoolean;
  * Displays a line or curve between positions. The path is drawn between input positions to achieve a specified path
  * type, e.g., {@link AVKey#GREAT_CIRCLE}. It can also conform to the underlying terrain. A curtain may be formed by
  * extruding the path to the ground.
- * <p/>
+ * <p>
  * Altitudes within the path's positions are interpreted according to the path's altitude mode. If the altitude mode is
  * {@link WorldWind#ABSOLUTE}, the altitudes are considered as height above the ellipsoid. If the altitude mode is
  * {@link WorldWind#RELATIVE_TO_GROUND}, the altitudes are added to the elevation of the terrain at the position. If the
  * altitude mode is {@link WorldWind#CLAMP_TO_GROUND} the altitudes are ignored.
- * <p/>
+ * <p>
  * Between the specified positions the path is drawn along a curve specified by the path's path type, either {@link
  * AVKey#GREAT_CIRCLE}, {@link AVKey#RHUMB_LINE} or {@link AVKey#LINEAR}. (See {@link #setPathType(String)}.)
- * <p/>
+ * <p>
  * Paths have separate attributes for normal display and highlighted display. If no attributes are specified, default
  * attributes are used. See {@link #DEFAULT_INTERIOR_MATERIAL}, {@link #DEFAULT_OUTLINE_MATERIAL}, and {@link
  * #DEFAULT_HIGHLIGHT_MATERIAL}.
- * <p/>
+ * <p>
  * When the path type is <code>LINEAR</code> the path conforms to terrain only if the follow-terrain property is true.
  * Otherwise the path control points will be connected by straight line segments.
- * <p/>
+ * <p>
  * The terrain conformance of <code>GREAT_CIRCLE</code> or <code>RHUMB_LINE</code> paths is determined by the path's
  * follow-terrain and terrain-conformance properties. When the follow-terrain property is true, terrain conformance
  * adapts as the view moves relative to the path; the terrain-conformance property governs the precision of conformance,
@@ -59,21 +59,21 @@ import static gov.nasa.worldwind.ogc.kml.impl.KMLExportUtil.kmlBoolean;
  * #setTerrainConformance(double)}. If the follow-terrain property is false, the view position is not considered and the
  * number of intermediate positions between specified positions is the constant value specified by the num-subsegments
  * property (see {@link #setNumSubsegments(int)}). The latter case may produce higher performance than the former.
- * <p/>
+ * <p>
  * The path positions may be shown by calling {@link #setShowPositions(boolean)} with an argument of <code>true</code>.
  * This causes dots to be drawn at each originally specified path position. Dots are not drawn at tessellated path
  * positions. The size of the dots may be specified via {@link #setShowPositionsScale(double)}. The dots are drawn only
  * when the Path is within a threshold distance from the eye point. The threshold may be specified by calling {@link
  * #setShowPositionsThreshold(double)}. The dots are drawn in the path's outline material colors by default.
- * <p/>
+ * <p>
  * The path's line and the path's position dots may be drawn in unique RGBA colors by configuring the path with a {@link
  * PositionColors} (see {@link #setPositionColors(gov.nasa.worldwind.render.Path.PositionColors)}).
- * <p/>
+ * <p>
  * Path picking includes information about which position dots are picked, in addition to the path itself. A position
  * dot under the cursor is returned as an Integer object in the PickedObject's AVList under they key AVKey.ORDINAL.
  * Position dots intersecting the pick rectangle are returned as a List of Integer objects in the PickedObject's AVList
  * under the key AVKey.ORDINAL_LIST.
- * <p/>
+ * <p>
  * When drawn on a 2D globe, this shape uses a {@link SurfacePolyline} to represent itself. The following features are
  * not provided in this case: display of path positions, extrusion, outline pick width, and identification of path
  * position picked.
@@ -112,11 +112,11 @@ public class Path extends AbstractShape
          * a color cannot be determined for the specified position and ordinal. The specified <code>position</code> is
          * guaranteed to be one of the same Position references passed to a path at construction or in a call to {@link
          * Path#setPositions(Iterable)}.
-         * <p/>
+         * <p>
          * The specified <code>ordinal</code> denotes the position's ordinal number as it appears in the position list
          * passed to the path. Ordinal numbers start with 0 and increase by 1 for every originally specified position.
          * For example, the first three path positions have ordinal values 0, 1, 2.
-         * <p/>
+         * <p>
          * The returned color's RGB components must <em>not</em> be premultiplied by its Alpha component.
          *
          * @param position the path position the color corresponds to.
@@ -412,7 +412,7 @@ public class Path extends AbstractShape
      * Subclass of PickSupport that adds the capability to resolve a Path's picked position point. Path position points
      * are registered with PathPickSupport by calling {@link #addPickablePositions(int, int, Path)} with the minimum and
      * maximum color codes that the Path's position points are drawn in.
-     * <p/>
+     * <p>
      * The resolution of the picked position point is integrated with the resolution of the picked Path. Either an
      * entire Path or one of its position points may be picked. In either case, resolvePick and getTopObject return a
      * PickedObject that specifies the picked Path. If a position point is picked, the PickedObject's AVList contains
@@ -438,7 +438,7 @@ public class Path extends AbstractShape
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Overridden to clear the list of pickable positions.
          */
         @Override
@@ -493,7 +493,7 @@ public class Path extends AbstractShape
          * Path or one of its position points. In either case, this returns a PickedObject that specifies the picked
          * Path. If a position point is picked, the PickedObject's AVList contains the picked position's geographic
          * position in the key AVKey.POSITION and its ordinal number in the key AVKey.ORDINAL.
-         * <p/>
+         * <p>
          * This returns null if the pickPoint is null, or if there is no Path or Path position point at the specified
          * pick point.
          *
@@ -698,7 +698,7 @@ public class Path extends AbstractShape
 
     /**
      * Creates a path with specified positions.
-     * <p/>
+     * <p>
      * Note: If fewer than two positions is specified, no path is drawn.
      *
      * @param positions the path positions. This reference is retained by this shape; the positions are not copied. If
@@ -714,7 +714,7 @@ public class Path extends AbstractShape
 
     /**
      * Creates a path with positions specified via a generic list.
-     * <p/>
+     * <p>
      * Note: If fewer than two positions is specified, the path is not drawn.
      *
      * @param positions the path positions. This reference is retained by this shape; the positions are not copied. If
@@ -760,7 +760,7 @@ public class Path extends AbstractShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to assign this Path's pickSupport property to a new PathPickSupport instance.
      */
     @Override
@@ -793,7 +793,7 @@ public class Path extends AbstractShape
 
     /**
      * Specifies this path's positions, which replace this path's current positions, if any.
-     * <p/>
+     * <p>
      * Note: If fewer than two positions is specified, this path is not drawn.
      *
      * @param positions this path's positions.
@@ -839,11 +839,11 @@ public class Path extends AbstractShape
      * <code>showPositions</code> is true, and override the ShapeAttributes' outline color and outline opacity for both
      * normal display and highlighted display. The specified <code>positionColors</code> do not affect this path's
      * filled interior or vertical drop lines displayed when this path is extruded.
-     * <p/>
+     * <p>
      * If this path is configured to tessellate itself by creating additional positions between the originally specified
      * positions, an interpolated color is assigned to each tessellated position by computing a weighted linear
      * combination of the colors at the originally specified positions.
-     * <p/>
+     * <p>
      * Specify <code>null</code> to disable position colors and draw this path's line and optional position dots
      * according to its ShapeAttributes. This path's position colors reference is <code>null</code> by default.
      *
@@ -913,7 +913,7 @@ public class Path extends AbstractShape
     /**
      * Indicates the number of segments used between specified positions to achieve this path's path type. Higher values
      * cause the path to conform more closely to the path type but decrease performance.
-     * <p/>
+     * <p>
      * Note: The sub-segments number is ignored when the path follows terrain or when the path type is {@link
      * AVKey#LINEAR}.
      *
@@ -929,7 +929,7 @@ public class Path extends AbstractShape
     /**
      * Specifies the number of segments used between specified positions to achieve this path's path type. Higher values
      * cause the path to conform more closely to the path type but decrease performance.
-     * <p/>
+     * <p>
      * Note: The sub-segments number is ignored when the path follows terrain or when the path type is {@link
      * AVKey#LINEAR}.
      *
@@ -1139,6 +1139,7 @@ public class Path extends AbstractShape
      * terrain. This returns <code>true</code> if this Path's altitude mode is <code>WorldWind.CLAMP_TO_GROUND</code>
      * and the follow-terrain property is <code>true</code>. Otherwise this returns <code>false</code>.
      *
+     * @param dc The draw context
      * @return <code>true</code> if this Path's positions and the positions in between are located on the underlying
      * terrain, and <code>false</code> otherwise.
      */
@@ -1216,7 +1217,7 @@ public class Path extends AbstractShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to add this Path's pickable positions to the pick candidates.
      */
     @Override
@@ -1235,7 +1236,7 @@ public class Path extends AbstractShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to place this Path behind other ordered renderables when this Path is entirely located on the
      * underlying terrain. In this case this Path must be drawn first to ensure that other ordered renderables are
      * correctly drawn on top of it and are not affected by this Path's depth offset. If two paths are both located on
@@ -1262,7 +1263,7 @@ public class Path extends AbstractShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * If this Path is entirely located on the terrain, this applies an offset to the Path's depth values to to ensure
      * it shows over the terrain. This does not apply a depth offset in any other case to avoid incorrectly drawing the
      * path over objects it should be behind, including the terrain. In addition to applying a depth offset, this
@@ -1481,7 +1482,7 @@ public class Path extends AbstractShape
 
     /**
      * Draws points at this path's specified positions.
-     * <p/>
+     * <p>
      * Note: when the draw context is in picking mode, this binds the current GL_ARRAY_BUFFER to 0 after using the
      * currently bound GL_ARRAY_BUFFER to specify the vertex pointer. This does not restore GL_ARRAY_BUFFER to the its
      * previous state. If the caller intends to use that buffer after this method returns, the caller must bind the
@@ -2322,7 +2323,7 @@ public class Path extends AbstractShape
 
     /**
      * Computes the minimum distance between this Path and the eye point.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc       the draw context.

--- a/src/gov/nasa/worldwind/render/PointPlacemark.java
+++ b/src/gov/nasa/worldwind/render/PointPlacemark.java
@@ -30,17 +30,17 @@ import static gov.nasa.worldwind.ogc.kml.impl.KMLExportUtil.kmlBoolean;
 /**
  * Represents a point placemark consisting of an image, an optional line linking the image to a corresponding point on
  * the terrain, and an optional label. The image and the label are displayed in the plane of the screen.
- * <p/>
+ * <p>
  * Point placemarks have separate attributes for normal rendering and highlighted rendering. If highlighting is
  * requested but no highlight attributes are specified, the normal attributes are used. If the normal attributes are not
  * specified, default attributes are used. See {@link #getDefaultAttributes()}.
- * <p/>
+ * <p>
  * This class implements and extends the functionality of a KML <i>Point</i>.
- * <p/>
+ * <p>
  * Point placemarks can participate in global text decluttering by setting their decluttering-enabled flag to {@code
  * true}. See {@link #setEnableDecluttering(boolean)}. The default for this flag is {@code false}. When participating in
  * decluttering, only the point placemark's label is considered when determining interference with other text.
- * <p/>
+ * <p>
  * When the label of a point placemark is picked, the associated {@link gov.nasa.worldwind.pick.PickedObject} contains
  * the key {@link AVKey#LABEL}
  *
@@ -460,7 +460,7 @@ public class PointPlacemark extends WWObjectImpl
      *
      * @return true if batch rendering is enabled, otherwise false.
      *
-     * @see #setEnableBatchRendering(boolean).
+     * @see #setEnableBatchRendering(boolean)
      */
     public boolean isEnableBatchRendering()
     {
@@ -483,7 +483,7 @@ public class PointPlacemark extends WWObjectImpl
      *
      * @return true if batch rendering is enabled, otherwise false.
      *
-     * @see #setEnableBatchPicking(boolean).
+     * @see #setEnableBatchPicking(boolean)
      */
     public boolean isEnableBatchPicking()
     {
@@ -525,7 +525,7 @@ public class PointPlacemark extends WWObjectImpl
      * contained in the same layer. This increases performance but allows only the top-most of the placemarks to be
      * reported in a {@link gov.nasa.worldwind.event.SelectEvent} even if several of the placemarks are at the pick
      * position.
-     * <p/>
+     * <p>
      * Batch rendering ({@link #setEnableBatchRendering(boolean)}) must be enabled in order for batch picking to occur.
      *
      * @param enableBatchPicking true to enable batch rendering, otherwise false.
@@ -707,7 +707,7 @@ public class PointPlacemark extends WWObjectImpl
      * If the scene controller is rendering ordered renderables, this method draws this placemark's image as an ordered
      * renderable. Otherwise the method determines whether this instance should be added to the ordered renderable
      * list.
-     * <p/>
+     * <p>
      * The Cartesian and screen points of the placemark are computed during the first call per frame and re-used in
      * subsequent calls of that frame.
      *
@@ -769,6 +769,7 @@ public class PointPlacemark extends WWObjectImpl
      * Determines whether the placemark image intersects the view frustum.
      *
      * @param dc the current draw context.
+     * @param opm the ordered placemark to test.
      *
      * @return true if the image intersects the frustum, otherwise false.
      */
@@ -865,6 +866,7 @@ public class PointPlacemark extends WWObjectImpl
      * Draws the path as an ordered renderable.
      *
      * @param dc the current draw context.
+     * @param opm the ordered placemark to draw.
      */
     protected void drawOrderedRenderable(DrawContext dc, OrderedPlacemark opm)
     {
@@ -934,6 +936,7 @@ public class PointPlacemark extends WWObjectImpl
      *
      * @param dc             the current draw context.
      * @param pickCandidates a pick support holding the picked object list to add this shape to.
+     * @param opm the ordered placemark to draw.
      */
     protected void doDrawOrderedRenderable(DrawContext dc, PickSupport pickCandidates, OrderedPlacemark opm)
     {
@@ -1130,6 +1133,8 @@ public class PointPlacemark extends WWObjectImpl
      * Draws the placemark's label if a label is specified.
      *
      * @param dc the current draw context.
+     * @param pickCandidates the pick candidates updated if in picking mode.
+     * @param opm the ordered placemark to label.
      */
     protected void drawLabel(DrawContext dc, PickSupport pickCandidates, OrderedPlacemark opm)
     {
@@ -1215,6 +1220,7 @@ public class PointPlacemark extends WWObjectImpl
      *
      * @param dc             the current draw context.
      * @param pickCandidates the pick support object to use when adding this as a pick candidate.
+     * @param opm            the ordered placemark to draw.
      */
     protected void drawLine(DrawContext dc, PickSupport pickCandidates, OrderedPlacemark opm)
     {
@@ -1249,6 +1255,7 @@ public class PointPlacemark extends WWObjectImpl
      *
      * @param dc             the current draw context.
      * @param pickCandidates the pick support object to use when adding this as a pick candidate.
+     * @param opm            the ordered placemark to draw
      */
     protected void drawPoint(DrawContext dc, PickSupport pickCandidates, OrderedPlacemark opm)
     {
@@ -1305,6 +1312,7 @@ public class PointPlacemark extends WWObjectImpl
      * Determines whether the placemark's optional line should be drawn and whether it intersects the view frustum.
      *
      * @param dc the current draw context.
+     * @param opm the ordered placemark to test.
      *
      * @return true if the line should be drawn and it intersects the view frustum, otherwise false.
      */
@@ -1564,6 +1572,7 @@ public class PointPlacemark extends WWObjectImpl
      * placemark's altitude mode when computing the points.
      *
      * @param dc the current draw context.
+     * @param opm the ordered placemark to update.
      */
     protected void computePlacemarkPoints(DrawContext dc, OrderedPlacemark opm)
     {
@@ -1614,7 +1623,6 @@ public class PointPlacemark extends WWObjectImpl
      * @param dc  the current draw context.
      * @param opm the ordered placemark.
      *
-     * @return the bounding rectangle.
      */
     protected void computeImageBounds(DrawContext dc, OrderedPlacemark opm)
     {
@@ -1762,7 +1770,6 @@ public class PointPlacemark extends WWObjectImpl
     /**
      * Export the Placemark. The {@code output} object will receive the exported data. The type of this object depends
      * on the export format. The formats and object types supported by this class are:
-     * <p/>
      * <pre>
      * Format                                         Supported output object types
      * ================================================================================

--- a/src/gov/nasa/worldwind/render/PointPlacemarkAttributes.java
+++ b/src/gov/nasa/worldwind/render/PointPlacemarkAttributes.java
@@ -320,7 +320,7 @@ public class PointPlacemarkAttributes implements Exportable
      *
      * @return the heading reference.
      *
-     * @see #setHeadingReference(String).
+     * @see #setHeadingReference(String)
      */
     public String getHeadingReference()
     {
@@ -332,7 +332,7 @@ public class PointPlacemarkAttributes implements Exportable
      * interpreted as relative to the screen and the placemark icon maintains the heading relative to the screen's
      * vertical edges. If {@link gov.nasa.worldwind.avlist.AVKey#RELATIVE_TO_GLOBE}, the heading is interpreted relative
      * to the globe and the placemark icon maintains the heading relative to the globe's north direction.
-     * <p/>
+     * <p>
      * The default heading reference is null, which {@link PointPlacemark} interprets as {@link
      * gov.nasa.worldwind.avlist.AVKey#RELATIVE_TO_SCREEN}.
      *
@@ -385,7 +385,7 @@ public class PointPlacemarkAttributes implements Exportable
     }
 
     /**
-     * Indicates whether one or more members of <i>this</> remain unresolved because they must be retrieved from an
+     * Indicates whether one or more members of <i>this</i> remain unresolved because they must be retrieved from an
      * external source.
      *
      * @return true if there are unresolved fields, false if no fields remain unresolved.
@@ -396,7 +396,7 @@ public class PointPlacemarkAttributes implements Exportable
     }
 
     /**
-     * Specifies whether one or more fields of <i>this</> remain unresolved because they must be retrieved from an
+     * Specifies whether one or more fields of <i>this</i> remain unresolved because they must be retrieved from an
      * external source.
      *
      * @param unresolved true if there are unresolved fields, false if no fields remain unresolved.
@@ -432,7 +432,7 @@ public class PointPlacemarkAttributes implements Exportable
      * image. An offset of (1, 1) in fraction units causes the text to start at the upper right corner of the image. The
      * text would also start there if the offset is in units of pixels and the X and Y values are the image width and
      * height, respectively.
-     * <p/>
+     * <p>
      * If no offset is specified, the label is placed at the right edge of the image with the top of the text at about
      * the same level as the top of the image. (An offset of (X = 1.0, Y = 0.6, both in fraction units.)
      *
@@ -584,7 +584,6 @@ public class PointPlacemarkAttributes implements Exportable
     /**
      * Export the Placemark. The {@code output} object will receive the exported data. The type of this object depends
      * on the export format. The formats and object types supported by this class are:
-     * <p/>
      * <pre>
      * Format                                         Supported output object types
      * ================================================================================
@@ -637,7 +636,10 @@ public class PointPlacemarkAttributes implements Exportable
 
     /**
      * Export the placemark attributes to KML as a {@code <Style>} element. The {@code output} object will receive the
-     * data. This object must be one of: java.io.Writer<br/> java.io.OutputStream<br/> javax.xml.stream.XMLStreamWriter
+     * data. This object must be one of: <br>
+     * java.io.Writer<br> 
+     * java.io.OutputStream<br> 
+     * javax.xml.stream.XMLStreamWriter
      *
      * @param output Object to receive the generated KML.
      *

--- a/src/gov/nasa/worldwind/render/Polygon.java
+++ b/src/gov/nasa/worldwind/render/Polygon.java
@@ -27,13 +27,13 @@ import java.util.*;
 
 /**
  * /** A 3D polygon. The polygon may be complex with multiple internal but not intersecting contours.
- * <p/>
+ * <p>
  * Polygons are safe to share among WorldWindows. They should not be shared among layers in the same WorldWindow.
- * <p/>
+ * <p>
  * In order to support simultaneous use of this shape with multiple globes (windows), this shape maintains a cache of
  * data computed relative to each globe. During rendering, the data for the currently active globe, as indicated in the
  * draw context, is made current. Subsequently called methods rely on the existence of this current data cache entry.
- * <p/>
+ * <p>
  * When drawn on a 2D globe, this shape uses a {@link SurfacePolygon} to represent itself. The following features are
  * not provided in this case: rotation and texture.
  *
@@ -871,7 +871,7 @@ public class Polygon extends AbstractShape
 
     /**
      * Compute enough geometry to determine this polygon's extent, reference point and eye distance.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc        the current draw context.
@@ -901,7 +901,7 @@ public class Polygon extends AbstractShape
 
     /**
      * Computes the minimum distance between this polygon and the eye point.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc        the draw context.
@@ -1003,7 +1003,7 @@ public class Polygon extends AbstractShape
 
     /**
      * Compute the cap geometry.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc        the current draw context.
@@ -1152,7 +1152,7 @@ public class Polygon extends AbstractShape
 
     /**
      * Tessellates the polygon.
-     * <p/>
+     * <p>
      * This method catches {@link OutOfMemoryError} exceptions and if the draw context is not null passes the exception
      * to the rendering exception listener (see {@link WorldWindow#addRenderingExceptionListener(gov.nasa.worldwind.event.RenderingExceptionListener)}).
      *
@@ -1417,7 +1417,7 @@ public class Polygon extends AbstractShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Note that this method overwrites the boundary locations lists, and therefore no longer refer to the originally
      * specified boundary lists.
      *
@@ -1460,7 +1460,7 @@ public class Polygon extends AbstractShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Note that this method overwrites the boundary locations lists, and therefore no longer refer to the originally
      * specified boundary lists.
      *

--- a/src/gov/nasa/worldwind/render/Polyline.java
+++ b/src/gov/nasa/worldwind/render/Polyline.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @author tag
  * @version $Id: Polyline.java 2188 2014-07-30 15:01:16Z tgaskins $
  * @deprecated Use {@link Path} instead.
- *             <p/>
+ *             <p>
  *             When drawn on a 2D globe, this shape uses either a {@link SurfacePolyline} or {@link SurfacePolygon} to
  *             represent itself.
  */
@@ -753,7 +753,7 @@ public class Polyline extends AVListImpl implements Renderable, OrderedRenderabl
      * If the scene controller is rendering ordered renderables, this method draws this placemark's image as an ordered
      * renderable. Otherwise the method determines whether this instance should be added to the ordered renderable
      * list.
-     * <p/>
+     * <p>
      * The Cartesian and screen points of the placemark are computed during the first call per frame and re-used in
      * subsequent calls of that frame.
      *

--- a/src/gov/nasa/worldwind/render/RigidShape.java
+++ b/src/gov/nasa/worldwind/render/RigidShape.java
@@ -24,8 +24,8 @@ import java.util.*;
 /**
  * A general rigid volume defined by a center position and the three axis radii. If A is the radius in the north-south
  * direction, and b is the radius in the east-west direction, and c is the radius in the vertical direction (increasing
- * altitude), then A == B == C defines a unit shape, A == B > C defines a vertically flattened shape (disk-shaped), A ==
- * B < C defines a vertically stretched shape.
+ * altitude), then {@code A == B == C } defines a unit shape, {@code A == B > C } defines a vertically flattened
+ * shape disk-shaped), {@code A == * B < C }defines a vertically stretched shape.
  *
  * @author ccrick
  * @version $Id: RigidShape.java 2990 2015-04-07 19:06:15Z tgaskins $
@@ -41,7 +41,7 @@ public abstract class RigidShape extends AbstractShape
     {
         /** Holds the computed tessellation of the shape in model coordinates. */
         protected List<Geometry> meshes = new ArrayList<Geometry>();
-        /** The GPU-resource cache keys to use for this entry's VBOs (one for eack LOD), if VBOs are used. */
+        /** The GPU-resource cache keys to use for this entry's VBOs (one for each LOD), if VBOs are used. */
         protected Map<Integer, Object> vboCacheKeys = new HashMap<Integer, Object>();
 
         /** Indicates whether the index buffer needs to be filled because a new buffer is used or some other reason. */
@@ -1369,7 +1369,7 @@ public abstract class RigidShape extends AbstractShape
 
     /**
      * Get or create OpenGL resource IDs for the current data cache entry.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param index the index of the LOD whose VboID's will be retrieved.
@@ -1393,7 +1393,7 @@ public abstract class RigidShape extends AbstractShape
 
     /**
      * Removes from the GPU resource cache the entry for the current data cache entry's VBOs.
-     * <p/>
+     * <p>
      * A {@link gov.nasa.worldwind.render.AbstractShape.AbstractShapeData} must be current when this method is called.
      *
      * @param dc the current draw context.

--- a/src/gov/nasa/worldwind/render/ScreenBrowserBalloon.java
+++ b/src/gov/nasa/worldwind/render/ScreenBrowserBalloon.java
@@ -78,13 +78,17 @@ public class ScreenBrowserBalloon extends AbstractBrowserBalloon implements Scre
 
     /**
      * Computes and stores this balloon's screen coordinates. This assigns balloon coordinate properties as follows:
-     * <p/>
-     * <ul> <li><code>screenOffset</code> - the balloon frame's screen-coordinate offset from this balloon's screen
-     * location.</li> <li><code>screenRect</code> - the balloon frame's screen-coordinate rectangle.</li>
+     * <ul> 
+     * <li><code>screenOffset</code> - the balloon frame's screen-coordinate offset from this balloon's screen
+     * location.</li> 
+     * <li><code>screenRect</code> - the balloon frame's screen-coordinate rectangle.</li>
      * <li><code>screenExtent</code> - this balloon's screen-coordinate bounding rectangle.</li>
      * <li><code>screenPickExtent</code> - this balloon's screen-coordinate bounding rectangle, including area covered
-     * by the balloon's pickable outline.</li> <li><code>webViewRect</code> - the WebView's screen-coordinate content
-     * frame.</li> <li><code>eyeDistance</code> - always 0.</li>
+     * by the balloon's pickable outline.</li> 
+     * <li><code>webViewRect</code> - the WebView's screen-coordinate content
+     * frame.
+     * </li> <li><code>eyeDistance</code> - always 0.</li>
+     * </ul>
      *
      * @param dc the current draw context.
      */

--- a/src/gov/nasa/worldwind/render/ScreenImage.java
+++ b/src/gov/nasa/worldwind/render/ScreenImage.java
@@ -710,7 +710,6 @@ public class ScreenImage extends WWObjectImpl implements Renderable, Exportable
     /**
      * Export the screen image. The {@code output} object will receive the exported data. The type of this object
      * depends on the export format. The formats and object types supported by this class are:
-     * <p/>
      * <pre>
      * Format                                         Supported output object types
      * ================================================================================
@@ -764,7 +763,7 @@ public class ScreenImage extends WWObjectImpl implements Renderable, Exportable
     /**
      * Export the screen image to KML as a {@code <ScreenOverlay>} element. The {@code output} object will receive the
      * data. This object must be one of: java.io.Writer java.io.OutputStream javax.xml.stream.XMLStreamWriter.
-     * <p/>
+     * <p>
      * The image path can only be exported if the image source is a path or URL. If the image source is a BufferedImage,
      * for example, the image will not be exported and no icon reference will be written into the ScreenOverlay tag.
      *

--- a/src/gov/nasa/worldwind/render/ScreenRelativeAnnotation.java
+++ b/src/gov/nasa/worldwind/render/ScreenRelativeAnnotation.java
@@ -14,7 +14,7 @@ import java.awt.*;
  * Provides a screen annotation positioned relatively to the window rather than absolutely. The annotation's position is
  * specified as fractional locations along the window's X and Y axes. When the window is resized the annotation is
  * repositioned according to its relative coordinates.
- * <p/>
+ * <p>
  * The annotation can be forced to remain fully visible even if its relative position would place a portion of it
  * outside the window. X and Y margins can be specified to ensure distance between the annotation's edges and the window
  * edges.

--- a/src/gov/nasa/worldwind/render/ShapeAttributes.java
+++ b/src/gov/nasa/worldwind/render/ShapeAttributes.java
@@ -257,7 +257,7 @@ public interface ShapeAttributes extends Exportable
      * used. For example, if <code>factor</code> is 3, each bit is repeated 3 times before using the next bit. The
      * specified <code>factor</code> must be either zero or an integer greater than zero. The <code>factor</code> may be
      * limited by an implementation-defined maximum during rendering. The maximum stipple factor is typically 256.
-     * <p/>
+     * <p>
      * To disable outline stippling, either specify a stipple factor of 0, or specify a stipple pattern of all 1 bits:
      * <code>0xFFFF</code>.
      *
@@ -285,7 +285,7 @@ public interface ShapeAttributes extends Exportable
      * the bit pattern repeats after reaching n*16 pixels, where n is the stipple factor. Each bit is repeated n-times
      * according to the outline stipple factor. For example, if the outline stipple factor is 3, each bit is repeated 3
      * times before using the next bit.
-     * <p/>
+     * <p>
      * To disable outline stippling, either specify a stipple factor of 0, or specify a stipple pattern of all 1 bits:
      * <code>0xFFFF</code>.
      *

--- a/src/gov/nasa/worldwind/render/Size.java
+++ b/src/gov/nasa/worldwind/render/Size.java
@@ -15,15 +15,15 @@ import java.awt.*;
  * Defines the dimensions of an image, label or other screen-space item relative to a container (for example, the
  * viewport). A size contains a width, a height, a width size mode, a height size mode, and for each of these a "units"
  * string indicating the coordinate units.
- * <p/>
+ * <p>
  * The possible size modes are: <ul> <li> {@link #NATIVE_DIMENSION} - Maintain the native dimensions.</li> <li> {@link
  * #MAINTAIN_ASPECT_RATIO} - Maintain the aspect ratio of the image when one dimension is specified and the other is
  * not.</li> <li> {@link #EXPLICIT_DIMENSION} - Use an explicit dimension. This dimension may be either an absolute
  * pixel value, or a fraction of the container.</li>
- * <p/>
+ * </ul>
  * Recognized units are {@link AVKey#PIXELS}, which indicates pixel units relative to the lower left corner of the
  * image, or {@link AVKey#FRACTION}, which indicates the units are fractions of the image width and height.
- * <p/>
+ * <p>
  * Examples:
  * <pre>
  * Width mode      Height mode      Width (Units)      Height (Units)        Result
@@ -37,7 +37,8 @@ import java.awt.*;
  *                                                                           container, but do not scale the height.
  *
  * This class implements the functionality of a KML <i>size</i>.
- *
+ *</pre>
+ * 
  * @author pabercrombie
  * @version $Id: Size.java 1171 2013-02-11 21:45:02Z dcollins $
  */

--- a/src/gov/nasa/worldwind/render/SurfaceEllipse.java
+++ b/src/gov/nasa/worldwind/render/SurfaceEllipse.java
@@ -351,7 +351,7 @@ public class SurfaceEllipse extends AbstractSurfaceShape
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to include the globe's state key in the returned state key.
      *
      * @see gov.nasa.worldwind.globes.Globe#getStateKey(DrawContext)

--- a/src/gov/nasa/worldwind/render/SurfaceIcon.java
+++ b/src/gov/nasa/worldwind/render/SurfaceIcon.java
@@ -86,7 +86,7 @@ public class SurfaceIcon extends AbstractSurfaceRenderable implements Movable, D
 
     /**
      * Get the icon displacement in pixels relative to the reference location.  Can be <code>null</code>.
-     * <p/>
+     * <p>
      * When <code>null</code> the icon will be drawn with it's image center on top of it's reference location - see
      * {@link #setLocation(LatLon)}. Otherwise the icon will be shifted of a distance equivalent to the number of pixels
      * specified as <code>x</code> and <code>y</code> offset values. Positive values will move the icon to the right for
@@ -101,7 +101,7 @@ public class SurfaceIcon extends AbstractSurfaceRenderable implements Movable, D
 
     /**
      * Set the icon displacement in pixels relative to the reference location. Can be <code>null</code>.
-     * <p/>
+     * <p>
      * When <code>null</code> the icon will be drawn with it's image center on top of it's refence location - see {@link
      * #setLocation(LatLon)}. Otherwise the icon will be shifted of a distance equivalent to the number of pixels
      * specified as <code>x</code> and <code>y</code> offset values. Positive values will move the icon to the right for
@@ -256,7 +256,7 @@ public class SurfaceIcon extends AbstractSurfaceRenderable implements Movable, D
     /**
      * Get the minimum size in meter the icon image is allowed to be reduced to once applied to the terrain surface.
      * This limit applies to the source image largest dimension.
-     * <p/>
+     * <p>
      * The icon will try to maintain it's apparent size depending on it's distance from the eye and will extend over a
      * rectangular area which largest dimension is bounded by the values provided with {@link #setMinSize(double)} and
      * {@link #setMaxSize(double)}.
@@ -271,7 +271,7 @@ public class SurfaceIcon extends AbstractSurfaceRenderable implements Movable, D
     /**
      * Set the minimum size in meter the icon image is allowed to be reduced to once applied to the terrain surface.
      * This limit applies to the source image largest dimension.
-     * <p/>
+     * <p>
      * The icon will try to maintain it's apparent size depending on it's distance from the eye and will extend over a
      * rectangular area which largest dimension is bounded by the values provided with <code>setMinSize(double)</code>
      * and {@link #setMaxSize(double)}.
@@ -287,7 +287,7 @@ public class SurfaceIcon extends AbstractSurfaceRenderable implements Movable, D
     /**
      * Get the maximum size in meter the icon image is allowed to be enlarged to once applied to the terrain surface.
      * This limit applies to the source image largest dimension.
-     * <p/>
+     * <p>
      * The icon will try to maintain it's apparent size depending on it's distance from the eye and will extend over a
      * rectangular area which largest dimension is bounded by the values provided with {@link #setMinSize(double)} and
      * {@link #setMaxSize(double)}.
@@ -302,7 +302,7 @@ public class SurfaceIcon extends AbstractSurfaceRenderable implements Movable, D
     /**
      * Get the maximum size in meter the icon image is allowed to be enlarged to once applied to the terrain surface.
      * This limit applies to the source image largest dimension.
-     * <p/>
+     * <p>
      * The icon will try to maintain it's apparent size depending on it's distance from the eye and will extend over a
      * rectangular area which largest dimension is bounded by the values provided with {@link #setMinSize(double)} and
      * <code>setMaxSize(double)</code>.
@@ -327,7 +327,7 @@ public class SurfaceIcon extends AbstractSurfaceRenderable implements Movable, D
 
     /**
      * Set the {@link Color} the source image will be combined with - default to white.
-     * <p/>
+     * <p>
      * A non white color will mostly affect the white portions from the original image. This is mostly useful to alter
      * the appearance of 'colorless' icons - which mainly contain black, white and shades of gray.
      *
@@ -356,7 +356,7 @@ public class SurfaceIcon extends AbstractSurfaceRenderable implements Movable, D
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to return a unique state key if the icon is configured to always redraw. SurfaceIcon does not use a
      * cached representation if it's heading is configured to follow the view, or if it's configured to maintain a
      * constant screen size.

--- a/src/gov/nasa/worldwind/render/SurfaceImage.java
+++ b/src/gov/nasa/worldwind/render/SurfaceImage.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 /**
  * Renders a single image contained in a local file, a remote file, or a <code>BufferedImage</code>.
- * <p/>
+ * <p>
  * Note: The view input handlers detect the surface image rather than the terrain as the top picked object in {@link
  * gov.nasa.worldwind.event.SelectEvent}s and will not respond to the user's attempts at navigation when the cursor is
  * over the image. If this is not the desired behavior, disable picking for the layer containing the surface image.
@@ -536,7 +536,6 @@ public class SurfaceImage extends WWObjectImpl
     /**
      * Export the Surface Image. The {@code output} object will receive the exported data. The type of this object
      * depends on the export format. The formats and object types supported by this class are:
-     * <p/>
      * <pre>
      * Format                                         Supported output object types
      * ================================================================================

--- a/src/gov/nasa/worldwind/render/SurfaceObject.java
+++ b/src/gov/nasa/worldwind/render/SurfaceObject.java
@@ -14,12 +14,12 @@ import java.awt.*;
  * Common interface for renderables that are drawn on the Globe's surface terrain, such as {@link
  * gov.nasa.worldwind.render.SurfaceShape}. SurfaceObject implements the {@link gov.nasa.worldwind.render.Renderable}
  * interface, so a surface object may be aggregated within any layer or within some arbitrary rendering code.
- * <p/>
+ * <p>
  * SurfaceObjects automatically aggregate themselves in the DrawContext's ordered surface renderable queue by calling
  * {@link gov.nasa.worldwind.render.DrawContext#addOrderedSurfaceRenderable(OrderedRenderable)} during the preRender,
  * pick, and render stages. This enables SurfaceObjects to be processed in bulk, and reduces texture memory consumption
  * by sharing rendering resources amongst multiple SurfaceObjects.
- * <p/>
+ * <p>
  * Implementations of SurfaceObject require that {@link #preRender(DrawContext)} is called before {@link
  * #render(DrawContext)} and {@link #pick(DrawContext, java.awt.Point)}, and that preRender is called at the appropriate
  * stage in the current rendering cycle. Calling preRender locks in the SurfaceObject's visual appearance for any

--- a/src/gov/nasa/worldwind/render/SurfaceObjectTileBuilder.java
+++ b/src/gov/nasa/worldwind/render/SurfaceObjectTileBuilder.java
@@ -25,24 +25,23 @@ import java.util.List;
  * SurfaceObjectTileBuilder directly. WorldWind's default scene controller automatically batches instances of
  * SurfaceRenderable in a single SurfaceObjectTileBuilder. Applications that need to draw basic surface shapes should
  * use or extend {@link gov.nasa.worldwind.render.SurfaceShape} instead of using SurfaceObjectTileBuilder directly.
- * <p/>
+ * <p>
  * Surface tiles are built by calling {@link #buildTiles(DrawContext, Iterable)} with an iterable of surface
  * renderables. This assembles a set of surface tiles that meet the resolution requirements for the specified draw
  * context, then draws the surface renderables into those offscreen surface tiles by calling render on each instance.
  * This process may temporarily use the framebuffer to perform offscreen rendering, and therefore should be called
  * during the preRender method of a WorldWind layer. See the {@link gov.nasa.worldwind.render.PreRenderable} interface
  * for details. Once built, the surface tiles can be rendered by a {@link gov.nasa.worldwind.render.SurfaceTileRenderer}.
- * <p/>
+ * <p>
  * By default, SurfaceObjectTileBuilder creates texture tiles with a width and height of 512 pixels, and with internal
  * format <code>GL_RGBA</code>. These parameters are configurable by calling {@link
  * #setTileDimension(java.awt.Dimension)} or {@link #setTileTextureFormat(int)}.
- * <p/>
+ * <p>
  * The most common usage pattern for SurfaceObjectTileBuilder is to build the surface tiles from a set of surface
  * renderables during the preRender phase, then draw those surface tiles during the render phase. For example, a
  * renderable can use SurfaceObjectTileBuilder to draw a set of surface renderables as follows:
- * <p/>
- * <code>
  * <pre>
+ * {@code 
  * class MyRenderable implements Renderable, PreRenderable
  * {
  *     protected SurfaceObjectTileBuilder tileBuilder = new SurfaceObjectTileBuilder();
@@ -60,8 +59,8 @@ import java.util.List;
  *         dc.getGeographicSurfaceTileRenderer().renderTiles(dc, this.tileBuilder.getTiles(dc));
  *     }
  * }
+ * }
  * </pre>
- * </code>
  *
  * @author dcollins
  * @version $Id: SurfaceObjectTileBuilder.java 3108 2015-05-26 19:07:06Z dcollins $
@@ -202,7 +201,9 @@ public class SurfaceObjectTileBuilder
 
     /**
      * Specifies the surface tile's OpenGL texture format. A value of 0 indicates that the default format should be
-     * used. Otherwise, the texture format may be one of the following: <code> <ul> <li>GL_ALPHA</li> <li>GL_ALPHA4</li>
+     * used. Otherwise, the texture format may be one of the following: 
+     * <ul> 
+     * <li>GL_ALPHA</li> <li>GL_ALPHA4</li>
      * <li>GL_ALPHA8</li> <li>GL_ALPHA12</li> <li>GL_ALPHA16</li> <li>GL_COMPRESSED_ALPHA</li>
      * <li>GL_COMPRESSED_LUMINANCE</li> <li>GL_COMPRESSED_LUMINANCE_ALPHA</li> <li>GL_COMPRESSED_INTENSITY</li>
      * <li>GL_COMPRESSED_RGB</li> <li>GL_COMPRESSED_RGBA</li> <li>GL_DEPTH_COMPONENT</li> <li>GL_DEPTH_COMPONENT16</li>
@@ -215,8 +216,8 @@ public class SurfaceObjectTileBuilder
      * <li>GL_RGB10</li> <li>GL_RGB12</li> <li>GL_RGB16</li> <li>GL_RGBA</li> <li>GL_RGBA2</li> <li>GL_RGBA4</li>
      * <li>GL_RGB5_A1</li> <li>GL_RGBA8</li> <li>GL_RGB10_A2</li> <li>GL_RGBA12</li> <li>GL_RGBA16</li>
      * <li>GL_SLUMINANCE</li> <li>GL_SLUMINANCE8</li> <li>GL_SLUMINANCE_ALPHA</li> <li>GL_SLUMINANCE8_ALPHA8</li>
-     * <li>GL_SRGB</li> <li>GL_SRGB8</li> <li>GL_SRGB_ALPHA</li> <li>GL_SRGB8_ALPHA8</li> </ul> </code>
-     * <p/>
+     * <li>GL_SRGB</li> <li>GL_SRGB8</li> <li>GL_SRGB_ALPHA</li> <li>GL_SRGB8_ALPHA8</li> </ul> 
+     * <p>
      * If the texture format is any of <code>GL_RGB, GL_RGB8, GL_RGBA, or GL_RGBA8</code>, the tile builder attempts to
      * use OpenGL framebuffer objects to render shapes to the texture tiles. Otherwise, this renders shapes to the
      * framebuffer and copies the framebuffer contents to the texture tiles.
@@ -372,7 +373,7 @@ public class SurfaceObjectTileBuilder
      * surface tiles are assembled to meet the necessary resolution of to the draw context's {@link
      * gov.nasa.worldwind.View}. This may temporarily use the framebuffer to perform offscreen rendering, and therefore
      * should be called during the preRender method of a WorldWind {@link gov.nasa.worldwind.layers.Layer}.
-     * <p/>
+     * <p>
      * This does nothing if the specified iterable is null, is empty or contains no surface renderables.
      *
      * @param dc       the draw context to build tiles for.
@@ -505,7 +506,7 @@ public class SurfaceObjectTileBuilder
     /**
      * Updates each {@link SurfaceObjectTileBuilder.SurfaceObjectTile} in the {@link #currentInfo}. This is typically
      * called after {@link #assembleTiles(DrawContext)} to update the assembled tiles.
-     * <p/>
+     * <p>
      * This method does nothing if <code>currentTiles</code> is empty.
      *
      * @param dc the draw context the tiles relate to.
@@ -619,18 +620,23 @@ public class SurfaceObjectTileBuilder
 
     /**
      * Returns a new surface tile texture for use on the specified draw context with the specified width and height.
-     * <p/>
+     * <p>
      * The returned texture's internal format is specified by <code>tilePixelFormat</code>. If
      * <code>tilePixelFormat</code> is zero, this returns a texture with internal format <code>GL_RGBA8</code>.
-     * <p/>
-     * The returned texture's parameters are configured as follows: <table> <tr><th>Parameter
-     * Name</th><th>Value</th></tr> <tr><td><code>GL.GL_TEXTURE_MIN_FILTER</code></td><td><code>GL_LINEAR_MIPMAP_LINEAR</code>
+     * <p>
+     * The returned texture's parameters are configured as follows: 
+     * <table> <caption>Parameters</caption>
+     * <tr><th>Parameter Name</th><th>Value</th></tr> 
+     * <tr><td><code>GL.GL_TEXTURE_MIN_FILTER</code></td><td><code>GL_LINEAR_MIPMAP_LINEAR</code>
      * if <code>useLinearFilter</code> and <code>useMipmaps</code> are both true, <code>GL_LINEAR</code> if
      * <code>useLinearFilter</code> is true and <code>useMipmaps</code> is false, and <code>GL_NEAREST</code> if
-     * <code>useLinearFilter</code> is false.</td></tr> <tr><td><code>GL.GL_TEXTURE_MAG_FILTER</code></td><td><code>GL_LINEAR</code>
+     * <code>useLinearFilter</code> is false.</td></tr> 
+     * <tr><td><code>GL.GL_TEXTURE_MAG_FILTER</code></td><td><code>GL_LINEAR</code>
      * if <code>useLinearFilter</code> is true, <code>GL_NEAREST</code> if <code>useLinearFilter</code> is
-     * false.</td></tr> <tr><td><code>GL.GL_TEXTURE_WRAP_S</code></td><td><code>GL_CLAMP_TO_EDGE</code></td></tr>
+     * false.</td></tr> 
+     * <tr><td><code>GL.GL_TEXTURE_WRAP_S</code></td><td><code>GL_CLAMP_TO_EDGE</code></td></tr>
      * <tr><td><code>GL.GL_TEXTURE_WRAP_T</code></td><td><code>GL_CLAMP_TO_EDGE</code></td></tr>
+     * </table>
      *
      * @param dc     the draw context to create a texture for.
      * @param width  the texture's width, in pixels.
@@ -742,15 +748,15 @@ public class SurfaceObjectTileBuilder
      * <code>SurfaceObjectTileBuilder</code> share common LevelSets to determine which tiles are visible, but create
      * unique tile instances and uses a unique tile cache name. Since all instances use the same tile structure to
      * determine visible tiles, this saves memory while ensuring that each instance stores its own tiles in the cache.
-     * <p/>
+     * <p>
      * The returned LevelSet's cache name and dataset name are dummy values, and should not be used. Use this tile
      * builder's cache name for the specified <code>tileDimension</code> instead.
-     * <p/>
+     * <p>
      * In practice, there are at most 10 dimensions we use: 512, 256, 128, 64, 32, 16, 8, 4, 2, 1. Therefore keeping the
      * <code>LevelSet</code>s in a map requires little memory overhead, and ensures each <code>LevelSet</code> is
      * retained once constructed. Retaining references to the <code>LevelSet</code>s means we're able to re-use the
      * texture resources associated with each <code>LevelSet</code> in the <code>DrawContext</code>'s texture cache.
-     * <p/>
+     * <p>
      * Subsequent calls are guaranteed to return the same <code>LevelSet</code> for the same
      * <code>tileDimension</code>.
      *
@@ -826,7 +832,7 @@ public class SurfaceObjectTileBuilder
      * frustum during rendering mode, and against the DrawContext's pick frustums during picking mode. If a tile does
      * not meet the tile builder's resolution criteria, it's split into four sub-tiles and the process recursively
      * repeated on the sub-tiles. Visible leaf tiles are added to the {@link #currentInfo}.
-     * <p/>
+     * <p>
      * During assembly each surface renderable in {@link #currentSurfaceObjects} is sorted into the tiles they
      * intersect. The top level tiles are used as an index to quickly determine which tiles each renderable intersects.
      * Surface renderables are sorted into sub-tiles by simple intersection tests, and are added to each tile's surface
@@ -923,7 +929,7 @@ public class SurfaceObjectTileBuilder
      * Potentially adds the specified tile or its descendants to the tile builder's {@link #currentInfo}. The tile and
      * its descendants are discarded if the tile is not visible or does not intersect any surface renderables in the
      * parent's surface renderable list. See {@link SurfaceObjectTileBuilder.SurfaceObjectTile#getObjectList()}.
-     * <p/>
+     * <p>
      * If the tile meet the tile builder's resolution criteria it's added to the tile builder's
      * <code>currentTiles</code> list. Otherwise, it's split into four sub-tiles and each tile is recursively processed.
      * See {@link #meetsRenderCriteria(DrawContext, gov.nasa.worldwind.util.LevelSet, gov.nasa.worldwind.util.Tile)}.
@@ -1149,7 +1155,7 @@ public class SurfaceObjectTileBuilder
      * Creates a key to address the tile information associated with the specified draw context. Each key is unique to
      * this instance, the tile dimensions that fit in the draw context's viewport, and the globe offset when a 2D globe
      * is in use. Using a unique set of tile information ensures that
-     * <p/>
+     * <p>
      * In practices, there are at most 10 dimensions we'll use (512, 256, 128, 64, 32, 16, 8, 4, 2, 1) and 3 globe
      * offsets (-1, 0, 1). Therefore there are at most 30 sets of tile information for each instance of
      * SurfaceObjectTileBuilder.
@@ -1457,7 +1463,7 @@ public class SurfaceObjectTileBuilder
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Overridden to return a new SurfaceObjectTile. The returned tile is created with the same cache name as this
          * tile.
          */
@@ -1469,7 +1475,7 @@ public class SurfaceObjectTileBuilder
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Overridden to return a TileKey with the same cache name as this tile.
          */
         @Override

--- a/src/gov/nasa/worldwind/render/SurfacePolygon.java
+++ b/src/gov/nasa/worldwind/render/SurfacePolygon.java
@@ -100,7 +100,7 @@ public class SurfacePolygon extends AbstractSurfaceShape implements Exportable
 
     /**
      * Constructs a new surface polygon with the default attributes and the specified iterable of locations.
-     * <p/>
+     * <p>
      * Note: If fewer than three locations is specified, no polygon is drawn.
      *
      * @param iterable the polygon locations.
@@ -123,7 +123,7 @@ public class SurfacePolygon extends AbstractSurfaceShape implements Exportable
      * Constructs a new surface polygon with the specified normal (as opposed to highlight) attributes and the specified
      * iterable of locations. Modifying the attribute reference after calling this constructor causes this shape's
      * appearance to change accordingly.
-     * <p/>
+     * <p>
      * Note: If fewer than three locations is specified, no polygon is drawn.
      *
      * @param normalAttrs the normal attributes. May be null, in which case default attributes are used.

--- a/src/gov/nasa/worldwind/render/SurfacePolygons.java
+++ b/src/gov/nasa/worldwind/render/SurfacePolygons.java
@@ -19,7 +19,7 @@ import java.util.logging.Level;
 /**
  * Renders fast multiple polygons with or without holes in one pass. It relies on a {@link
  * gov.nasa.worldwind.util.CompoundVecBuffer}.
- * <p/>
+ * <p>
  * Whether a polygon ring is filled or is a hole in another polygon depends on the vertices winding order and the
  * winding rule used - see setWindingRule(String).
  *
@@ -47,10 +47,10 @@ public class SurfacePolygons extends SurfacePolylines // TODO: Review
 
     /**
      * Get a copy of the polygon ring groups array - can be null.
-     * <p/>
+     * <p>
      * When not null the polygon ring groups array identifies the starting sub buffer index for each polygon. In that
      * case rings from a same group will be tesselated together as part of the same polygon.
-     * <p/>
+     * <p>
      * When <code>null</code> polygon rings that follow the current winding rule are tessellated separatly as different
      * polygons. Rings that are reverse winded are considered holes to be applied to the last straight winded ring
      * polygon.
@@ -64,10 +64,10 @@ public class SurfacePolygons extends SurfacePolylines // TODO: Review
 
     /**
      * Set the polygon ring groups array - can be null.
-     * <p/>
+     * <p>
      * When not null the polygon ring groups array identifies the starting sub buffer index for each polygon. In that
      * case rings from a same group will be tesselated together as part of the same polygon.
-     * <p/>
+     * <p>
      * When <code>null</code> polygon rings that follow the current winding rule are tessellated separatly as different
      * polygons. Rings that are reverse winded are considered holes to be applied to the last straight winded ring
      * polygon.
@@ -83,7 +83,7 @@ public class SurfacePolygons extends SurfacePolylines // TODO: Review
     /**
      * Get the winding rule used when tessellating polygons. Can be one of {@link AVKey#CLOCKWISE} (default) or {@link
      * AVKey#COUNTER_CLOCKWISE}.
-     * <p/>
+     * <p>
      * When set to {@link AVKey#CLOCKWISE} polygons which run clockwise will be filled and those which run counter
      * clockwise will produce 'holes'. The interpretation is reversed when the winding rule is set to {@link
      * AVKey#COUNTER_CLOCKWISE}.
@@ -98,7 +98,7 @@ public class SurfacePolygons extends SurfacePolylines // TODO: Review
     /**
      * Set the winding rule used when tessellating polygons. Can be one of {@link AVKey#CLOCKWISE} (default) or {@link
      * AVKey#COUNTER_CLOCKWISE}.
-     * <p/>
+     * <p>
      * When set to {@link AVKey#CLOCKWISE} polygons which run clockwise will be filled and those which run counter
      * clockwise will produce 'holes'. The interpretation is reversed when the winding rule is set to {@link
      * AVKey#COUNTER_CLOCKWISE}.

--- a/src/gov/nasa/worldwind/render/SurfacePolyline.java
+++ b/src/gov/nasa/worldwind/render/SurfacePolyline.java
@@ -60,7 +60,7 @@ public class SurfacePolyline extends AbstractSurfaceShape implements Exportable
 
     /**
      * Constructs a new surface polyline with the default attributes and the specified iterable of locations.
-     * <p/>
+     * <p>
      * Note: If fewer than two locations is specified, no polyline is drawn.
      *
      * @param iterable the polyline locations.
@@ -83,7 +83,7 @@ public class SurfacePolyline extends AbstractSurfaceShape implements Exportable
      * Constructs a new surface polyline with the specified normal (as opposed to highlight) attributes and the
      * specified iterable of locations. Modifying the attribute reference after calling this constructor causes this
      * shape's appearance to change accordingly.
-     * <p/>
+     * <p>
      * Note: If fewer than two locations is specified, no polyline is drawn.
      *
      * @param normalAttrs the normal attributes. May be null, in which case default attributes are used.

--- a/src/gov/nasa/worldwind/render/SurfaceQuad.java
+++ b/src/gov/nasa/worldwind/render/SurfaceQuad.java
@@ -290,7 +290,7 @@ public class SurfaceQuad extends AbstractSurfaceShape implements Exportable
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to include the globe's state key in the returned state key.
      *
      * @see gov.nasa.worldwind.globes.Globe#getStateKey(DrawContext)

--- a/src/gov/nasa/worldwind/render/SurfaceRenderable.java
+++ b/src/gov/nasa/worldwind/render/SurfaceRenderable.java
@@ -24,7 +24,7 @@ public interface SurfaceRenderable extends Renderable
     /**
      * Returns a list of sectors indicating the geographic region that bounds this renderable for the specified draw
      * context.
-     * <p/>
+     * <p>
      * The returned list typically contains one sector that bounds this renderable in geographic coordinates. When this
      * renderable spans the anti-meridian - the +/- 180 degree meridian - the returned list contains two sectors, one on
      * either side of the anti-meridian.
@@ -37,7 +37,7 @@ public interface SurfaceRenderable extends Renderable
 
     /**
      * Returns an object that uniquely identifies this renderable's state for the specified draw context.
-     * <p/>
+     * <p>
      * Callers can perform an equality test on two state keys using {@link Object#equals(Object)} in order to determine
      * whether or not a renderable has changed. The returned object is guaranteed to be globally unique with respect to
      * other SurfaceRenderable state keys; an equality test with a state key from another renderable always returns

--- a/src/gov/nasa/worldwind/render/SurfaceShape.java
+++ b/src/gov/nasa/worldwind/render/SurfaceShape.java
@@ -13,7 +13,7 @@ import gov.nasa.worldwind.globes.Globe;
  * Common interface for surface conforming shapes such as {@link gov.nasa.worldwind.render.SurfacePolygon}, {@link
  * gov.nasa.worldwind.render.SurfacePolyline}, {@link gov.nasa.worldwind.render.SurfaceEllipse}, {@link
  * gov.nasa.worldwind.render.SurfaceQuad}, and {@link gov.nasa.worldwind.render.SurfaceSector}.
- * <p/>
+ * <p>
  * SurfaceShape extends the {@link gov.nasa.worldwind.render.SurfaceObject} interface, and inherits SurfaceObject's
  * batch rendering capabilities.
  *

--- a/src/gov/nasa/worldwind/render/SurfaceText.java
+++ b/src/gov/nasa/worldwind/render/SurfaceText.java
@@ -134,7 +134,7 @@ public class SurfaceText extends AbstractSurfaceObject implements GeographicText
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * The offset determines how the text is placed relative to this position. The default offset centers the text on
      * the position both horizontally and vertically.
      *
@@ -252,7 +252,7 @@ public class SurfaceText extends AbstractSurfaceObject implements GeographicText
      * Specifies a location relative to the label position at which to align the label. The label text begins at the
      * point indicated by the offset. An offset of (0, 0) aligns the left baseline of the text with the position. An
      * offset of (-0.5, -0.5) fraction aligns the center of the text with the position.
-     * <p/>
+     * <p>
      * A pixel based offset is interpreted based on the geographic size of the text. For example, if the text rendered
      * "normally" in two dimensions would be 20 pixels tall, and the geographic text is 100 meters tall, then each pixel
      * of text corresponds to 5 meters. So an offset of 2 pixels would correspond to a geographic offset of 10 meters.

--- a/src/gov/nasa/worldwind/render/TextRenderer.java
+++ b/src/gov/nasa/worldwind/render/TextRenderer.java
@@ -225,74 +225,64 @@ public class TextRenderer {
         this(font, false, false, null, false);
     }
 
-    /** Creates a new TextRenderer with the given font, using no
-        antialiasing or fractional metrics, and the default
-        RenderDelegate. If <CODE>mipmap</CODE> is true, attempts to use
-        OpenGL's automatic mipmap generation for better smoothing when
-        rendering the TextureRenderer's contents at a distance.
-        Equivalent to <code>TextRenderer(font, false, false)</code>.
-
-        @param font the font to render with
-        @param mipmap whether to attempt use of automatic mipmap generation
-    */
+    /**
+     * Creates a new TextRenderer with the given font, using no antialiasing or fractional metrics, and the default
+     * RenderDelegate. If <CODE>mipmap</CODE> is true, attempts to use OpenGL's automatic mipmap generation for better
+     * smoothing when rendering the TextureRenderer's contents at a distance. Equivalent to
+     * <code>TextRenderer(font, false, false)</code>.
+     *
+     * @param font the font to render with
+     * @param mipmap whether to attempt use of automatic mipmap generation
+     */
     public TextRenderer(Font font, boolean mipmap) {
         this(font, false, false, null, mipmap);
     }
 
-    /** Creates a new TextRenderer with the given Font, specified font
-        properties, and default RenderDelegate. The
-        <code>antialiased</code> and <code>useFractionalMetrics</code>
-        flags provide control over the same properties at the Java 2D
-        level. No mipmap support is requested. Equivalent to
-        <code>TextRenderer(font, antialiased, useFractionalMetrics,
-        null)</code>.
-
-        @param font the font to render with
-        @param antialiased whether to use antialiased fonts
-        @param useFractionalMetrics whether to use fractional font
-        metrics at the Java 2D level
-    */
+    /**
+     * Creates a new TextRenderer with the given Font, specified font properties, and default RenderDelegate. The
+     * <code>antialiased</code> and <code>useFractionalMetrics</code> flags provide control over the same properties at
+     * the Java 2D level. No mipmap support is requested. Equivalent to
+     * <code>TextRenderer(font, antialiased, useFractionalMetrics,
+     * null)</code>.
+     *
+     * @param font the font to render with
+     * @param antialiased whether to use antialiased fonts
+     * @param useFractionalMetrics whether to use fractional font metrics at the Java 2D level
+     */
     public TextRenderer(Font font, boolean antialiased,
                         boolean useFractionalMetrics) {
         this(font, antialiased, useFractionalMetrics, null, false);
     }
 
-    /** Creates a new TextRenderer with the given Font, specified font
-        properties, and given RenderDelegate. The
-        <code>antialiased</code> and <code>useFractionalMetrics</code>
-        flags provide control over the same properties at the Java 2D
-        level. The <code>renderDelegate</code> provides more control
-        over the text rendered. No mipmap support is requested.
-
-        @param font the font to render with
-        @param antialiased whether to use antialiased fonts
-        @param useFractionalMetrics whether to use fractional font
-        metrics at the Java 2D level
-        @param renderDelegate the render delegate to use to draw the
-        text's bitmap, or null to use the default one
-    */
+    /**
+     * Creates a new TextRenderer with the given Font, specified font properties, and given RenderDelegate. The
+     * <code>antialiased</code> and <code>useFractionalMetrics</code> flags provide control over the same properties at
+     * the Java 2D level. The <code>renderDelegate</code> provides more control over the text rendered. No mipmap
+     * support is requested.
+     *
+     * @param font the font to render with
+     * @param antialiased whether to use antialiased fonts
+     * @param useFractionalMetrics whether to use fractional font metrics at the Java 2D level
+     * @param renderDelegate the render delegate to use to draw the text's bitmap, or null to use the default one
+     */
     public TextRenderer(Font font, boolean antialiased,
                         boolean useFractionalMetrics, RenderDelegate renderDelegate) {
         this(font, antialiased, useFractionalMetrics, renderDelegate, false);
     }
 
-    /** Creates a new TextRenderer with the given Font, specified font
-        properties, and given RenderDelegate. The
-        <code>antialiased</code> and <code>useFractionalMetrics</code>
-        flags provide control over the same properties at the Java 2D
-        level. The <code>renderDelegate</code> provides more control
-        over the text rendered. If <CODE>mipmap</CODE> is true, attempts
-        to use OpenGL's automatic mipmap generation for better smoothing
-        when rendering the TextureRenderer's contents at a distance.
-
-        @param font the font to render with
-        @param antialiased whether to use antialiased fonts
-        @param useFractionalMetrics whether to use fractional font
-        metrics at the Java 2D level
-        @param renderDelegate the render delegate to use to draw the
-        text's bitmap, or null to use the default one
-        @param mipmap whether to attempt use of automatic mipmap generation
-    */
+    /**
+     * Creates a new TextRenderer with the given Font, specified font properties, and given RenderDelegate. The
+     * <code>antialiased</code> and <code>useFractionalMetrics</code> flags provide control over the same properties at
+     * the Java 2D level. The <code>renderDelegate</code> provides more control over the text rendered. If
+     * <CODE>mipmap</CODE> is true, attempts to use OpenGL's automatic mipmap generation for better smoothing when
+     * rendering the TextureRenderer's contents at a distance.
+     *
+     * @param font the font to render with
+     * @param antialiased whether to use antialiased fonts
+     * @param useFractionalMetrics whether to use fractional font metrics at the Java 2D level
+     * @param renderDelegate the render delegate to use to draw the text's bitmap, or null to use the default one
+     * @param mipmap whether to attempt use of automatic mipmap generation
+     */
     public TextRenderer(Font font, boolean antialiased,
                         boolean useFractionalMetrics, RenderDelegate renderDelegate,
                         boolean mipmap) {
@@ -314,28 +304,31 @@ public class TextRenderer {
         mGlyphProducer = new GlyphProducer(font.getNumGlyphs());
     }
 
-    /** Returns the bounding rectangle of the given String, assuming it
-        was rendered at the origin. See {@link #getBounds(CharSequence)
-        getBounds(CharSequence)}. */
+    /**
+     * Returns the bounding rectangle of the given String, assuming it was rendered at the origin. See {@link #getBounds(CharSequence)
+     * getBounds(CharSequence)}.
+     *
+     * @param str the string to evaluate.
+     * @return the bounding rectangle.
+     */
     public Rectangle2D getBounds(String str) {
         return getBounds((CharSequence) str);
     }
 
-    /** Returns the bounding rectangle of the given CharSequence,
-        assuming it was rendered at the origin. The coordinate system of
-        the returned rectangle is Java 2D's, with increasing Y
-        coordinates in the downward direction. The relative coordinate
-        (0, 0) in the returned rectangle corresponds to the baseline of
-        the leftmost character of the rendered string, in similar
-        fashion to the results returned by, for example, {@link
-        java.awt.font.GlyphVector#getVisualBounds}. Most applications
-        will use only the width and height of the returned Rectangle for
-        the purposes of centering or justifying the String. It is not
-        specified which Java 2D bounds ({@link
-        java.awt.font.GlyphVector#getVisualBounds getVisualBounds},
-        {@link java.awt.font.GlyphVector#getPixelBounds getPixelBounds},
-        etc.) the returned bounds correspond to, although every effort
-        is made to ensure an accurate bound. */
+    /**
+     * Returns the bounding rectangle of the given CharSequence, assuming it was rendered at the origin. The coordinate
+     * system of the returned rectangle is Java 2D's, with increasing Y coordinates in the downward direction. The
+     * relative coordinate (0, 0) in the returned rectangle corresponds to the baseline of the leftmost character of the
+     * rendered string, in similar fashion to the results returned by, for example, {@link
+     * java.awt.font.GlyphVector#getVisualBounds}. Most applications will use only the width and height of the returned
+     * Rectangle for the purposes of centering or justifying the String. It is not specified which Java 2D bounds ({@link
+     * java.awt.font.GlyphVector#getVisualBounds getVisualBounds},
+     * {@link java.awt.font.GlyphVector#getPixelBounds getPixelBounds}, etc.) the returned bounds correspond to,
+     * although every effort is made to ensure an accurate bound.
+     *
+     * @param str The character sequence to evaluate.
+     * @return The bounding rectangle.
+     */
     public Rectangle2D getBounds(CharSequence str) {
         // FIXME: this should be more optimized and use the glyph cache
         Rect r = stringLocations.get(str);
@@ -354,16 +347,23 @@ public class TextRenderer {
                                                   getFontRenderContext()));
     }
 
-    /** Returns the Font this renderer is using. */
+    /**
+     * Returns the Font this renderer is using.
+     *
+     * @return The font.
+     */
     public Font getFont() {
         return font;
     }
 
-    /** Returns a FontRenderContext which can be used for external
-        text-related size computations. This object should be considered
-        transient and may become invalidated between {@link
-        #beginRendering beginRendering} / {@link #endRendering
-        endRendering} pairs. */
+    /**
+     * Returns a FontRenderContext which can be used for external text-related size computations. This object should be
+     * considered transient and may become invalidated between {@link
+     * #beginRendering beginRendering} / {@link #endRendering
+     * endRendering} pairs.
+     *
+     * @return The font render context.
+     */
     public FontRenderContext getFontRenderContext() {
         if (cachedFontRenderContext == null) {
             cachedFontRenderContext = getGraphics2D().getFontRenderContext();
@@ -372,69 +372,60 @@ public class TextRenderer {
         return cachedFontRenderContext;
     }
 
-    /** Begins rendering with this {@link TextRenderer TextRenderer}
-        into the current OpenGL drawable, pushing the projection and
-        modelview matrices and some state bits and setting up a
-        two-dimensional orthographic projection with (0, 0) as the
-        lower-left coordinate and (width, height) as the upper-right
-        coordinate. Binds and enables the internal OpenGL texture
-        object, sets the texture environment mode to GL_MODULATE, and
-        changes the current color to the last color set with this
-        TextRenderer via {@link #setColor setColor}. This method
-        disables the depth test and is equivalent to
-        beginRendering(width, height, true).
-
-        @param width the width of the current on-screen OpenGL drawable
-        @param height the height of the current on-screen OpenGL drawable
-        @throws com.jogamp.opengl.GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Begins rendering with this {@link TextRenderer TextRenderer} into the current OpenGL drawable, pushing the
+     * projection and modelview matrices and some state bits and setting up a two-dimensional orthographic projection
+     * with (0, 0) as the lower-left coordinate and (width, height) as the upper-right coordinate. Binds and enables the
+     * internal OpenGL texture object, sets the texture environment mode to GL_MODULATE, and changes the current color
+     * to the last color set with this TextRenderer via {@link #setColor setColor}. This method disables the depth test
+     * and is equivalent to beginRendering(width, height, true).
+     *
+     * @param width the width of the current on-screen OpenGL drawable
+     * @param height the height of the current on-screen OpenGL drawable
+     * @throws com.jogamp.opengl.GLException If an OpenGL context is not current when this method is called
+     */
     public void beginRendering(int width, int height) throws GLException {
         beginRendering(width, height, true);
     }
 
-    /** Begins rendering with this {@link TextRenderer TextRenderer}
-        into the current OpenGL drawable, pushing the projection and
-        modelview matrices and some state bits and setting up a
-        two-dimensional orthographic projection with (0, 0) as the
-        lower-left coordinate and (width, height) as the upper-right
-        coordinate. Binds and enables the internal OpenGL texture
-        object, sets the texture environment mode to GL_MODULATE, and
-        changes the current color to the last color set with this
-        TextRenderer via {@link #setColor setColor}. Disables the depth
-        test if the disableDepthTest argument is true.
-
-        @param width the width of the current on-screen OpenGL drawable
-        @param height the height of the current on-screen OpenGL drawable
-        @param disableDepthTest whether to disable the depth test
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Begins rendering with this {@link TextRenderer TextRenderer} into the current OpenGL drawable, pushing the
+     * projection and modelview matrices and some state bits and setting up a two-dimensional orthographic projection
+     * with (0, 0) as the lower-left coordinate and (width, height) as the upper-right coordinate. Binds and enables the
+     * internal OpenGL texture object, sets the texture environment mode to GL_MODULATE, and changes the current color
+     * to the last color set with this TextRenderer via {@link #setColor setColor}. Disables the depth test if the
+     * disableDepthTest argument is true.
+     *
+     * @param width the width of the current on-screen OpenGL drawable
+     * @param height the height of the current on-screen OpenGL drawable
+     * @param disableDepthTest whether to disable the depth test
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void beginRendering(int width, int height, boolean disableDepthTest)
         throws GLException {
         beginRendering(true, width, height, disableDepthTest);
     }
 
-    /** Begins rendering of 2D text in 3D with this {@link TextRenderer
-        TextRenderer} into the current OpenGL drawable. Assumes the end
-        user is responsible for setting up the modelview and projection
-        matrices, and will render text using the {@link #draw3D draw3D}
-        method. This method pushes some OpenGL state bits, binds and
-        enables the internal OpenGL texture object, sets the texture
-        environment mode to GL_MODULATE, and changes the current color
-        to the last color set with this TextRenderer via {@link
-        #setColor setColor}.
-
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Begins rendering of 2D text in 3D with this {@link TextRenderer
+     * TextRenderer} into the current OpenGL drawable. Assumes the end user is responsible for setting up the modelview
+     * and projection matrices, and will render text using the {@link #draw3D draw3D} method. This method pushes some
+     * OpenGL state bits, binds and enables the internal OpenGL texture object, sets the texture environment mode to
+     * GL_MODULATE, and changes the current color to the last color set with this TextRenderer via {@link
+     * #setColor setColor}.
+     *
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void begin3DRendering() throws GLException {
         beginRendering(false, 0, 0, false);
     }
 
-    /** Changes the current color of this TextRenderer to the supplied
-        one. The default color is opaque white.
-
-        @param color the new color to use for rendering text
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Changes the current color of this TextRenderer to the supplied one. The default color is opaque white.
+     *
+     * @param color the new color to use for rendering text
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void setColor(Color color) throws GLException {
         boolean noNeedForFlush = (haveCachedColor && (cachedColor != null) &&
                                   color.equals(cachedColor));
@@ -448,21 +439,19 @@ public class TextRenderer {
         cachedColor = color;
     }
 
-    /** Changes the current color of this TextRenderer to the supplied
-        one, where each component ranges from 0.0f - 1.0f. The alpha
-        component, if used, does not need to be premultiplied into the
-        color channels as described in the documentation for {@link
-        com.jogamp.opengl.util.texture.Texture Texture}, although
-        premultiplied colors are used internally. The default color is
-        opaque white.
-
-        @param r the red component of the new color
-        @param g the green component of the new color
-        @param b the blue component of the new color
-        @param a the alpha component of the new color, 0.0f = completely
-        transparent, 1.0f = completely opaque
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Changes the current color of this TextRenderer to the supplied one, where each component ranges from 0.0f - 1.0f.
+     * The alpha component, if used, does not need to be premultiplied into the color channels as described in the
+     * documentation for {@link
+     * com.jogamp.opengl.util.texture.Texture Texture}, although premultiplied colors are used internally. The default
+     * color is opaque white.
+     *
+     * @param r the red component of the new color
+     * @param g the green component of the new color
+     * @param b the blue component of the new color
+     * @param a the alpha component of the new color, 0.0f = completely transparent, 1.0f = completely opaque
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void setColor(float r, float g, float b, float a)
         throws GLException {
         boolean noNeedForFlush = (haveCachedColor && (cachedColor == null) &&
@@ -482,93 +471,109 @@ public class TextRenderer {
         cachedColor = null;
     }
 
-    /** Draws the supplied CharSequence at the desired location using
-        the renderer's current color. The baseline of the leftmost
-        character is at position (x, y) specified in OpenGL coordinates,
-        where the origin is at the lower-left of the drawable and the Y
-        coordinate increases in the upward direction.
-
-        @param str the string to draw
-        @param x the x coordinate at which to draw
-        @param y the y coordinate at which to draw
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Draws the supplied CharSequence at the desired location using the renderer's current color. The baseline of the
+     * leftmost character is at position (x, y) specified in OpenGL coordinates, where the origin is at the lower-left
+     * of the drawable and the Y coordinate increases in the upward direction.
+     *
+     * @param str the string to draw
+     * @param x the x coordinate at which to draw
+     * @param y the y coordinate at which to draw
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void draw(CharSequence str, int x, int y) throws GLException {
         draw3D(str, x, y, 0, 1);
     }
 
-    /** Draws the supplied String at the desired location using the
-        renderer's current color. See {@link #draw(CharSequence, int,
-        int) draw(CharSequence, int, int)}. */
+    /**
+     * Draws the supplied String at the desired location using the renderer's current color. See {@link #draw(CharSequence, int,
+     * int) draw(CharSequence, int, int)}.
+     *
+     * @param str The string to draw.
+     * @param x The x coordinate at which to draw.
+     * @param y The y coordinate at which to draw.
+     */
     public void draw(String str, int x, int y) throws GLException {
         draw3D(str, x, y, 0, 1);
     }
 
-    /** Draws the supplied CharSequence at the desired 3D location using
-        the renderer's current color. The baseline of the leftmost
-        character is placed at position (x, y, z) in the current
-        coordinate system.
-
-        @param str the string to draw
-        @param x the x coordinate at which to draw
-        @param y the y coordinate at which to draw
-        @param z the z coordinate at which to draw
-        @param scaleFactor a uniform scale factor applied to the width and height of the drawn rectangle
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Draws the supplied CharSequence at the desired 3D location using the renderer's current color. The baseline of
+     * the leftmost character is placed at position (x, y, z) in the current coordinate system.
+     *
+     * @param str the string to draw
+     * @param x the x coordinate at which to draw
+     * @param y the y coordinate at which to draw
+     * @param z the z coordinate at which to draw
+     * @param scaleFactor a uniform scale factor applied to the width and height of the drawn rectangle
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void draw3D(CharSequence str, float x, float y, float z,
                        float scaleFactor) {
         internal_draw3D(str, x, y, z, scaleFactor);
     }
 
-    /** Draws the supplied String at the desired 3D location using the
-        renderer's current color. See {@link #draw3D(CharSequence,
-        float, float, float, float) draw3D(CharSequence, float, float,
-        float, float)}. */
+    /**
+     * Draws the supplied String at the desired 3D location using the renderer's current color. See {@link #draw3D(CharSequence,
+     * float, float, float, float) draw3D(CharSequence, float, float, float, float)}.
+     *
+     * @param str the string to draw
+     * @param x the x coordinate at which to draw
+     * @param y the y coordinate at which to draw
+     * @param z the z coordinate at which to draw
+     * @param scaleFactor a uniform scale factor applied to the width and height of the drawn rectangle
+     */
     public void draw3D(String str, float x, float y, float z, float scaleFactor) {
         internal_draw3D(str, x, y, z, scaleFactor);
     }
 
-    /** Returns the pixel width of the given character. */
+    /**
+     * Returns the pixel width of the given character.
+     *
+     * @param inChar the char to test
+     * @return the width
+     */
     public float getCharWidth(char inChar) {
         return mGlyphProducer.getGlyphPixelWidth(inChar);
     }
 
-    /** Causes the TextRenderer to flush any internal caches it may be
-        maintaining and draw its rendering results to the screen. This
-        should be called after each call to draw() if you are setting
-        OpenGL state such as the modelview matrix between calls to
-        draw(). */
+    /**
+     * Causes the TextRenderer to flush any internal caches it may be maintaining and draw its rendering results to the
+     * screen. This should be called after each call to draw() if you are setting OpenGL state such as the modelview
+     * matrix between calls to draw().
+     */
     public void flush() {
         flushGlyphPipeline();
     }
 
-    /** Ends a render cycle with this {@link TextRenderer TextRenderer}.
-        Restores the projection and modelview matrices as well as
-        several OpenGL state bits. Should be paired with {@link
-        #beginRendering beginRendering}.
-
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Ends a render cycle with this {@link TextRenderer TextRenderer}. Restores the projection and modelview matrices
+     * as well as several OpenGL state bits. Should be paired with {@link
+     * #beginRendering beginRendering}.
+     *
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void endRendering() throws GLException {
         endRendering(true);
     }
 
-    /** Ends a 3D render cycle with this {@link TextRenderer TextRenderer}.
-        Restores several OpenGL state bits. Should be paired with {@link
-        #begin3DRendering begin3DRendering}.
-
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Ends a 3D render cycle with this {@link TextRenderer TextRenderer}. Restores several OpenGL state bits. Should be
+     * paired with {@link
+     * #begin3DRendering begin3DRendering}.
+     *
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void end3DRendering() throws GLException {
         endRendering(false);
     }
 
-    /** Disposes of all resources this TextRenderer is using. It is not
-        valid to use the TextRenderer after this method is called.
-
-        @throws GLException If an OpenGL context is not current when this method is called
-    */
+    /**
+     * Disposes of all resources this TextRenderer is using. It is not valid to use the TextRenderer after this method
+     * is called.
+     *
+     * @throws GLException If an OpenGL context is not current when this method is called
+     */
     public void dispose() throws GLException {
         packer.dispose();
         packer = null;
@@ -711,8 +716,8 @@ public class TextRenderer {
      * emzic: here the call to glBindBuffer crashes on certain graphicscard/driver combinations
      * this is why the ugly try-catch block has been added, which falls back to the old textrenderer
      *
-     * @param ortho
-     * @throws GLException
+     * @param ortho the setting to apply.
+     * @throws GLException if an error occurs.
      */
     private void endRendering(boolean ortho) throws GLException {
         flushGlyphPipeline();
@@ -934,62 +939,82 @@ public class TextRenderer {
         debugged = true;
     }
 
-    /** Class supporting more full control over the process of rendering
-        the bitmapped text. Allows customization of whether the backing
-        store text bitmap is full-color or intensity only, the size of
-        each individual rendered text rectangle, and the contents of
-        each individual rendered text string. The default implementation
-        of this interface uses an intensity-only texture, a
-        closely-cropped rectangle around the text, and renders text
-        using the color white, which is modulated by the set color
-        during the rendering process. */
+    /**
+     * Class supporting more full control over the process of rendering the bitmapped text. Allows customization of
+     * whether the backing store text bitmap is full-color or intensity only, the size of each individual rendered text
+     * rectangle, and the contents of each individual rendered text string. The default implementation of this interface
+     * uses an intensity-only texture, a closely-cropped rectangle around the text, and renders text using the color
+     * white, which is modulated by the set color during the rendering process.
+     */
     public static interface RenderDelegate {
-        /** Indicates whether the backing store of this TextRenderer
-            should be intensity-only (the default) or full-color. */
+        /**
+         * Indicates whether the backing store of this TextRenderer should be intensity-only (the default) or
+         * full-color.
+         *
+         * @return the setting
+         */
         public boolean intensityOnly();
 
-        /** Computes the bounds of the given String relative to the
-            origin. */
+        /**
+         * Computes the bounds of the given String relative to the origin.
+         * @param str the string to evaluate.
+         * @param font the font.
+         * @param frc the font render context.
+         * @return the bounds of the string.
+         */
         public Rectangle2D getBounds(String str, Font font,
                                      FontRenderContext frc);
 
-        /** Computes the bounds of the given character sequence relative
-            to the origin. */
+        /**
+         * Computes the bounds of the given character sequence relative to the origin.
+         *
+         * @param str the string to evaluate.
+         * @param font the font.
+         * @param frc the font render context.
+         * @return the bounds of the string.
+         */
         public Rectangle2D getBounds(CharSequence str, Font font,
                                      FontRenderContext frc);
 
-        /** Computes the bounds of the given GlyphVector, already
-            assumed to have been created for a particular Font,
-            relative to the origin. */
+        /**
+         * Computes the bounds of the given GlyphVector, already assumed to have been created for a particular Font,
+         * relative to the origin.
+         * 
+         * @param gv the glyph vector to evaluate.
+         * @param frc the font render context.
+         * @return the bounding rectangle.
+         */
         public Rectangle2D getBounds(GlyphVector gv, FontRenderContext frc);
 
-        /** Render the passed character sequence at the designated
-            location using the supplied Graphics2D instance. The
-            surrounding region will already have been cleared to the RGB
-            color (0, 0, 0) with zero alpha. The initial drawing context
-            of the passed Graphics2D will be set to use
-            AlphaComposite.Src, the color white, the Font specified in the
-            TextRenderer's constructor, and the rendering hints specified
-            in the TextRenderer constructor.  Changes made by the end user
-            may be visible in successive calls to this method, but are not
-            guaranteed to be preserved.  Implementors of this method
-            should reset the Graphics2D's state to that desired each time
-            this method is called, in particular those states which are
-            not the defaults. */
+        /**
+         * Render the passed character sequence at the designated location using the supplied Graphics2D instance. The
+         * surrounding region will already have been cleared to the RGB color (0, 0, 0) with zero alpha. The initial
+         * drawing context of the passed Graphics2D will be set to use AlphaComposite.Src, the color white, the Font
+         * specified in the TextRenderer's constructor, and the rendering hints specified in the TextRenderer
+         * constructor. Changes made by the end user may be visible in successive calls to this method, but are not
+         * guaranteed to be preserved. Implementors of this method should reset the Graphics2D's state to that desired
+         * each time this method is called, in particular those states which are not the defaults.
+         * 
+         * @param graphics the graphics instance.
+         * @param str the string to draw.
+         * @param x the x coordinate at which to draw.
+         * @param y the y coordinate at which to draw.
+         */
         public void draw(Graphics2D graphics, String str, int x, int y);
 
-        /** Render the passed GlyphVector at the designated location using
-            the supplied Graphics2D instance. The surrounding region will
-            already have been cleared to the RGB color (0, 0, 0) with zero
-            alpha. The initial drawing context of the passed Graphics2D
-            will be set to use AlphaComposite.Src, the color white, the
-            Font specified in the TextRenderer's constructor, and the
-            rendering hints specified in the TextRenderer constructor.
-            Changes made by the end user may be visible in successive
-            calls to this method, but are not guaranteed to be preserved.
-            Implementors of this method should reset the Graphics2D's
-            state to that desired each time this method is called, in
-            particular those states which are not the defaults. */
+        /**
+         * Render the passed GlyphVector at the designated location using the supplied Graphics2D instance. The
+         * surrounding region will already have been cleared to the RGB color (0, 0, 0) with zero alpha. The initial
+         * drawing context of the passed Graphics2D will be set to use AlphaComposite.Src, the color white, the Font
+         * specified in the TextRenderer's constructor, and the rendering hints specified in the TextRenderer
+         * constructor. Changes made by the end user may be visible in successive calls to this method, but are not
+         * guaranteed to be preserved. Implementors of this method should reset the Graphics2D's state to that desired
+         * each time this method is called, in particular those states which are not the defaults.
+         * @param graphics the graphics instance.
+         * @param str the GlyphVector string to draw.
+         * @param x the x coordinate at which to draw.
+         * @param y the y coordinate at which to draw.
+         */
         public void drawGlyphVector(Graphics2D graphics, GlyphVector str,
                                     int x, int y);
     }
@@ -1971,30 +1996,32 @@ public class TextRenderer {
     }
 
     /**
-     * Sets whether vertex arrays are being used internally for
-     * rendering, or whether text is rendered using the OpenGL
-     * immediate mode commands. This is provided as a concession for
-     * certain graphics cards which have poor vertex array
+     * Sets whether vertex arrays are being used internally for rendering, or whether text is rendered using the OpenGL
+     * immediate mode commands. This is provided as a concession for certain graphics cards which have poor vertex array
      * performance. Defaults to true.
+     *
+     * @param useVertexArrays the setting to apply.
      */
     public void setUseVertexArrays(boolean useVertexArrays) {
         this.useVertexArrays = useVertexArrays;
     }
 
     /**
-     * Indicates whether vertex arrays are being used internally for
-     * rendering, or whether text is rendered using the OpenGL
-     * immediate mode commands. Defaults to true.
+     * Indicates whether vertex arrays are being used internally for rendering, or whether text is rendered using the
+     * OpenGL immediate mode commands. Defaults to true.
+     *
+     * @return the current setting.
      */
     public final boolean getUseVertexArrays() {
         return useVertexArrays;
     }
 
     /**
-     * Sets whether smoothing (i.e., GL_LINEAR filtering) is enabled
-     * in the backing TextureRenderer of this TextRenderer. A few
-     * graphics cards do not behave well when this is enabled,
-     * resulting in fuzzy text. Defaults to true.
+     * Sets whether smoothing (i.e., GL_LINEAR filtering) is enabled in the backing TextureRenderer of this
+     * TextRenderer. A few graphics cards do not behave well when this is enabled, resulting in fuzzy text. Defaults to
+     * true.
+     *
+     * @param smoothing the setting to apply.
      */
     public void setSmoothing(boolean smoothing) {
         this.smoothing = smoothing;
@@ -2002,10 +2029,10 @@ public class TextRenderer {
     }
 
     /**
-     * Indicates whether smoothing is enabled in the backing
-     * TextureRenderer of this TextRenderer. A few graphics cards do
-     * not behave well when this is enabled, resulting in fuzzy text.
-     * Defaults to true.
+     * Indicates whether smoothing is enabled in the backing TextureRenderer of this TextRenderer. A few graphics cards
+     * do not behave well when this is enabled, resulting in fuzzy text. Defaults to true.
+     *
+     * @return the current setting.
      */
     public boolean getSmoothing() {
         return smoothing;

--- a/src/gov/nasa/worldwind/render/WWIcon.java
+++ b/src/gov/nasa/worldwind/render/WWIcon.java
@@ -82,7 +82,7 @@ public interface WWIcon extends AVList, Restorable
     /**
      * Sets the desired screen size of the icon. When rendered, the icon is scaled to this size if it's specified. If a
      * screen size is not specified, the icon is displayed at the size of its source image.
-     * <p/>
+     * <p>
      * This size is not related to the icon's image source size. Whatever the source size is, it's scaled to display at
      * the specified screen size, if any.
      *

--- a/src/gov/nasa/worldwind/render/WWTexture.java
+++ b/src/gov/nasa/worldwind/render/WWTexture.java
@@ -10,7 +10,7 @@ import com.jogamp.opengl.util.texture.TextureCoords;
 
 /**
  * Represents a texture derived from an image source such as an image file or a {@link java.awt.image.BufferedImage}.
- * <p/>
+ * <p>
  * The interface contains a method, {@link #isTextureInitializationFailed()} to determine whether the instance failed to
  * convert an image source to a texture. If such a failure occurs, the method returns true and no further attempts are
  * made to create the texture.
@@ -29,10 +29,10 @@ public interface WWTexture
 
     /**
      * Makes this texture the current texture for rendering.
-     * <p/>
+     * <p>
      * If the implementing instance's internal texture has not been created from its image source, the implementing
      * class determines when the texture is retrieved and available.
-     * <p/>
+     * <p>
      * If a texture cannot be created from its image source it cannot be bound. This method returns an indication of
      * whether the texture was bound or was not bound due to a failure during creation.
      *

--- a/src/gov/nasa/worldwind/render/airspaces/AbstractAirspace.java
+++ b/src/gov/nasa/worldwind/render/airspaces/AbstractAirspace.java
@@ -647,6 +647,7 @@ public abstract class AbstractAirspace extends WWObjectImpl
      * Determines which attributes -- normal, highlight or default -- to use each frame. Places the result in this
      * shape's current active attributes.
      *
+     * @param dc the draw context.
      * @see #getActiveAttributes()
      */
     protected void determineActiveAttributes(DrawContext dc)

--- a/src/gov/nasa/worldwind/render/airspaces/Airspace.java
+++ b/src/gov/nasa/worldwind/render/airspaces/Airspace.java
@@ -207,17 +207,17 @@ public interface Airspace extends Renderable, Restorable, AVList, ExtentHolder, 
     /**
      * Sets the altitude datum, which indicates whether airspace altitudes are relative to mean sea level, ground level
      * or a single ground reference location.
-     * <p/>
+     * <p>
      * A value of {@link AVKey#ABOVE_MEAN_SEA_LEVEL}, the default for both lower and upper datums, indicates a datum of
      * mean sea level. The respective lower or upper surface of the airspace is drawn at the constant altitude specified
      * by {@link #setAltitude(double)}.
-     * <p/>
+     * <p>
      * A datum of {@link AVKey#ABOVE_GROUND_LEVEL} indicates that each position of the respective airspace surface is
      * offset vertically from the altitude specified to {@link #setAltitude(double)} by an amount equal to the terrain
      * elevation at that position. For example, if the specified lower altitude is zero, the lower surface lies on and
      * conforms to the terrain. If non-zero, the surface undulates in tandem with the terrain but relative to the
      * specified altitude.
-     * <p/>
+     * <p>
      * A datum of {@link AVKey#ABOVE_GROUND_REFERENCE} combines both of the above datums. It indicates that the
      * respective surface is drawn at the altitude specified to {@link #setAltitude(double)} but offset vertically by an
      * amount equal to the elevation at a single reference location on the ground. This is useful for displaying
@@ -273,7 +273,7 @@ public interface Airspace extends Renderable, Restorable, AVList, ExtentHolder, 
      *
      * @return true if batch rendering is enabled, otherwise false.
      *
-     * @see #setEnableBatchRendering(boolean).
+     * @see #setEnableBatchRendering(boolean)
      */
     boolean isEnableBatchRendering();
 
@@ -291,7 +291,7 @@ public interface Airspace extends Renderable, Restorable, AVList, ExtentHolder, 
      *
      * @return true if batch rendering is enabled, otherwise false.
      *
-     * @see #setEnableBatchPicking(boolean).
+     * @see #setEnableBatchPicking(boolean)
      */
     boolean isEnableBatchPicking();
 
@@ -300,7 +300,7 @@ public interface Airspace extends Renderable, Restorable, AVList, ExtentHolder, 
      * together if they are contained in the same layer. This increases performance but allows only the top-most of the
      * polygons to be reported in a {@link gov.nasa.worldwind.event.SelectEvent} even if several of the polygons are at
      * the pick position.
-     * <p/>
+     * <p>
      * Batch rendering ({@link #setEnableBatchRendering(boolean)}) must be enabled in order for batch picking to occur.
      *
      * @param enableBatchPicking true to enable batch rendering, otherwise false.
@@ -334,7 +334,7 @@ public interface Airspace extends Renderable, Restorable, AVList, ExtentHolder, 
     /**
      * Specifies the outline line width to use during picking. A larger width than normal typically makes the outline
      * easier to pick.
-     * <p/>
+     * <p>
      * Note that the size of the pick aperture also affects the precision necessary to pick.
      *
      * @param outlinePickWidth the outline pick width. The default is 10.

--- a/src/gov/nasa/worldwind/render/airspaces/BasicAirspaceAttributes.java
+++ b/src/gov/nasa/worldwind/render/airspaces/BasicAirspaceAttributes.java
@@ -26,8 +26,8 @@ public class BasicAirspaceAttributes extends BasicShapeAttributes implements Air
     /**
      * Creates a new BasicAirspaceAttributes with the default attributes. The default attributes differ from
      * BasicShapeAttributes, and are as follows:
-     * <p/>
-     * <table> <tr><th>Attribute</th><th>Default Value</th></tr> <tr><td>unresolved</td><td><code>true</code></td></tr>
+     * <table><caption>Attributes</caption>
+     * <tr><th>Attribute</th><th>Default Value</th></tr> <tr><td>unresolved</td><td><code>true</code></td></tr>
      * <tr><td>drawInterior</td><td><code>true</code></td></tr> <tr><td>drawOutline</td><td><code>false</code></td></tr>
      * <tr><td>enableAntialiasing</td><td><code>false</code></td></tr> <tr><td>enableLighting</td><td><code>true</code></td></tr>
      * <tr><td>interiorMaterial</td><td>{@link gov.nasa.worldwind.render.Material#WHITE}</td></tr>
@@ -50,15 +50,19 @@ public class BasicAirspaceAttributes extends BasicShapeAttributes implements Air
     /**
      * Creates a new BasicAirspaceAttributes with the specified interior material and interior opacity. All other
      * attributes are set to the default values, which differ from BasicShapeAttributes, and are as follows:
-     * <p/>
-     * <table> <tr><th>Attribute</th><th>Default Value</th></tr> <tr><td>unresolved</td><td><code>true</code></td></tr>
+     * <table><caption>Attributes</caption>
+     * <tr><th>Attribute</th><th>Default Value</th></tr> <tr><td>unresolved</td><td><code>true</code></td></tr>
      * <tr><td>drawInterior</td><td><code>true</code></td></tr> <tr><td>drawOutline</td><td><code>false</code></td></tr>
-     * <tr><td>enableAntialiasing</td><td><code>false</code></td></tr> <tr><td>enableLighting</td><td><code>true</code></td></tr>
+     * <tr><td>enableAntialiasing</td><td><code>false</code></td></tr>
+     * <tr><td>enableLighting</td><td><code>true</code></td></tr>
      * <tr><td>interiorMaterial</td><td>material</td></tr> <tr><td>outlineMaterial</td><td>{@link
      * gov.nasa.worldwind.render.Material#BLACK}</td></tr> <tr><td>interiorOpacity</td><td>opacity</td></tr>
      * <tr><td>outlineOpacity</td><td>1.0</td></tr> <tr><td>outlineWidth</td><td>1.0</td></tr>
      * <tr><td>outlineStippleFactor</td><td>0</td></tr> <tr><td>outlineStipplePattern</td><td>0xF0F0</td></tr>
      * <tr><td>imageSource</td><td><code>null</code></td></tr> <tr><td>imageScale</td><td>1.0</td></tr> </table>
+     *
+     * @param material the specified material
+     * @param opacity the interior opacity
      */
     public BasicAirspaceAttributes(Material material, double opacity)
     {

--- a/src/gov/nasa/worldwind/render/airspaces/Box.java
+++ b/src/gov/nasa/worldwind/render/airspaces/Box.java
@@ -219,6 +219,10 @@ public class Box extends AbstractAirspace
     /**
      * Specifies the azimuth angles for this box's four corners, relative to geographic north. Specifying a null
      * argument indicates that the default angle should be used.
+     * @param beginLeftAzimuth the beginning left angle.
+     * @param beginRightAzimuth the beginning right angle.
+     * @param endLeftAzimuth the ending left angle.
+     * @param endRightAzimuth the ending right angle.
      */
     public void setCornerAzimuths(Angle beginLeftAzimuth, Angle beginRightAzimuth, Angle endLeftAzimuth,
         Angle endRightAzimuth)

--- a/src/gov/nasa/worldwind/render/airspaces/TrackAirspace.java
+++ b/src/gov/nasa/worldwind/render/airspaces/TrackAirspace.java
@@ -185,7 +185,7 @@ public class TrackAirspace extends AbstractAirspace
     /**
      * Specifies the threshold that defines whether the angle between two adjacent legs is small. This threshold is used
      * to determine the best method for adjusting the vertices of adjacent legs.
-     * <p/>
+     * <p>
      * When the angle between adjacent legs is small, the standard method of joining the leg's vertices forms a very
      * large peak pointing away from the leg's common point. In this case <code>TrackAirspace</code> uses a method that
      * avoids this peak and produces a seamless transition between the adjacent legs.
@@ -473,7 +473,7 @@ public class TrackAirspace extends AbstractAirspace
      * the second. <code>leg1</code> must precede <code>leg2</code>, and they must share a common location at the end of
      * <code>leg1</code> and the beginning of <code>leg2</code>. Without joining the adjacent edges, the geometry of the
      * two adjacent boxes contains a gap on one side and an intersection on the other.
-     * <p/>
+     * <p>
      * This has no effect if the legs cannot be joined for any reason.
      *
      * @param leg1  the first leg.

--- a/src/gov/nasa/worldwind/retrieve/AbstractRetrievalPostProcessor.java
+++ b/src/gov/nasa/worldwind/retrieve/AbstractRetrievalPostProcessor.java
@@ -19,7 +19,7 @@ import java.nio.channels.ClosedByInterruptException;
 /**
  * Abstract base class for retrieval post-processors. Verifies the retrieval operation and dispatches the content to the
  * a subclasses content handlers.
- * <p/>
+ * <p>
  * Subclasses are expected to override the methods necessary to handle their particular post-processing operations.
  *
  * @author Tom Gaskins
@@ -201,7 +201,7 @@ public abstract class AbstractRetrievalPostProcessor implements RetrievalPostPro
 
     /**
      * Saves the retrieved and possibly transformed data. The data may have been transformed during content handling.
-     * <p/>
+     * <p>
      * The default implementation of this method simply calls {@link #saveBuffer(java.nio.ByteBuffer)} with an argument
      * of null.
      *
@@ -517,7 +517,7 @@ public abstract class AbstractRetrievalPostProcessor implements RetrievalPostPro
     /**
      * Handles image content. The default implementation simply saves the retrieved data via {@link #saveBuffer()},
      * first converting it to DDS if the suffix of the output file is .dds.
-     * <p/>
+     * <p>
      * The default implementation of this method returns immediately if the output file cannot be determined or it
      * exists and {@link #overwriteExistingFile()} returns false.
      *

--- a/src/gov/nasa/worldwind/retrieve/BulkRetrievalThread.java
+++ b/src/gov/nasa/worldwind/retrieve/BulkRetrievalThread.java
@@ -33,10 +33,10 @@ public abstract class BulkRetrievalThread extends Thread
     /**
      * Construct a thread that attempts to download to a specified {@link FileStore} a retrievable's data for a given
      * {@link Sector} and resolution.
-     * <p/>
+     * <p>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link gov.nasa.worldwind.terrain.BasicElevationModelBulkDownloader}.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *

--- a/src/gov/nasa/worldwind/retrieve/JarRetriever.java
+++ b/src/gov/nasa/worldwind/retrieve/JarRetriever.java
@@ -13,7 +13,7 @@ import java.nio.ByteBuffer;
 import java.util.logging.Level;
 
 /**
- * Retrieves resources identified by a jar url, which has the form jar:<url>!/{entry}, as in:
+ * Retrieves resources identified by a jar url, which has the form {@code jar:<url>!/{entry}}, as in:
  * jar:http://www.foo.com/bar/baz.jar!/COM/foo/Quux.class. See {@link java.net.JarURLConnection} for a full description
  * of jar URLs.
  *

--- a/src/gov/nasa/worldwind/retrieve/URLRetriever.java
+++ b/src/gov/nasa/worldwind/retrieve/URLRetriever.java
@@ -548,7 +548,7 @@ public abstract class URLRetriever extends WWObjectImpl implements Retriever
      * Indicates the expiration time specified by either the Expires header or the max-age directive of the
      * Cache-Control header. If both are present, then Cache-Control is given priority (See section 14.9.3 of the HTTP
      * Specification: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
-     * <p/>
+     * <p>
      * If both the Expires and Date headers are present then the expiration time is calculated as current time +
      * (expires - date). This helps guard against clock skew between the client and server.
      *

--- a/src/gov/nasa/worldwind/symbology/AbstractIconRetriever.java
+++ b/src/gov/nasa/worldwind/symbology/AbstractIconRetriever.java
@@ -16,24 +16,23 @@ import java.net.URL;
 
 /**
  * Base class for icon retrievers. This class provides methods for loading and manipulating icons.
- * <p/>
  * <h2>Icon retrieval</h2>
- * <p/>
+ * <p>
  * Each symbol in a symbology set must have a unique identifier. The IconRetriever's job is to create a BufferedImage to
  * represent a symbol given the symbol identifier. Usually this means retrieving an image from the file system or the
  * network, and optionally manipulating the symbol (for example, changing the color to represent a hostile or friendly
  * entity).
- * <p/>
+ * <p>
  * Each instance of AbstractIconRetriever is configured with a retrieval path which specifies the location of a symbol
  * repository on the file system or the network. {@link #readImage(String) readImage} retrieves images relative to this
  * base path. The retrieval path may be a file URL to a directory on the local file system (for example,
  * file:///symbols/mil-std-2525). A URL to a network resource (http://myserver.com/milstd2525/), or a URL to a JAR or
  * ZIP file (jar:file:milstd2525-symbols.zip!).
- * <p/>
+ * <p>
  * A simple icon retriever might use a symbol repository that is a simple directory of PNG files, where each file name
  * matches a symbol identifier. Such an icon retriever could be implemented like this:
- * <p/>
  * <pre>
+ * {@code 
  * class SimpleIconRetriever extends AbstractIconRetriever
  * {
  *     public BufferedImage createIcon(String symbolId)
@@ -42,15 +41,16 @@ import java.net.URL;
  *         return this.readImage(symbolId + ".png");
  *     }
  * }
+ * }
  * </pre>
- * <p/>
  * <h2>Composite icons</h2>
- * <p/>
+ * <p>
  * Complicated symbols may be made up of several different graphical elements. {@link
  * #drawImage(java.awt.image.BufferedImage, java.awt.image.BufferedImage) drawImage} helps build a complex symbol from
  * simple pieces. For example, if a symbol is composed of a frame and an icon, the icon retriever could load the frame
  * and icon independently, draw the icon over the frame, and return the composite image:
  * <pre>
+ * {@code 
  * // Load the frame and icon as separate pieces.
  * BufferedImage frame = this.readImage("path/to/frame.png");
  * BufferedImage icon = this.readImage("path/to/icon.png");
@@ -60,10 +60,10 @@ import java.net.URL;
  *
  * // Return the composite image.
  * return fullImage;
+ * }
  * </pre>
- * <p/>
  * <h2>Changing the color of an icon</h2>
- * <p/>
+ * <p>
  * {@link #multiply(java.awt.image.BufferedImage, java.awt.Color) multiply} can change the color of an image by
  * multiplying each pixel in the image by a color. The multiplication color will replace any white pixels and black
  * pixels will be unaffected. For example, a symbol set in which hostile symbols are drawn in red and friendly symbols

--- a/src/gov/nasa/worldwind/symbology/AbstractTacticalGraphic.java
+++ b/src/gov/nasa/worldwind/symbology/AbstractTacticalGraphic.java
@@ -18,11 +18,11 @@ import java.util.*;
 import java.util.List;
 
 /**
- * Base class for tactical graphics. See the TacticalGraphic <a title="Tactical Graphic Usage Guide"
- * href="https://goworldwind.org/developers-guide/symbology/tactical-graphics/" target="_blank">Usage Guide</a> for
+ * Base class for tactical graphics. See the TacticalGraphic
+ * <a href="https://goworldwind.org/developers-guide/symbology/tactical-graphics/" target="_blank">Usage Guide</a> for
  * instructions on using TacticalGraphic in an application. This base class provides functionality for creating and
  * rendering a graphic that is made up of one or more shapes, and text labels.
- * <p/>
+ * <p>
  * Implementations must implement at least {@link #doRenderGraphic(gov.nasa.worldwind.render.DrawContext)
  * doRenderGraphic} and {@link #applyDelegateOwner(Object)}.
  *

--- a/src/gov/nasa/worldwind/symbology/AbstractTacticalSymbol.java
+++ b/src/gov/nasa/worldwind/symbology/AbstractTacticalSymbol.java
@@ -1866,6 +1866,7 @@ public abstract class AbstractTacticalSymbol extends WWObjectImpl implements Tac
      * prevent the text from overlapping if the symbol is scaled to a very small size.
      *
      * @param dc Current draw context.
+     * @param modifiers The text modifiers.
      *
      * @return Minimum dimension for the label layout rectangle.
      */

--- a/src/gov/nasa/worldwind/symbology/SymbologyConstants.java
+++ b/src/gov/nasa/worldwind/symbology/SymbologyConstants.java
@@ -37,14 +37,16 @@ public interface SymbologyConstants
      * associated with a MIL-STD-2525 symbol (SIDC positions 11-12). A symbol's auxiliary equipment is currently used to
      * define towed sonar arrays. See MIL-STD-2525C section 5.3.4.4 (page 27) and table VII (page 28). When used as a
      * key, the corresponding value must be one of the following:
-     * <p/>
-     * <ul> <li>AUXILIARY_EQUIPMENT_TOWED_SONAR_ARRAY_SHORT</li> <li>AUXILIARY_EQUIPMENT_TOWED_SONAR_ARRAY_LONG</li>
+     * <ul> 
+     * <li>AUXILIARY_EQUIPMENT_TOWED_SONAR_ARRAY_SHORT</li> 
+     * <li>AUXILIARY_EQUIPMENT_TOWED_SONAR_ARRAY_LONG</li>
      * </ul>
-     * <p/>
+     * <p>
      * The auxiliary equipment codes are the same for all symbology schemes that use them, and are defined in each
      * appendix of the MIL-STD-2525C specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> 
+     * </ul>
      */
     final String AUXILIARY_EQUIPMENT = "AG";
     /**
@@ -75,16 +77,22 @@ public interface SymbologyConstants
      * dimension defines the primary mission area for the object being represented. See MIL-STD-2525C section 5.3.1.3
      * (page 17), table I (page 15) and table II (page 16). When used as a key, the corresponding value must be one of
      * the following:
-     * <p/>
-     * <ul> <li>BATTLE_DIMENSION_SPACE</li> <li>BATTLE_DIMENSION_AIR</li> <li>BATTLE_DIMENSION_GROUND</li>
-     * <li>BATTLE_DIMENSION_SEA_SURFACE</li> <li>BATTLE_DIMENSION_SEA_SUBSURFACE</li> <li>BATTLE_DIMENSION_SOF</li>
-     * <li>BATTLE_DIMENSION_OTHER</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>BATTLE_DIMENSION_SPACE</li> 
+     * <li>BATTLE_DIMENSION_AIR</li> 
+     * <li>BATTLE_DIMENSION_GROUND</li>
+     * <li>BATTLE_DIMENSION_SEA_SURFACE</li> 
+     * <li>BATTLE_DIMENSION_SEA_SUBSURFACE</li> 
+     * <li>BATTLE_DIMENSION_SOF</li>
+     * <li>BATTLE_DIMENSION_OTHER</li> 
+     * </ul>
+     * <p>
      * The battle dimension codes are the same for all symbology schemes that use them, and are defined in each appendix
      * of the MIL-STD-2525C specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.c (page 51) and table A-I (page 51)</li> <li>Signals Intelligence -
-     * section D.5.2.1.c (page 963) and table D-I (page 964)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.c (page 51) and table A-I (page 51)</li> 
+     * <li>Signals Intelligence - section D.5.2.1.c (page 963) and table D-I (page 964)</li> 
+     * </ul>
      */
     final String BATTLE_DIMENSION = "gov.nasa.worldwind.symbology.BattleDimension";
     /**
@@ -154,24 +162,37 @@ public interface SymbologyConstants
      * Indicates the category code associated with a MIL-STD-2525 symbol (SIDC position 3). The meaning of a symbol's
      * category and the recognized values depend on the specific MIL-STD-2525 symbology scheme the symbol belongs to,
      * and are defined in each appendix of the MIL-STD-2525C specification:
-     * <p/>
-     * <strong>Tactical Graphics</strong> <br/> See MIL-STD-2525C section B5.2.1.c (page 304) and table B-I (page 305).
-     * <p/>
-     * <ul> <li>CATEGORY_TASKS</li> <li>CATEGORY_COMMAND_CONTROL_GENERAL_MANEUVER</li>
-     * <li>CATEGORY_MOBILITY_SURVIVABILITY</li> <li>CATEGORY_FIRE_SUPPORT</li> <li>CATEGORY_COMBAT_SERVICE_SUPPORT</li>
-     * <li>CATEGORY_OTHER</li> </ul>
-     * <p/>
-     * <strong>Stability Operations</strong> <br/> See MIL-STD-2525C section E5.2.1.c (page 991) and table E-I (page
-     * 991).
-     * <p/>
-     * <ul> <li>CATEGORY_VIOLENT_ACTIVITIES</li> <li>CATEGORY_LOCATIONS</li> <li>CATEGORY_OPERATIONS</li>
-     * <li>CATEGORY_ITEMS</li> <li>CATEGORY_INDIVIDUAL</li> <li>CATEGORY_NONMILITARY_GROUP_ORGANIZATION</li>
-     * <li>CATEGORY_RAPE</li> </ul>
-     * <p/>
-     * <strong>Emergency Management</strong> <br/> See MIL-STD-2525C table G-I (page 1032).
-     * <p/>
-     * <ul> <li>CATEGORY_INCIDENT</li> <li>CATEGORY_NATURAL_EVENTS</li> <li>CATEGORY_OPERATIONS</li>
-     * <li>CATEGORY_INFRASTRUCTURE</li> </ul>
+     * <p>
+     * <strong>Tactical Graphics</strong> <br> 
+     * See MIL-STD-2525C section B5.2.1.c (page 304) and table B-I (page 305).
+     * <ul> 
+     * <li>CATEGORY_TASKS</li> 
+     * <li>CATEGORY_COMMAND_CONTROL_GENERAL_MANEUVER</li>
+     * <li>CATEGORY_MOBILITY_SURVIVABILITY</li> 
+     * <li>CATEGORY_FIRE_SUPPORT</li> 
+     * <li>CATEGORY_COMBAT_SERVICE_SUPPORT</li>
+     * <li>CATEGORY_OTHER</li> 
+     * </ul>
+     * <p>
+     * <strong>Stability Operations</strong> <br> 
+     * See MIL-STD-2525C section E5.2.1.c (page 991) and table E-I (page 991).
+     * <ul> 
+     * <li>CATEGORY_VIOLENT_ACTIVITIES</li> 
+     * <li>CATEGORY_LOCATIONS</li> 
+     * <li>CATEGORY_OPERATIONS</li>
+     * <li>CATEGORY_ITEMS</li> 
+     * <li>CATEGORY_INDIVIDUAL</li> 
+     * <li>CATEGORY_NONMILITARY_GROUP_ORGANIZATION</li>
+     * <li>CATEGORY_RAPE</li> 
+     * </ul>
+     * <p>
+     * <strong>Emergency Management</strong> <br> See MIL-STD-2525C table G-I (page 1032).
+     * <ul> 
+     * <li>CATEGORY_INCIDENT</li> 
+     * <li>CATEGORY_NATURAL_EVENTS</li> 
+     * <li>CATEGORY_OPERATIONS</li>
+     * <li>CATEGORY_INFRASTRUCTURE</li> 
+     * </ul>
      */
     final String CATEGORY = "gov.nasa.worldwind.symbology.Category";
     /**
@@ -299,11 +320,13 @@ public interface SymbologyConstants
      * Indicates the country code associated with a MIL-STD-2525 symbol (SIDC positions 13-14). See <a
      * href="http://www.iso.org/iso/country_codes.htm" target="_blank">ISO 3166-1</a> for a definition of valid country
      * codes. The country codes are the same for all symbology schemes that use them:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.g and table A-I (page 51)</li> <li>Tactical Graphics - section B.5.2.1.g
-     * (page 304) and table B-I (page 305)</li> <li>Signals Intelligence - section D.5.2.1.g and table D-I (page
-     * 964)</li> <li>Stability Operations - section E.5.2.1.g and table E-I (page 991)</li> <li>Emergency Management -
-     * table G-I (page 1032)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.g and table A-I (page 51)</li> 
+     * <li>Tactical Graphics - section B.5.2.1.g (page 304) and table B-I (page 305)</li> 
+     * <li>Signals Intelligence - section D.5.2.1.g and table D-I (page 964)</li> 
+     * <li>Stability Operations - section E.5.2.1.g and table E-I (page 991)</li> 
+     * <li>Emergency Management - table G-I (page 1032)</li> 
+     * </ul>
      */
     final String COUNTRY_CODE = "gov.nasa.worldwind.symbology.CountryCode";
 
@@ -333,18 +356,30 @@ public interface SymbologyConstants
      * (SIDC position 12). A symbol's echelon defines the command level of a unit represented by the symbol. See
      * MIL-STD-2525 section 5.3.4.2 (page 25), section 5.5.2.2 (page 40), and table V (pages 25-26). When used as a key,
      * the corresponding value must be one of the following:
-     * <p/>
-     * <ul> <li>ECHELON_TEAM_CREW</li> <li>ECHELON_SQUAD</li> <li>ECHELON_SECTION</li>
-     * <li>ECHELON_PLATOON_DETACHMENT</li> <li>ECHELON_COMPANY_BATTERY_TROOP</li> <li>ECHELON_BATTALION_SQUADRON</li>
-     * <li>ECHELON_REGIMENT_GROUP</li> <li>ECHELON_BRIGADE</li> <li>ECHELON_DIVISION</li> <li>ECHELON_CORPS</li>
-     * <li>ECHELON_ARMY</li> <li>ECHELON_ARMY_GROUP_FRONT</li> <li>ECHELON_REGION</li> <li>ECHELON_COMMAND</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>ECHELON_TEAM_CREW</li> 
+     * <li>ECHELON_SQUAD</li> 
+     * <li>ECHELON_SECTION</li>
+     * <li>ECHELON_PLATOON_DETACHMENT</li> 
+     * <li>ECHELON_COMPANY_BATTERY_TROOP</li> 
+     * <li>ECHELON_BATTALION_SQUADRON</li>
+     * <li>ECHELON_REGIMENT_GROUP</li> 
+     * <li>ECHELON_BRIGADE</li> 
+     * <li>ECHELON_DIVISION</li> 
+     * <li>ECHELON_CORPS</li>
+     * <li>ECHELON_ARMY</li> 
+     * <li>ECHELON_ARMY_GROUP_FRONT</li> 
+     * <li>ECHELON_REGION</li> 
+     * <li>ECHELON_COMMAND</li> 
+     * </ul>
+     * <p>
      * The echelon codes are the same for all symbology schemes that use them, and are defined in each appendix of the
      * MIL-STD-2525C specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> <li>Tactical Graphics -
-     * section B.5.2.1.f (page 304) and table B-II (page 305)</li> <li>Stability Operations - section E.5.2.1.f (page
-     * 991) and table E-II (pages 992-994)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> 
+     * <li>Tactical Graphics - section B.5.2.1.f (page 304) and table B-II (page 305)</li> 
+     * <li>Stability Operations - section E.5.2.1.f (page 991) and table E-II (pages 992-994)</li> 
+     * </ul>
      */
     final String ECHELON = "B";
     /**
@@ -439,15 +474,27 @@ public interface SymbologyConstants
      * The MIL-STD-2525 Evaluation Rating modifier field ID. Indicates the reliability and credibility of a unit,
      * equipment, or installation. When used as a key, the corresponding value must be a string containing two
      * characters.
-     * <p/>
-     * The first character indicates the reliability rating, and must be one of the following: <ul> <li>"A" - completely
-     * reliable</li> <li>"B" - usually reliable</li> <li>"C" - fairly reliable</li> <li>"D" - not usually reliable</li>
-     * <li>"E" - unreliable</li> <li>"F" - reliability cannot be judged</li> </ul>
-     * <p/>
-     * The second character indicates the credibility rating, and must be one of the following: <ul> <li>"1" - confirmed
-     * by other sources</li> <li>"2" - probably true</li> <li>"3" - possibly true</li> <li>"4" - doubtfully true</li>
-     * <li>"5" - improbable</li> <li>"6" - truth cannot be judged</li> </ul>
-     * <p/>
+     * <p>
+     * The first character indicates the reliability rating, and must be one of the following:
+     * <ul> 
+     * <li>"A" - completely reliable</li> 
+     * <li>"B" - usually reliable</li> 
+     * <li>"C" - fairly reliable</li> 
+     * <li>"D" - not usually reliable</li>
+     * <li>"E" - unreliable</li> 
+     * <li>"F" - reliability cannot be judged</li> 
+     * </ul>
+     * <p>
+     * The second character indicates the credibility rating, and must be one of the following: 
+     * <ul> 
+     * <li>"1" - confirmed by other sources</li> 
+     * <li>"2" - probably true</li> 
+     * <li>"3" - possibly true</li> 
+     * <li>"4" - doubtfully true</li>
+     * <li>"5" - improbable</li> 
+     * <li>"6" - truth cannot be judged</li> 
+     * </ul>
+     * <p>
      * See FM 34-3, Intelligence Analysis, March 1990, pages 2-13 through 2-17 for complete definitions of evaluation
      * ratings.
      */
@@ -460,11 +507,12 @@ public interface SymbologyConstants
      * changed to include a dashed inverted "V" above its frame. See MIL-STD-2525 section 5.3.4.7 (page 28). When used
      * as a key, the corresponding value must be a boolean value. The value is <code>true</code> if the symbol's
      * represented object is a feint/dummy, and <code>false</code> otherwise.
-     * <p/>
+     * <p>
      * The following symbology schemes support the feint/dummy modifier:
-     * <p/>
-     * <ul> <li>Warfighting</li> <li>Stability Operations</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>Warfighting</li> 
+     * <li>Stability Operations</li> 
+     * </ul>
      */
     final String FEINT_DUMMY = "AB";
 
@@ -485,21 +533,25 @@ public interface SymbologyConstants
      * Indicates the function ID associated with a MIL-STD-2525 symbol (SIDC positions 5-10). The function IDs are
      * unique to each symbology schemes that uses them, and are defined in each appendix of the MIL-STD-2525C
      * specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.e (page 51) and table A-I (page 51)</li> <li>Tactical Graphics - section
-     * B.5.2.1.e (page 304) and table B-I (page 305)</li> <li>Meteorological and Oceanographic - section C.5.2.1.d (page
-     * 763) and table C-I (page 763)</li> <li>Signals Intelligence - section D.5.2.1.e (page 964) and table D-I (page
-     * 964)</li> <li>Stability Operations - section E.5.2.1.e (page 991) and table E-I (page 991)</li> <li>Emergency
-     * Management - table G-I (page 1032)</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.e (page 51) and table A-I (page 51)</li> 
+     * <li>Tactical Graphics - section B.5.2.1.e (page 304) and table B-I (page 305)</li> 
+     * <li>Meteorological and Oceanographic - section C.5.2.1.d (page 763) and table C-I (page 763)</li> 
+     * <li>Signals Intelligence - section D.5.2.1.e (page 964) and table D-I (page 964)</li> 
+     * <li>Stability Operations - section E.5.2.1.e (page 991) and table E-I (page 991)</li> 
+     * <li>Emergency Management - table G-I (page 1032)</li> 
+     * </ul>
      */
     final String FUNCTION_ID = "gov.nasa.worldwind.symbology.FunctionId";
 
     /**
      * Indicates the type of a graphic in the Meteorological and Oceanographic scheme (SIDC positions 11-13). When used
      * as a key, the corresponding value must be one of the following:
-     * <p/>
-     * <ul> <li>GRAPHIC_TYPE_POINT</li> <li>GRAPHIC_TYPE_LINE</li> <li>GRAPHIC_TYPE_AREA</li> </ul>
+     * <ul> 
+     * <li>GRAPHIC_TYPE_POINT</li> 
+     * <li>GRAPHIC_TYPE_LINE</li> 
+     * <li>GRAPHIC_TYPE_AREA</li> 
+     * </ul>
      */
     final String GRAPHIC_TYPE = "gov.nasa.worldwind.symbology.GraphicType";
     /** The MIL-STD-2525 Point type, used by symbols belonging to the METOC scheme. */
@@ -521,10 +573,12 @@ public interface SymbologyConstants
      * downward from the left side of its frame. See MIL-STD-2525 section 5.3.4.8 (page 29). When used as a key, the
      * corresponding value must be a boolean value. The value is <code>true</code> if the symbol's represented object is
      * a headquarters, and <code>false</code> otherwise.
-     * <p/>
+     * <p>
      * The following symbology schemes support the headquarters modifier:
-     * <p/>
-     * <ul> <li>Warfighting</li> <li>Stability Operations</li> </ul>
+     * <ul> 
+     * <li>Warfighting</li> 
+     * <li>Stability Operations</li> 
+     * </ul>
      */
     final String HEADQUARTERS = "S";
 
@@ -558,15 +612,18 @@ public interface SymbologyConstants
      * symbol (SIDC positions 11-12). When a marked as an installation, a symbol's represented object is a military camp
      * or base. See MIL-STD-2525 section 5.3.4.5 (page 28). When used as a key, the corresponding value must be one of
      * the following:
-     * <p/>
-     * <ul> <li>INSTALLATION_NORMAL</li> <li>INSTALLATION_FEINT_DUMMY</li>  </ul>
-     * <p/>
+     * <ul> 
+     * <li>INSTALLATION_NORMAL</li> 
+     * <li>INSTALLATION_FEINT_DUMMY</li>
+     * </ul>
+     * <p>
      * The installation codes are the same for all symbology schemes that use them, and are defined in each appendix of
      * the MIL-STD-2525C specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> <li>Stability Operations -
-     * section E.5.2.1.f (page 991) and table E-II (pages 992-994)</li> <li>Emergency Management - section G.5.5.5 (page
-     * 1030) and table G-II (page 1032)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> 
+     * <li>Stability Operations - section E.5.2.1.f (page 991) and table E-II (pages 992-994)</li> 
+     * <li>Emergency Management - section G.5.5.5 (page 1030) and table G-II (page 1032)</li> 
+     * </ul>
      */
     final String INSTALLATION = "AC";
     /**
@@ -595,17 +652,26 @@ public interface SymbologyConstants
      * object, other than mobility intrinsic to the represented object. Mobility codes are currently used only to
      * describe mobility features of equipment. See MIL-STD-2525 section 5.3.4.3 (page 26) and table VI (pages 26-27).
      * When used as a key, the corresponding value must be one of the following:
-     * <p/>
-     * <ul> <li>MOBILITY_WHEELED</li> <li>MOBILITY_CROSS_COUNTRY</li> <li>MOBILITY_TRACKED</li>
-     * <li>MOBILITY_WHEELED_TRACKED_COMBINATION</li> <li>MOBILITY_TOWED</li> <li>MOBILITY_RAIL</li>
-     * <li>MOBILITY_OVER_THE_SNOW</li> <li>MOBILITY_SLED</li> <li>MOBILITY_PACK_ANIMALS</li> <li>MOBILITY_BARGE</li>
-     * <li>MOBILITY_AMPHIBIOUS</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>MOBILITY_WHEELED</li> 
+     * <li>MOBILITY_CROSS_COUNTRY</li> 
+     * <li>MOBILITY_TRACKED</li>
+     * <li>MOBILITY_WHEELED_TRACKED_COMBINATION</li> 
+     * <li>MOBILITY_TOWED</li> 
+     * <li>MOBILITY_RAIL</li>
+     * <li>MOBILITY_OVER_THE_SNOW</li> 
+     * <li>MOBILITY_SLED</li> 
+     * <li>MOBILITY_PACK_ANIMALS</li> 
+     * <li>MOBILITY_BARGE</li>
+     * <li>MOBILITY_AMPHIBIOUS</li> 
+     * </ul>
+     * <p>
      * The mobility codes are the same for all symbology schemes that use them, and are defined in each appendix of the
      * MIL-STD-2525C specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> <li>Emergency Management -
-     * section G.5.5.5 (page 1030) and table G-II (page 1032)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> 
+     * <li>Emergency Management - section G.5.5.5 (page 1030) and table G-II (page 1032)</li> 
+     * </ul>
      */
     final String MOBILITY = "R";
     /**
@@ -765,18 +831,24 @@ public interface SymbologyConstants
      * battle provides additional information about the symbol in the operational environment. The recognized values
      * depend on the specific MIL-STD-2525 symbology scheme the symbol belongs to, and are defined in each appendix of
      * the MIL-STD-2525C specification:
-     * <p/>
-     * <strong>Warfighting, Signals Intelligence, Stability Operations, Emergency Management</strong> <br/> See
-     * MIL-STD-2525C section A.5.2.1.h (page 51), table A-I (page 51), section D.5.2.1.h (page 964), table D-I (page
+     * <p>
+     * <strong>Warfighting, Signals Intelligence, Stability Operations, Emergency Management</strong> <br> 
+     * See MIL-STD-2525C section A.5.2.1.h (page 51), table A-I (page 51), section D.5.2.1.h (page 964), table D-I (page
      * 964), section E.5.2.1.h (page 991), table E-I (page 991), and table G-I (page 1032).
-     * <p/>
-     * <ul> <li>ORDER_OF_BATTLE_AIR</li> <li>ORDER_OF_BATTLE_ELECTRONIC</li> <li>ORDER_OF_BATTLE_CIVILIAN</li>
-     * <li>ORDER_OF_BATTLE_GROUND</li> <li>ORDER_OF_BATTLE_MARITIME</li> <li>ORDER_OF_BATTLE_STRATEGIC_FORCE_RELATED</li>
+     * <ul> 
+     * <li>ORDER_OF_BATTLE_AIR</li> 
+     * <li>ORDER_OF_BATTLE_ELECTRONIC</li> 
+     * <li>ORDER_OF_BATTLE_CIVILIAN</li>
+     * <li>ORDER_OF_BATTLE_GROUND</li> 
+     * <li>ORDER_OF_BATTLE_MARITIME</li> 
+     * <li>ORDER_OF_BATTLE_STRATEGIC_FORCE_RELATED</li>
      * </ul>
-     * <p/>
-     * <strong>Tactical Graphics</strong> <br/> See MIL-STD-2525C section B5.2.1.h (page 304) and table B-I (page 305).
-     * <p/>
-     * <ul> <li>ORDER_OF_BATTLE_CONTROL_MARKINGS</li> </ul>
+     * <p>
+     * <strong>Tactical Graphics</strong> 
+     * See MIL-STD-2525C section B5.2.1.h (page 304) and table B-I (page 305).
+     * <ul> 
+     * <li>ORDER_OF_BATTLE_CONTROL_MARKINGS</li> 
+     * </ul>
      */
     final String ORDER_OF_BATTLE = "gov.nasa.worldwind.symbology.OrderOfBattle";
     /** The MIL-STD-2525 Air order of battle code. */
@@ -830,9 +902,11 @@ public interface SymbologyConstants
     /**
      * The MIL-STD-2525 Reinforced or Reduced modifier field ID. Indicates whether a unit is reinforced or reduced, or
      * both. When used as a key, the corresponding value must be one of the following values:
-     * <p/>
-     * <ul> <li>REINFORCED to indicate that the unit is reinforced</li> <li>REDUCED to indicate that the unit is
-     * reduced</li> <li>REINFORCED_AND_REDUCED to indicate that the unit is reinforced and reduced</li> </ul>
+     * <ul> 
+     * <li>REINFORCED to indicate that the unit is reinforced</li> 
+     * <li>REDUCED to indicate that the unit is reduced</li> 
+     * <li>REINFORCED_AND_REDUCED to indicate that the unit is reinforced and reduced</li> 
+     * </ul>
      */
     final String REINFORCED_REDUCED = "F";
 
@@ -846,9 +920,14 @@ public interface SymbologyConstants
      * Indicates the scheme code associated with a MIL-STD-2525 symbol (SIDC position 1). A symbol's scheme defines the
      * specific MIL-STD-2525 symbology set that it belongs to. The scheme codes are defined in each appendix of the
      * MIL-STD-2525 specification. When used as a key, the corresponding value must be one of the following:
-     * <p/>
-     * <ul> <li>SCHEME_WARFIGHTING</li> <li>SCHEME_TACTICAL_GRAPHICS</li> <li>SCHEME_METOC</li>
-     * <li>SCHEME_INTELLIGENCE</li> <li>SCHEME_STABILITY_OPERATIONS</li> <li>SCHEME_EMERGENCY_MANAGEMENT</li> </ul>
+     * <ul> 
+     * <li>SCHEME_WARFIGHTING</li> 
+     * <li>SCHEME_TACTICAL_GRAPHICS</li> 
+     * <li>SCHEME_METOC</li>
+     * <li>SCHEME_INTELLIGENCE</li> 
+     * <li>SCHEME_STABILITY_OPERATIONS</li> 
+     * <li>SCHEME_EMERGENCY_MANAGEMENT</li> 
+     * </ul>
      */
     final String SCHEME = "gov.nasa.worldwind.symbology.Scheme";
     /** The MIL-STD-2525 Emergency Management (EM) scheme code. See MIL-STD-2525C table G-I (page 1032). */
@@ -946,20 +1025,31 @@ public interface SymbologyConstants
      * identity defines the threat posed by the object being represented. See MIL-STD-2525C section 3.2.39 (page 10),
      * section 5.3.1.1 (page 17), table I (page 15), and table II (page 16). When used as a key, the corresponding value
      * must be one of the following:
-     * <p/>
-     * <ul> <li>STANDARD_IDENTITY_PENDING</li> <li>STANDARD_IDENTITY_UNKNOWN</li> <li>STANDARD_IDENTITY_ASSUMED_FRIEND</li>
-     * <li>STANDARD_IDENTITY_FRIEND</li> <li>STANDARD_IDENTITY_NEUTRAL</li> <li>STANDARD_IDENTITY_SUSPECT</li>
-     * <li>STANDARD_IDENTITY_HOSTILE</li> <li>STANDARD_IDENTITY_EXERCISE_PENDING</li>
-     * <li>STANDARD_IDENTITY_EXERCISE_UNKNOWN</li> <li>STANDARD_IDENTITY_EXERCISE_ASSUMED_FRIEND</li>
-     * <li>STANDARD_IDENTITY_EXERCISE_FRIEND</li> <li>STANDARD_IDENTITY_EXERCISE_NEUTRAL</li>
-     * <li>STANDARD_IDENTITY_JOKER</li> <li>STANDARD_IDENTITY_FAKER</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>STANDARD_IDENTITY_PENDING</li> 
+     * <li>STANDARD_IDENTITY_UNKNOWN</li> 
+     * <li>STANDARD_IDENTITY_ASSUMED_FRIEND</li>
+     * <li>STANDARD_IDENTITY_FRIEND</li> 
+     * <li>STANDARD_IDENTITY_NEUTRAL</li> 
+     * <li>STANDARD_IDENTITY_SUSPECT</li>
+     * <li>STANDARD_IDENTITY_HOSTILE</li> 
+     * <li>STANDARD_IDENTITY_EXERCISE_PENDING</li>
+     * <li>STANDARD_IDENTITY_EXERCISE_UNKNOWN</li> 
+     * <li>STANDARD_IDENTITY_EXERCISE_ASSUMED_FRIEND</li>
+     * <li>STANDARD_IDENTITY_EXERCISE_FRIEND</li> 
+     * <li>STANDARD_IDENTITY_EXERCISE_NEUTRAL</li>
+     * <li>STANDARD_IDENTITY_JOKER</li> 
+     * <li>STANDARD_IDENTITY_FAKER</li> </ul>
+     * <p>
      * The standard identity codes are the same for all symbology schemes that use them, and are defined in each
      * appendix of the MIL-STD-2525 specification:
-     * <p/>
-     * <ul> <li>Warfighting - table A-I (page 51)</li> <li>Tactical Graphics - table B-I (page 305)</li> <li>Signals
-     * Intelligence - table D-I (page 964)</li> <li>Stability Operations - table E-I (page 991)</li> <li>Emergency
-     * Management - table G-I (page 1032)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - table A-I (page 51)</li> 
+     * <li>Tactical Graphics - table B-I (page 305)</li> 
+     * <li>Signals Intelligence - table D-I (page 964)</li> 
+     * <li>Stability Operations - table E-I (page 991)</li> 
+     * <li>Emergency Management - table G-I (page 1032)</li> 
+     * </ul>
      */
     final String STANDARD_IDENTITY = "gov.nasa.worldwind.symbology.StandardIdentity";
     /**
@@ -1053,8 +1143,10 @@ public interface SymbologyConstants
     /**
      * Indicates if a graphic in the Meteorological and Oceanographic scheme is static or dynamic (SIDC positions 3 and
      * 4). When used as a key, the corresponding value must be one of the following:
-     * <p/>
-     * <ul> <li>STATIC</li> <li>DYNAMIC</li> </ul>
+     * <ul> 
+     * <li>STATIC</li> 
+     * <li>DYNAMIC</li> 
+     * </ul>
      */
     final String STATIC_DYNAMIC = "gov.nasa.worldwind.symbology.StaticDynamic";
     /** The MIL-STD-2525 Static, used by symbols belonging to the METOC scheme. */
@@ -1073,22 +1165,34 @@ public interface SymbologyConstants
      * define its operational condition. See MIL-STD-2525C section 3.2.41 (page 10), section 5.3.1.4 (pages 17-18), and
      * tables III and III-2 (pages 18-17). The recognized values depend on the specific MIL-STD-2525 symbology scheme
      * the symbol belongs to, and are defined in each appendix of the MIL-STD-2525C specification:
-     * <p/>
-     * <strong>Warfighting, Signals Intelligence, Stability Operations</strong> <br/> See MIL-STD-2525C section
-     * A.5.2.1.d (page 51), table A-I (page 51), section D.5.2.1.d (page 964), table D-I (page 964), section E.5.2.1.d
-     * (page 991), and table E-I (page 991).
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> <li>STATUS_PRESENT_FULLY_CAPABLE</li>
-     * <li>STATUS_PRESENT_DAMAGED</li> <li>STATUS_PRESENT_DESTROYED</li> <li>STATUS_PRESENT_FULL_TO_CAPACITY</li> </ul>
-     * <p/>
-     * <strong>Tactical Graphics</strong> <br/> See MIL-STD-2525C section B5.2.1.d (page 304) and table B-I (page 305).
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_SUSPECTED</li> <li>STATUS_PRESENT</li> <li>STATUS_KNOWN</li> </ul>
-     * <p/>
-     * <strong>Emergency Management</strong> <br/> See MIL-STD-2525C section G.5.2.4 (page 1028) and table G-I (page
-     * 1032).
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> </ul>
+     * <p>
+     * <strong>Warfighting, Signals Intelligence, Stability Operations</strong> <br> 
+     * See MIL-STD-2525C section A.5.2.1.d (page 51), table A-I (page 51), section D.5.2.1.d (page 964), 
+     * table D-I (page 964), section E.5.2.1.d (page 991), and table E-I (page 991).
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> 
+     * <li>STATUS_PRESENT</li> 
+     * <li>STATUS_PRESENT_FULLY_CAPABLE</li>
+     * <li>STATUS_PRESENT_DAMAGED</li> 
+     * <li>STATUS_PRESENT_DESTROYED</li> 
+     * <li>STATUS_PRESENT_FULL_TO_CAPACITY</li> 
+     * </ul>
+     * <p>
+     * <strong>Tactical Graphics</strong> <br> 
+     * See MIL-STD-2525C section B5.2.1.d (page 304) and table B-I (page 305).
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> 
+     * <li>STATUS_SUSPECTED</li> 
+     * <li>STATUS_PRESENT</li> 
+     * <li>STATUS_KNOWN</li> 
+     * </ul>
+     * <p>
+     * <strong>Emergency Management</strong> <br> 
+     * See MIL-STD-2525C section G.5.2.4 (page 1028) and table G-I (page 1032).
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> 
+     * <li>STATUS_PRESENT</li> 
+     * </ul>
      */
     final String STATUS = "AL";
     /**
@@ -1170,10 +1274,11 @@ public interface SymbologyConstants
      * feint/dummy, installation, task force, headquarters staff, equipment mobility, and auxiliary equipment. The
      * recognized values depend on the specific MIL-STD-2525 symbology scheme the symbol belongs to, and are defined in
      * each appendix of the MIL-STD-2525C specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> <li>Stability Operations -
-     * section E.5.2.1.f (page 991) and table E-II (pages 992-994)</li> <li>Emergency Management - section G.5.5 (page
-     * 1029) and table EG-II (page 1032)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> 
+     * <li>Stability Operations - section E.5.2.1.f (page 991) and table E-II (pages 992-994)</li> 
+     * <li>Emergency Management - section G.5.5 (page 1029) and table EG-II (page 1032)</li> 
+     * </ul>
      */
     final String SYMBOL_MODIFIER = "gov.nasa.worldwind.symbology.SymbolModifier";
 
@@ -1190,10 +1295,12 @@ public interface SymbologyConstants
      * its echelon. See MIL-STD-2525 section 5.3.4.6 (page 28). When used as a key, the corresponding value must be a
      * boolean value. The value is <code>true</code> if the symbol's represented object is a task force, and
      * <code>false</code> otherwise.
-     * <p/>
+     * <p>
      * The following symbology schemes support the task force modifier:
-     * <p/>
-     * <ul> <li>Warfighting</li> <li>Stability Operations</li> </ul>
+     * <ul> 
+     * <li>Warfighting</li> 
+     * <li>Stability Operations</li> 
+     * </ul>
      */
     final String TASK_FORCE = "D";
 

--- a/src/gov/nasa/worldwind/symbology/TacticalGraphic.java
+++ b/src/gov/nasa/worldwind/symbology/TacticalGraphic.java
@@ -15,29 +15,26 @@ import gov.nasa.worldwind.util.UnitsFormat;
 /**
  * TacticalGraphic provides a common interface for displaying a graphic from a symbology set. A graphic can be an icon
  * that is drawn a geographic position, a vector graphic that is positioned using one or more control points, or a line
- * or polygon that is styled according to the symbol set's specification. See the TacticalGraphic <a title="Tactical
- * Graphic Usage Guide" href="https://goworldwind.org/developers-guide/symbology/tactical-graphics/"
+ * or polygon that is styled according to the symbol set's specification. See the TacticalGraphic <a href="https://goworldwind.org/developers-guide/symbology/tactical-graphics/"
  * target="_blank">Usage Guide</a> for instructions on using TacticalGraphic in an application.
- * <p/>
- * See the {@link gov.nasa.worldwindx.examples.symbology.Symbology} and {@link gov.nasa.worldwindx.examples.symbology.TacticalGraphics}
- * example applications for examples of how to use tactical graphics.
- * <p/>
+ * <p>
+ * See the {@link gov.nasa.worldwindx.examples.symbology.Symbology} and
+ * {@link gov.nasa.worldwindx.examples.symbology.TacticalGraphics} example applications for examples of how to use
+ * tactical graphics.
  * <h1>Construction</h1>
- * <p/>
  * TacticalGraphics are typically created by an instance of {@link TacticalGraphicFactory}. Each graphic within a symbol
  * set is identified by a string identifier. The format of this identifier depends on the symbol set. For example, a
  * MIL-STD-2525 Symbol Identification Code (SIDC) is a string of 15 characters.
- * <p/>
- * You will need to instantiate the appropriate factory for the symbol set that you intend to use.  For example, {@link
+ * <p>
+ * You will need to instantiate the appropriate factory for the symbol set that you intend to use. For example, {@link
  * gov.nasa.worldwind.symbology.milstd2525.MilStd2525GraphicFactory} creates graphics for the MIL-STD-2525 symbology
  * set.
- * <p/>
+ * <p>
  * The TacticalGraphic interface provides access to settings common to all tactical graphics. TacticalGraphic extends
  * the {@link Renderable} interface, so you can add a TacticalGraphic directly to a {@link
- * gov.nasa.worldwind.layers.RenderableLayer}. Here's an example of creating a graphic from the MIL-STD-2525 symbol
- * set:
- * <p/>
+ * gov.nasa.worldwind.layers.RenderableLayer}. Here's an example of creating a graphic from the MIL-STD-2525 symbol set:
  * <pre>
+ * {@code
  * // Create a graphic factory for MIL-STD-2525
  * TacticalGraphicFactory factory = new MilStd2525GraphicFactory();
  *
@@ -65,75 +62,74 @@ import gov.nasa.worldwind.util.UnitsFormat;
  * WorldWindow wwd = ... // A reference to your application's WorldWind instance.
  * wwd.getModel().getLayers().add(graphicLayer);
  * wwd.redraw();
+ * }
  * </pre>
- * <p/>
- * The symbol identifier ({@code GHGPGLP----AUSX}) tells the factory what type of graphic to create,  and how the
- * graphic should be styled. In the example above we added a text modifier of "Alpha" to identify our shape. These
- * parameters can be specified using a parameter list when the TacticalGraphic is created, as shown above. They can also
- * be set after creation using setters in the TacticalGraphic interface.
- * <p/>
+ * <p>
+ * The symbol identifier ({@code GHGPGLP----AUSX}) tells the factory what type of graphic to create, and how the graphic
+ * should be styled. In the example above we added a text modifier of "Alpha" to identify our shape. These parameters
+ * can be specified using a parameter list when the TacticalGraphic is created, as shown above. They can also be set
+ * after creation using setters in the TacticalGraphic interface.
  * <h1>Modifiers</h1>
- * <p/>
+ * <p>
  * Many graphics support text or graphic modifiers. Each modifier is identified by a String key. The set of possible
  * modifiers is determined by the symbol set. Modifiers can be specified in the parameter list when a graphic is
  * created, or using {@link #setModifier(String, Object) setModifier} after the graphic has been created.
- * <p/>
+ * <p>
  * For example, a MIL-STD-2525 General Area graphic can have a text modifier that identifies the area. Here's an example
  * of how to specify the modifier when the graphic is created:
- * <p/>
  * <pre>
+ * {@code
  * AVList modifiers = new AVListImpl();
  * modifiers.setValue(SymbologyConstants.UNIQUE_DESIGNATION, "Boston"); // Text that identifies the area enclosed by
  *                                                                      //  the  graphic.
  *
  * List<Position> positions = ...; // List of positions that define the boundary of the area.
  * TacticalGraphic graphic = milstd2525Factory.createGraphic("GHGPGAG----AUSX", positions, modifiers);
+ * }
  * </pre>
- * <p/>
+ * <p>
  * The modifier can also be set (or changed) after the graphic is created:
- * <p/>
  * <pre>
+ * {@code
  * // Create the graphic
  * TacticalGraphic graphic = milstd2525Factory.createGraphic("GHGPGAG----AUSX", positions, null);
  * graphic.setModifier(SymbologyConstants.UNIQUE_DESIGNATION, "Boston");
+ * }
  * </pre>
- * <p/>
  * <h1>Position</h1>
- * <p/>
+ * <p>
  * Each tactical graphic is positioned by one or more control points. How many points are required depends on the type
- * of graphic.  A point graphic will only require one point. A more complex shape may require three or four, and a line
+ * of graphic. A point graphic will only require one point. A more complex shape may require three or four, and a line
  * or area may allow any number.
- * <p/>
+ * <p>
  * Here is an example of how to create a point graphic in the MIL-STD-2525 symbol set:
- * <p/>
- * <pre>
+ * <pre> {@code
  * Position position = Position.fromDegrees(34.9362, -118.2559, 0);
  * TacticalGraphic graphic = milstd2525Factory.createPoint("GFGPAPD----AUSX", position, null);
- * </pre>
- * <p/>
+ * } </pre>
+ * <p>
  * More complicated graphics will require more control points. MIL-STD-2525 defines a template for each type of tactical
  * graphic. Each template identifies how many control points are required for the graphic, and how the points are
  * interpreted. The TacticalGraphic requires a list of Position objects, which identify the control points in the same
  * order as in the specification. For example, in order to create a graphic that requires three control points we need
  * to create a list of positions that specifies the three points in order:
- * <p/>
  * <pre>
+ * {@code
  * List<Position> positions = Arrays.asList(
  *     Position.fromDegrees(34.5073, -117.8380, 0), // PT. 1
  *     Position.fromDegrees(34.8686, -117.5088, 0), // PT. 2
  *     Position.fromDegrees(34.4845, -117.8495, 0)); // PT. 3
  *
  * TacticalGraphic graphic = milstd2525Factory.createGraphic("GFGPSLA----AUSX", positions, null);
+ * }
  * </pre>
- * <p/>
  * <h1>Sub-interfaces of TacticalGraphic</h1>
- * <p/>
+ * <p>
  * TacticalGraphic describes any tactical graphic in the most general terms: a list of positions and modifiers. However,
  * this general interface is not convenient for all graphics. For example, when creating a circle graphic it is more
  * convenient to access the radius of the circle directly than to set a modifier that affects the radius. Sub-interfaces
  * of tactical graphic provide more convenient methods for manipulating common types of graphics. Instances of these
  * sub-interfaces can be created directly using a TacticalGraphicFactory. The sub-interfaces are:
- * <p/>
  * <ul> <li>{@link TacticalPoint}- Graphics positioned by a single point.</li> <li>{@link TacticalCircle} - Graphics
  * positioned by a center point and radius.</li> <li>{@link TacticalQuad} - Rectangles with a length and width.</li>
  * <li>{@link TacticalRoute} - A series of point graphics connected by lines and treated as a single graphic.</li>
@@ -336,7 +332,7 @@ public interface TacticalGraphic extends Renderable, Highlightable, Movable, AVL
      * Specifies an offset used to position this graphic's main label relative to the label's geographic position. The
      * geographic position is determined by the type of graphic. For example, the label for an area graphic is typically
      * placed at the center of the area polygon. Note that not all graphics have labels.
-     * <p/>
+     * <p>
      * The offset can specify an absolute pixel value, or a an offset relative to the size of the label. For example, an
      * offset of (-0.5, -0.5) in fraction units will center the label on its geographic position both horizontally and
      * vertically.

--- a/src/gov/nasa/worldwind/symbology/TacticalGraphicAttributes.java
+++ b/src/gov/nasa/worldwind/symbology/TacticalGraphicAttributes.java
@@ -14,11 +14,10 @@ import java.awt.*;
  * Holds attributes for a {@link TacticalGraphic}. Changes made to the attributes are applied to the graphic when the
  * <code>WorldWindow</code> renders the next frame. Instances of <code>TacticalGraphicAttributes</code> may be shared by
  * many graphics, thereby reducing the memory normally required to store attributes for each graphic.
- * <p/>
+ * <p>
  * TacticalGraphicAttributes is used to override default attributes determined by a graphic's symbol set. Any non-null
  * attributes will override the corresponding default attributes. Here's an example of overriding only the outline
  * material of a graphic without affecting other styling specified by the symbol set:
- * <p/>
  * <pre>
  * TacticalGraphic graphic = ...
  * TacticalGraphicAttributes attrs = new BasicTacticalGraphicAttributes();
@@ -54,7 +53,7 @@ public interface TacticalGraphicAttributes
     /**
      * Indicates the graphic scale as a ratio of the graphics's original size. See {@link #setScale(Double)} for a
      * description of how scale is used.
-     * <p/>
+     * <p>
      * Scale directly affects the size of point graphics. Line and area graphics do not change size based on the scale,
      * but if a line or area graphic includes a tactical symbol as part of a composite shape, the scale may be applied
      * to the symbol.
@@ -68,7 +67,7 @@ public interface TacticalGraphicAttributes
      * number greater than 0.0: values less than 1.0 make the graphic smaller, while values greater than 1.0 make the
      * symbol larger. The scale applies to both the graphic and the graphic modifiers. The specified scale must be
      * either <code>null</code> or greater than or equal to 0.0.
-     * <p/>
+     * <p>
      * Scale directly affects the size of point graphics. Line and area graphics do not change size based on the scale,
      * but if a line or area graphic includes a tactical symbol as part of a composite shape, the scale may be applied
      * to the symbol.

--- a/src/gov/nasa/worldwind/symbology/TacticalGraphicFactory.java
+++ b/src/gov/nasa/worldwind/symbology/TacticalGraphicFactory.java
@@ -12,9 +12,8 @@ import gov.nasa.worldwind.geom.Position;
 /**
  * A factory to create {@link TacticalGraphic}s. Each implementation of this interface handles the graphics for a
  * specific symbol set. Each graphic within that set is identified by a string identifier.
- * <p/>
+ * <p>
  * The factory exposes creation several methods:
- * <p/>
  * <ul><li>{@link #createGraphic(String, Iterable, gov.nasa.worldwind.avlist.AVList) createGraphic} - Creates a graphic
  * from a list of positions and modifiers. This method is the most general, and can create any type of graphic. The
  * other creation methods are provided for convenience.</li> <li>{@link #createPoint(String,

--- a/src/gov/nasa/worldwind/symbology/TacticalGraphicLabel.java
+++ b/src/gov/nasa/worldwind/symbology/TacticalGraphicLabel.java
@@ -300,7 +300,7 @@ public class TacticalGraphicLabel
      * horizontal with the text alignment position, and centers the label vertically. For example, if the text alignment
      * is <code>AVKey.LEFT</code>., then the left edge of the text will be aligned with the geographic position, and the
      * label will be centered vertically.
-     * <p/>
+     * <p>
      * When the text is rotated a horizontal offset moves the text along the orientation line, and a vertical offset
      * moves the text perpendicular to the orientation line.
      *
@@ -604,7 +604,7 @@ public class TacticalGraphicLabel
      *
      * @return true if batch rendering is enabled, otherwise false.
      *
-     * @see #setEnableBatchPicking(boolean).
+     * @see #setEnableBatchPicking(boolean)
      */
     public boolean isEnableBatchPicking()
     {
@@ -615,7 +615,7 @@ public class TacticalGraphicLabel
      * Specifies whether adjacent Labels in the ordered renderable list may be pick-tested together if they are
      * contained in the same layer. This increases performance but allows only the top-most of the label to be reported
      * in a {@link gov.nasa.worldwind.event.SelectEvent} even if several of the labels are at the pick position.
-     * <p/>
+     * <p>
      * Batch rendering ({@link #setEnableBatchRendering(boolean)}) must be enabled in order for batch picking to occur.
      *
      * @param enableBatchPicking true to enable batch rendering, otherwise false.
@@ -630,7 +630,7 @@ public class TacticalGraphicLabel
      *
      * @return true if batch rendering is enabled, otherwise false.
      *
-     * @see #setEnableBatchRendering(boolean).
+     * @see #setEnableBatchRendering(boolean)
      */
     public boolean isEnableBatchRendering()
     {

--- a/src/gov/nasa/worldwind/symbology/TacticalGraphicUtil.java
+++ b/src/gov/nasa/worldwind/symbology/TacticalGraphicUtil.java
@@ -174,12 +174,12 @@ public class TacticalGraphicUtil
     /**
      * Compute a point along a Bezier curve defined by a list of control points. The first and last points should mark
      * the start and end of the curve.
-     * <p/>
+     * <p>
      * This function implements the Bezier curve equation from "Mathematics for 3D Game Programming and Computer
      * Graphics, Second Edition" by Eric Lengyel (equation 15.16, pg. 458).
-     * <p/>
+     * <p>
      * A typical usage looks like this:
-     * <pre>
+     * <pre>{@code
      * Vec4[] controlPoints = ... // Determine control points appropriate for your curve
      *
      * List<Position> curvePositions = new ArrayList<Position>();
@@ -194,7 +194,7 @@ public class TacticalGraphicUtil
      *     Position pos = globe.computePositionFromPoint(p);
      *     curvePositions.add(pos);
      * }
-     * </pre>
+     * }</pre>
      *
      * @param controlPoints Control points for the curve.
      * @param t             Interpolation parameter in the range [0..1].

--- a/src/gov/nasa/worldwind/symbology/TacticalSymbol.java
+++ b/src/gov/nasa/worldwind/symbology/TacticalSymbol.java
@@ -14,13 +14,13 @@ import gov.nasa.worldwind.util.UnitsFormat;
 /**
  * TacticalSymbol provides a common interface for displaying tactical point symbols from symbology sets. A tactical
  * symbol displays graphic and textual information about an object at a single geographic position at a particular point
- * in time. See the <a title="Tactical Symbol Usage Guide" href="https://goworldwind.org/developers-guide/symbology/tactical-symbols/"
+ * in time. See the <a href="https://goworldwind.org/developers-guide/symbology/tactical-symbols/"
  * target="_blank">Tactical Symbol Usage Guide</a> for instructions on using TacticalSymbol in an application.
- * <p/>
+ * 
  * <h2>Construction</h2> Implementations of this interface provide support for symbols belonging to a specific symbology
  * set. For example, class {@link gov.nasa.worldwind.symbology.milstd2525.MilStd2525TacticalSymbol} provides support for
  * tactical symbols from the MIL-STD-2525 symbology specification.
- * <p/>
+ * <p>
  * To create a tactical symbol, instantiate a concrete implementation appropriate for the desired symbology set. Pass a
  * string identifier, the desired geographic position, and (optionally) one or more symbol modifier key-value pairs to
  * the symbol's constructor. The tactical symbol creates a graphic appropriate for the string identifier and optional
@@ -28,16 +28,15 @@ import gov.nasa.worldwind.util.UnitsFormat;
  * symbol implementation may display a 3D object at the position, or display a screen space icon who's screen location
  * tracks the position. MIL-STD-2525 tactical symbols display a screen space icon with graphic and text modifiers
  * surrounding the icon.
- * <p/>
+ * <p>
  * The format of the string identifier and the modifier key-value pairs are implementation dependent. For MIL-STD-2525,
  * the string identifier must be a 15-character alphanumeric symbol identification code (SIDC), and the modifier keys
  * must be one of the constants defined in MilStd2525TacticalSymbol's documentation.
- * <p/>
+ * <p>
  * Since TacticalSymbol extends the Renderable interface, a tactical symbol is displayed either by adding it to a layer,
  * or by calling its render method from within a custom layer or renderable object. The simplest way to display a
  * tactical symbol is to add it to a {@link gov.nasa.worldwind.layers.RenderableLayer}. Here's an example of creating
  * and displaying a tactical symbol for a MIL-STD-2525 friendly ground unit using a RenderableLayer:
- * <p/>
  * <pre>
  * // Create a tactical symbol for a MIL-STD-2525 friendly ground unit. Since the SIDC specifies a ground symbol, the
  * // tactical symbol's altitude mode is automatically configured as WorldWind.CLAMP_TO_GROUND.
@@ -55,30 +54,27 @@ import gov.nasa.worldwind.util.UnitsFormat;
  * wwd.getModel().getLayers().add(symbolLayer);
  * wwd.redraw();
  * </pre>
- * <p/>
  * <h2>Position</h2> A symbol's geographic position defines where the symbol displays its graphic. Either the graphic's
  * geometric center is displayed at the position, or a specific location within the graphic (such as the bottom of a
  * leader line) is displayed at the position. This behavior depends on the symbol implementation, the string identifier,
  * and the symbol modifiers (if any).
- * <p/>
+ * <p>
  * A symbol's altitude mode defines how the altitude component if the position is interpreted. Altitude mode may be
  * specified by calling {@link #setAltitudeMode(int)}. Recognized modes are: <ul> <li>WorldWind.CLAMP_TO_GROUND -- the
  * symbol graphic is placed on the terrain at the latitude and longitude of its position.</li>
  * <li>WorldWind.RELATIVE_TO_GROUND -- the symbol graphic is placed above the terrain at the latitude and longitude of
  * its position and the distance specified by its elevation.</li> <li>WorldWind.ABSOLUTE -- the symbol graphic is placed
  * at its specified position.</li> </ul>
- * <p/>
+ * <p>
  * Tactical symbol implementations configure the altitude mode from the string identifier specified during construction.
  * For example, specifying the MIL-STD-2525 SIDC "SFGPU---------G" specifies a friendly ground unit symbol, and causes a
  * tactical symbol to configure the altitude mode as WorldWind.CLAMP_TO_GROUND. The automatically configured mode can be
  * overridden by calling setAltitudeMode.
- * <p/>
  * <h2>Modifiers</h2> Symbols modifiers are optional attributes that augment or change a symbol's graphic. Modifiers can
  * be specified at construction by passing a list of key-value pairs, or after construction by calling {@link
  * #setModifier(String, Object)} with the modifier key and value. Which modifier keys are recognized by a tactical
  * symbol and how they affect the symbol's graphic is implementation dependent. Here's an example of setting the the
  * heading (direction of movement) modifier at construction for a MIL-STD-2525 friendly ground unit:
- * <p/>
  * <pre>
  * // Create a tactical symbol for a MIL-STD-2525 friendly ground unit, specifying the optional Direction of Movement
  * // modifier by passing in a list of key-value pairs.
@@ -87,9 +83,8 @@ import gov.nasa.worldwind.util.UnitsFormat;
  * TacticalSymbol symbol = new MilStd2525TacticalSymbol("SFGPU---------G", Position.fromDegrees(40, -120, 0),
  *     modifiers);
  * </pre>
- * <p/>
+ * <p>
  * Here's an example of setting the same modifier after construction:
- * <p/>
  * <pre>
  * // Create a tactical symbol for a MIL-STD-2525 friendly ground unit.
  * TacticalSymbol symbol = new MilStd2525TacticalSymbol("SFGPU---------G", Position.fromDegrees(40, -120, 0));
@@ -97,12 +92,11 @@ import gov.nasa.worldwind.util.UnitsFormat;
  * // Set the heading (direction of movement) modifier.
  * symbol.setModifier(SymbologyConstants.DIRECTION_OF_MOVEMENT, Angle.fromDegrees(45));
  * </pre>
- * <p/>
+ * <p>
  * Tactical symbol implementations apply modifiers from the string identifier specified during construction. For
  * example, given a MIL-STD-2525 symbol representing units, installation, or equipment, SIDC positions 11-12 specify the
  * echelon and task force modifiers (See MIL-STD-2525C, Appendix A). Here's an example of setting the echelon and task
  * force modifiers at construction for a MIL-STD-2525 friendly ground unit:
- * <p/>
  * <pre>
  * // Create a tactical symbol for a MIL-STD-2525 friendly ground unit. Specify the echelon modifier and task force
  * // modifiers by setting the SIDC characters 11-12 to "EA". This indicates that the ground unit is a Task Force with
@@ -205,7 +199,7 @@ public interface TacticalSymbol extends WWObject, Renderable, Highlightable
      * graphic is placed above the terrain at the latitude and longitude of its position and the distance specified by
      * its elevation.</li> <li>WorldWind.ABSOLUTE -- this symbol's graphic is placed at its specified position.</li>
      * </ul>
-     * <p/>
+     * <p>
      * This symbol assumes the altitude mode WorldWind.ABSOLUTE if the specified mode is not recognized.
      *
      * @param altitudeMode this symbol's new altitude mode.
@@ -295,7 +289,7 @@ public interface TacticalSymbol extends WWObject, Renderable, Highlightable
      * symbol's graphic is implementation dependent. If the modifier has an implicit value and only needs to be enabled
      * (e.g. the MIL-STD-2525 location modifier), specify true as the modifier value. If the specified value is
      * <code>null</code>, the modifier is removed from this symbol.
-     * <p/>
+     * <p>
      * If the specified modifier represents a graphic or text modifier, its display is suppressed if
      * isShowGraphicModifiers or isShowTextModifiers, respectively, returns false.
      *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525IconRetriever.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525IconRetriever.java
@@ -17,28 +17,32 @@ import java.util.*;
 
 /**
  * Retriever to retrieve icons for symbols in the MIL-STD-2525 symbol set. The retriever can retrieve icons from either
- * a local or remote symbol store. See the <a href="https://goworldwind.org/developers-guide/symbology/tactical-symbols/#offline-use">Symbology
- * Usage Guide</a> for details on how to configure a local symbol repository. For more information on how to use this
- * class see the IconRetriever Usage Guide and the {@link gov.nasa.worldwindx.examples.symbology.IconRetrieverUsage}
- * example.
- * <p/>
+ * a local or remote symbol store. See the
+ * <a href="https://goworldwind.org/developers-guide/symbology/tactical-symbols/#offline-use">Symbology Usage Guide</a>
+ * for details on how to configure a local symbol repository. For more information on how to use this class see the
+ * IconRetriever Usage Guide and the {@link gov.nasa.worldwindx.examples.symbology.IconRetrieverUsage} example.
  * <h2><a name="parameters">Retrieval parameters</a></h2>
- * <p/>
+ * <p>
  * Table IX (pg. 35) of MIL-STD-2525C defines a hierarchy for simplifying tactical symbols. This hierarchy is
  * implemented using retrieval parameters SHOW_FILL, SHOW_FRAME, and SHOW_ICON. By default, all three elements are
  * displayed, and they can be turned off by setting the appropriate parameter. If frame and icon are turned off the
  * retriever will return an image that contains a circle, either black or filled with the icon fill color (depending on
  * the state of SHOW_FILL).
- * <p/>
+ * <p>
  * {@link #createIcon(String, gov.nasa.worldwind.avlist.AVList) createIcon} accepts the following parameters:
- * <p/>
- * <table> <tr><th>Key</th><th>Type</th><td>Description</th></tr> <tr><td>SymbologyConstants.SHOW_ICON</td><td>Boolean</td><td>Determines
- * if the symbol will be created with an icon.</td></tr> <tr><td>SymbologyConstants.SHOW_FRAME</td><td>Boolean</td><td>Determines
- * if the symbol will be created with a frame.</td></tr> <tr><td>SymbologyConstants.SHOW_FILL</td><td>Boolean</td><td>Determines
- * if the symbol will be created with a fill color.</td></tr><tr><td valign="top">AVKey.COLOR</td><td
+ * <table><caption>Tactical Symbol Hierarchy</caption>
+ * <tr><th>Key</th><th>Type</th><th>Description</th></tr>
+ * <tr><td>SymbologyConstants.SHOW_ICON</td><td>Boolean</td><td>Determines if the symbol will be created with an
+ * icon.</td></tr>
+ * <tr><td>SymbologyConstants.SHOW_FRAME</td><td>Boolean</td><td>Determines if the symbol will be created with a
+ * frame.</td></tr>
+ * <tr><td>SymbologyConstants.SHOW_FILL</td><td>Boolean</td><td>Determines if the symbol will be created with a fill
+ * color.</td></tr>
+ * <tr><td valign="top">AVKey.COLOR</td><td
  * valign="top">java.awt.Color</td><td valign="top">Fill color applied to the symbol. If the symbol is drawn with a
  * frame, then this color will be used to fill the frame. If the symbol is not drawn with a frame, then the fill will be
- * applied to the icon itself. The fill color has no effect if Show Fill is False.</td></tr> </table>
+ * applied to the icon itself. The fill color has no effect if Show Fill is False.</td></tr>
+ * </table>
  *
  * @author ccrick
  * @version $Id: MilStd2525IconRetriever.java 1171 2013-02-11 21:45:02Z dcollins $

--- a/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525PointGraphic.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525PointGraphic.java
@@ -353,7 +353,7 @@ public class MilStd2525PointGraphic extends AVListImpl implements MilStd2525Tact
      * the terrain at the latitude and longitude of its position.</li> <li>WorldWind.RELATIVE_TO_GROUND -- this graphic
      * is placed above the terrain at the latitude and longitude of its position and the distance specified by its
      * elevation.</li> <li>WorldWind.ABSOLUTE -- this graphic is placed at its specified position.</li> </ul>
-     * <p/>
+     * <p>
      * This graphic assumes the altitude mode WorldWind.ABSOLUTE if the specified mode is not recognized.
      *
      * @param altitudeMode this symbol's new altitude mode.

--- a/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525PointGraphicRetriever.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525PointGraphicRetriever.java
@@ -19,13 +19,13 @@ import java.util.MissingResourceException;
  * Retriever to fetch icons for MIL-STD-2525C point graphics. The retriever can fetch images from either local or remote
  * locations. See <a href="https://goworldwind.org/developers-guide/symbology/tactical-symbols/#offline-use">Offline
  * Use</a> for information on how to set the icon retrieval location.
- * <p/>
+ * <p>
  * The retriever base URL must identify a location on a local or remote file system (including zip and jar files) that
  * holds the icon files in an expected directory structure. Each icon URL is constructed from three parts:
  * [base]/icons/[scheme]/[sidc].png. Parts of the SIDC that do not identify a type of graphic (such as echelon, status,
  * standard identity, order of battle, etc.) are replaced with hyphens. For example, the Underwater Datum graphic
  * (2.X.2.1.1.1.1.1) will be retrieved from this URL: [base]/icons/tacgrp/g-g-gpuud------.png
- * <p/>
+ * <p>
  * An application should only use this class directly if it needs to access point graphics independent of the {@link
  * TacticalGraphic} system (for example, to populate a UI independent of the globe).
  *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525TacticalGraphic.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525TacticalGraphic.java
@@ -9,12 +9,14 @@ package gov.nasa.worldwind.symbology.milstd2525;
 import gov.nasa.worldwind.symbology.TacticalGraphic;
 
 /**
- * Interface to describe tactical graphics defined by <a href="http://www.assistdocs.com/search/document_details.cfm?ident_number=114934">MIL-STD-2525</a>.
- * See the TacticalGraphic <a title="Tactical Graphic Usage Guide" href="https://goworldwind.org/developers-guide/symbology/tactical-graphics/"
+ * Interface to describe tactical graphics defined by
+ * <a href="http://www.assistdocs.com/search/document_details.cfm?ident_number=114934">MIL-STD-2525</a>. See the
+ * TacticalGraphic <a href="https://goworldwind.org/developers-guide/symbology/tactical-graphics/"
  * target="_blank">Usage Guide</a> for instructions on using TacticalGraphic in an application.
- * <p/>
+ * <p>
  * The following table lists the modifiers supported by 2525 graphics. Note that not all graphics support all modifiers.
- * <table width="100%"> <tr><th>Field</th><th>Modifier key</th><th>Data type</th><th>Description</th></tr>
+ * <table width="100%"><caption>Modifiers</caption> <tr><th>Field</th><th>Modifier key</th><th>Data
+ * type</th><th>Description</th></tr>
  * <tr><td>A</td><td>SymbologyConstants.SYMBOL</td><td>String</td><td>SIDC for a MIL-STD-2525 Tactical Symbol</td></tr>
  * <tr><td>B</td><td>SymbologyConstants.ECHELON</td><td>String</td><td>Echelon</td></tr>
  * <tr><td>C</td><td>SymbologyConstants.QUANTITY</td><td>String</td><td>Quantity</td></tr>
@@ -26,9 +28,10 @@ import gov.nasa.worldwind.symbology.TacticalGraphic;
  * <tr><td>X</td><td>SymbologyConstants.ALTITUDE_DEPTH</td><td>Double</td><td>Altitude/depth</td></tr>
  * <tr><td>AM</td><td>SymbologyConstants.DISTANCE</td><td>Double</td><td>Radius, length or width of rectangle.</td></tr>
  * <tr><td>AN</td><td>SymbologyConstants.AZIMUTH</td><td>Angle</td><td>Azimuth</td></tr> </table>
- * <p/>
+ * <p>
  * Here's an example of setting modifiers during construction of a graphic:
  * <pre>
+ * {@code
  * AVList modifiers = new AVListImpl();
  * modifiers.setValue(SymbologyConstants.UNIQUE_DESIGNATION, "X469"); // Field T
  * modifiers.setValue(SymbologyConstants.DATE_TIME_GROUP, "10095900ZJAN92); // Field W
@@ -39,17 +42,20 @@ import gov.nasa.worldwind.symbology.TacticalGraphic;
  *
  * // Create the graphic with the modifier list
  * TacticalGraphic graphic = factory.createGraphic("GHMPNEB----AUSX", positions, modifiers);
+ * }
  * </pre>
- * <p/>
+ * <p>
  * Some graphics support multiple instances of a modifier. For example, 2525 uses the field code W for a date/time
  * modifier. Some graphics support multiple timestamps, in which case the fields are labeled W, W1, W2, etc. An
  * application can pass an {@link Iterable} to <code>setModifier</code> if multiple values are required to specify the
  * modifier. Here's an example of how to specify two timestamps:
  * <pre>
+ * {@code
  * String startDate = ...
  * String endData = ...
  *
  * graphic.setModifier(SymbologyConstants.DATE_TIME_GROUP, Arrays.asList(startDate, endDate));
+ * }
  * </pre>
  *
  * @author pabercrombie
@@ -70,18 +76,25 @@ public interface MilStd2525TacticalGraphic extends TacticalGraphic
      * Specifies this graphic's Status/Operational Condition field. A graphic's Status defines whether the represented
      * object exists at the time the symbol was generated, or is anticipated to exist in the future. Additionally, a
      * graphic's Status can define its operational condition. The recognized values depend on the graphic's scheme:
-     * <p/>
+     * <p>
      * <strong>Tactical graphics</strong>
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_SUSPECTED</li> <li>STATUS_PRESENT</li> <li>STATUS_KNOWN</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> 
+     * <li>STATUS_SUSPECTED</li> 
+     * <li>STATUS_PRESENT</li> 
+     * <li>STATUS_KNOWN</li> 
+     * </ul>
+     * <p>
      * <strong>Meteorological and Oceanographic</strong>
-     * <p/>
-     * <ul> <li>Not supported</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>Not supported</li> 
+     * </ul>
+     * <p>
      * <strong>Emergency Management</strong>
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> </ul>
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> 
+     * <li>STATUS_PRESENT</li> 
+     * </ul>
      *
      * @param value the new value for the Status/Operational Condition field.
      *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525TacticalSymbol.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525TacticalSymbol.java
@@ -21,7 +21,7 @@ import java.util.List;
 /**
  * Implementation of {@link gov.nasa.worldwind.symbology.TacticalSymbol} that provides support for tactical symbols from
  * the <a href="http://www.assistdocs.com/search/document_details.cfm?ident_number=114934">MIL-STD-2525</a> symbology
- * set. See the <a title="Tactical Symbol Usage Guide" href="https://goworldwind.org/developers-guide/symbology/tactical-symbols/"
+ * set. See the <a href="https://goworldwind.org/developers-guide/symbology/tactical-symbols/"
  * target="_blank">Tactical Symbol Usage Guide</a> for instructions on using TacticalSymbol in an application.
  *
  * @author dcollins
@@ -67,11 +67,11 @@ public class MilStd2525TacticalSymbol extends AbstractTacticalSymbol
      * position. This constructor does not accept any supplemental modifiers, so the symbol contains only the attributes
      * specified by its symbol identifier. This constructor does not accept any icon retrieval path, so the created
      * symbol retrieves its icons from the default location.
-     * <p/>
+     * <p>
      * The symbolId specifies the tactical symbol's appearance. The symbolId must be a 15-character alphanumeric symbol
      * identification code (SIDC). The symbol's shape, fill color, outline color, and icon are all defined by the symbol
      * identifier. Use the '-' character to specify null entries in the symbol identifier.
-     * <p/>
+     * <p>
      * The position specifies the latitude, longitude, and altitude where the symbol is drawn on the globe. The
      * position's altitude component is interpreted according to the altitudeMode.
      *
@@ -92,14 +92,14 @@ public class MilStd2525TacticalSymbol extends AbstractTacticalSymbol
      * Constructs a tactical symbol for the MIL-STD-2525 symbology set with the specified symbol identifier, position,
      * and list of modifiers. This constructor does not accept any icon retrieval path, so the created symbol retrieves
      * its icons from the default location.
-     * <p/>
+     * <p>
      * The symbolId specifies the tactical symbol's appearance. The symbolId must be a 15-character alphanumeric symbol
      * identification code (SIDC). The symbol's shape, fill color, outline color, and icon are all defined by the symbol
      * identifier. Use the '-' character to specify null entries in the symbol identifier.
-     * <p/>
+     * <p>
      * The position specifies the latitude, longitude, and altitude where the symbol is drawn on the globe. The
      * position's altitude component is interpreted according to this symbol's altitudeMode.
-     * <p/>
+     * <p>
      * The modifiers specify supplemental graphic and text attributes as key-value pairs. See the
      * MilStd2525TacticalSymbol class documentation for the list of recognized modifiers. In the case where both the
      * symbol identifier and the modifiers list specify the same attribute, the modifiers list has priority.
@@ -171,19 +171,29 @@ public class MilStd2525TacticalSymbol extends AbstractTacticalSymbol
      * object exists at the time the symbol was generated, or is anticipated to exist in the future. Additionally, a
      * symbol's Status can define its operational condition. The recognized values depend on the specific MIL-STD-2525
      * symbology scheme the symbol belongs to:
-     * <p/>
+     * <p>
      * <strong>Warfighting, Signals Intelligence, Stability Operations</strong>
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> <li>STATUS_PRESENT_FULLY_CAPABLE</li>
-     * <li>STATUS_PRESENT_DAMAGED</li> <li>STATUS_PRESENT_DESTROYED</li> <li>STATUS_PRESENT_FULL_TO_CAPACITY</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> 
+     * <li>STATUS_PRESENT</li> 
+     * <li>STATUS_PRESENT_FULLY_CAPABLE</li>
+     * <li>STATUS_PRESENT_DAMAGED</li> 
+     * <li>STATUS_PRESENT_DESTROYED</li> 
+     * <li>STATUS_PRESENT_FULL_TO_CAPACITY</li> </ul>
+     * <p>
      * <strong>Tactical Graphics</strong>
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_SUSPECTED</li> <li>STATUS_PRESENT</li> <li>STATUS_KNOWN</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> 
+     * <li>STATUS_SUSPECTED</li> 
+     * <li>STATUS_PRESENT</li> 
+     * <li>STATUS_KNOWN</li> 
+     * </ul>
+     * <p>
      * <strong>Emergency Management</strong>
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> </ul>
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> 
+     * <li>STATUS_PRESENT</li> 
+     * </ul>
      *
      * @param value the new value for the Status/Operational Condition field.
      *
@@ -224,9 +234,9 @@ public class MilStd2525TacticalSymbol extends AbstractTacticalSymbol
     /**
      * Specifies whether to draw this symbol's frame. The showFrame property provides control over this tactical
      * symbol's display option hierarchy as defined by MIL-STD-2525C, section 5.4.5 and table III.
-     * <p/>
+     * <p>
      * When <code>true</code>, this symbol's frame is drawn. This state corresponds to MIL-STD-2525C, table III, row 1.
-     * <p/>
+     * <p>
      * When <code>false</code>, this symbol's frame is not drawn. Instead, only the symbol's internal icon is drawn.
      * This state corresponds to MIL-STD-2525C, table III, row 4.
      *
@@ -252,9 +262,9 @@ public class MilStd2525TacticalSymbol extends AbstractTacticalSymbol
     /**
      * Specifies whether to draw this symbol's fill. The showFill property provides control over this tactical symbol's
      * display option hierarchy as defined by MIL-STD-2525C, section 5.4.5 and table III.
-     * <p/>
+     * <p>
      * When <code>true</code>, this symbol's fill is drawn. This state corresponds to MIL-STD-2525C, table III, row 1.
-     * <p/>
+     * <p>
      * When <code>false</code>, this symbol's fill is not drawn. Instead, only the symbol's frame and internal icon are
      * drawn. This state corresponds to MIL-STD-2525C, table III, row 2.
      *
@@ -280,9 +290,9 @@ public class MilStd2525TacticalSymbol extends AbstractTacticalSymbol
     /**
      * Specifies whether to draw this symbol's internal icon. The showIcon property provides control over this tactical
      * symbol's display option hierarchy as defined by MIL-STD-2525C, section 5.4.5 and table III.
-     * <p/>
+     * <p>
      * When <code>true</code>, this symbol's icon is drawn. This state corresponds to MIL-STD-2525C, table III, row 1.
-     * <p/>
+     * <p>
      * When <code>false</code>, this symbol's icon is not drawn. Instead, only the symbol's frame and fill are drawn.
      * This state corresponds to MIL-STD-2525C, table III, row 5.
      *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525UnitsFormat.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525UnitsFormat.java
@@ -30,7 +30,7 @@ public class MilStd2525UnitsFormat extends UnitsFormat
      * Constructs an instance that display length and area in specified units, and angles in degrees, minutes, seconds.
      *
      * @param lengthUnits the desired length units. Available length units are <code>METERS, KILOMETERS, MILES,
-     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code.
+     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code>.
      * @param areaUnits   the desired area units. Available area units are <code>SQUARE_METERS, SQUARE_KILOMETERS,
      *                    HECTARE, ACRE, SQUARE_YARD</code> and <code>SQUARE_FEET</code>.
      *
@@ -45,7 +45,7 @@ public class MilStd2525UnitsFormat extends UnitsFormat
      * Constructs an instance that display length and area in specified units, and angles in a specified format.
      *
      * @param lengthUnits the desired length units. Available length units are <code>METERS, KILOMETERS, MILES,
-     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code.
+     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code>.
      * @param areaUnits   the desired area units. Available area units are <code>SQUARE_METERS, SQUARE_KILOMETERS,
      *                    HECTARE, ACRE, SQUARE_YARD</code> and <code>SQUARE_FEET</code>.
      * @param showDMS     true if the desired angle format is degrees-minutes-seconds, false if the format is decimal

--- a/src/gov/nasa/worldwind/symbology/milstd2525/SymbolCode.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/SymbolCode.java
@@ -15,23 +15,32 @@ import gov.nasa.worldwind.util.Logging;
  * SymbolCode provides a utility for parsing and representing the individual fields of a MIL-STD-2525 symbol
  * identification code (SIDC). A SymbolCode can either be created by parsing a 15-character symbol code string or by
  * creating an empty SymbolCode and manually specifying its fields.
- * <p/>
+ * <p>
  * To parse a symbol code string, construct a new SymbolCode passing in the identifier string as the sole argument.
  * SymbolCode validates and parses the string, and populates its fields according to the contents of the string. If any
  * field in the code is unrecognized SymbolCode throws an exception and indicates the problematic fields in the
  * exception's message. After parsing, each field can be accessed by calling the appropriate accessor methods (for
  * example: getScheme/setScheme). SymbolCodes supports the following fields:
- * <p/>
- * <ul> <li>Coding Scheme</li> <li>Standard Identity</li> <li>Battle Dimension</li> <li>Category</li> <li>Function
- * ID</li> <li>Symbol Modifier</li> <li>Echelon</li> <li>Status</li> <li>Country Code</li> <li>Order of Battle</li>
+ * <ul> 
+ * <li>Coding Scheme</li> 
+ * <li>Standard Identity</li> 
+ * <li>Battle Dimension</li> 
+ * <li>Category</li> 
+ * <li>Function ID</li> 
+ * <li>Symbol Modifier</li> 
+ * <li>Echelon</li> 
+ * <li>Status</li> 
+ * <li>Country Code</li> 
+ * <li>Order of Battle</li>
  * </ul>
- * <p/>
+ * <p>
  * Which fields are populated after parsing a symbol code depends on the MIL-STD-2525 symbology set the symbol code
  * belongs to:
- * <p/>
- * <table border="1"> <tr><th>Symbology Set</th><th>Coding Scheme</th><th>Standard Identity</th><th>Battle
+ * <table border="1"><caption>Symbol Codes</caption> 
+ * <tr><th>Symbology Set</th><th>Coding Scheme</th><th>Standard Identity</th><th>Battle
  * Dimension</th><th>Category</th><th>Status</th><th>Function ID</th><th>Symbol Modifier</th><th>Echelon</th><th>Country
- * Code</th><th>Order of Battle</th></tr> <tr><td>Warfighting</td><td>YES</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td></tr>
+ * Code</th><th>Order of Battle</th></tr> 
+ * <tr><td>Warfighting</td><td>YES</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td></tr>
  * <tr><td>Tactical Graphics</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td><td>YES</td></tr>
  * <tr><td>Signals Intelligence</td><td>YES</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td><td>NO</td><td>NO</td><td>YES</td><td>YES</td></tr>
  * <tr><td>Stability Operations</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td><td>YES</td><td>YES</td><td>NO</td><td>YES</td><td>YES</td></tr>
@@ -58,7 +67,7 @@ public class SymbolCode extends AVListImpl
      * This throws an exception if any field in the symbol code is unrecognized, and indicates the problematic fields in
      * the exception's message. After construction, each field can be accessed by calling the appropriate accessor
      * methods (for example: getScheme/setScheme)
-     * <p/>
+     * <p>
      * See SymbolCode's class-level documentation for an overview of the supported MIL-STD-2525 symbol code fields.
      *
      * @param symCode the symbol identification code to parse.
@@ -107,9 +116,14 @@ public class SymbolCode extends AVListImpl
     /**
      * Specifies this symbol code's Coding Scheme field.  A symbol code's Coding Scheme defines the specific
      * MIL-STD-2525 symbology set that it belongs to. The value must be <code>null</code> or one of the following:
-     * <p/>
-     * <ul> <li>SCHEME_WARFIGHTING</li> <li>SCHEME_TACTICAL_GRAPHICS</li> <li>SCHEME_METOC</li>
-     * <li>SCHEME_INTELLIGENCE</li> <li>SCHEME_STABILITY_OPERATIONS</li> <li>SCHEME_EMERGENCY_MANAGEMENT</li> </ul>
+     * <ul> 
+     * <li>SCHEME_WARFIGHTING</li> 
+     * <li>SCHEME_TACTICAL_GRAPHICS</li> 
+     * <li>SCHEME_METOC</li>
+     * <li>SCHEME_INTELLIGENCE</li> 
+     * <li>SCHEME_STABILITY_OPERATIONS</li> 
+     * <li>SCHEME_EMERGENCY_MANAGEMENT</li> 
+     * </ul>
      *
      * @param value the new value for the Coding Scheme field. May be <code>null</code>.
      */
@@ -133,13 +147,14 @@ public class SymbolCode extends AVListImpl
     /**
      * Specifies this symbol code's Standard Identity field. A symbol code's Standard Identity defines the threat posed
      * by the object being represented. The value must be <code>null</code> or one of the following:
-     * <p/>
-     * <ul> <li>STANDARD_IDENTITY_PENDING</li> <li>STANDARD_IDENTITY_UNKNOWN</li> <li>STANDARD_IDENTITY_ASSUMED_FRIEND</li>
+     * <ul> 
+     * <li>STANDARD_IDENTITY_PENDING</li> <li>STANDARD_IDENTITY_UNKNOWN</li> <li>STANDARD_IDENTITY_ASSUMED_FRIEND</li>
      * <li>STANDARD_IDENTITY_FRIEND</li> <li>STANDARD_IDENTITY_NEUTRAL</li> <li>STANDARD_IDENTITY_SUSPECT</li>
      * <li>STANDARD_IDENTITY_HOSTILE</li> <li>STANDARD_IDENTITY_EXERCISE_PENDING</li>
      * <li>STANDARD_IDENTITY_EXERCISE_UNKNOWN</li> <li>STANDARD_IDENTITY_EXERCISE_ASSUMED_FRIEND</li>
      * <li>STANDARD_IDENTITY_EXERCISE_FRIEND</li> <li>STANDARD_IDENTITY_EXERCISE_NEUTRAL</li>
-     * <li>STANDARD_IDENTITY_JOKER</li> <li>STANDARD_IDENTITY_FAKER</li> </ul>
+     * <li>STANDARD_IDENTITY_JOKER</li> <li>STANDARD_IDENTITY_FAKER</li> 
+     * </ul>
      *
      * @param value the new value for the Standard Identity field. May be <code>null</code>.
      */
@@ -163,10 +178,11 @@ public class SymbolCode extends AVListImpl
     /**
      * Specifies this symbol code's Battle Dimension field. A symbol code's Battle Dimension defines the primary mission
      * area for the object being represented. The value must be <code>null</code> or one of the following:
-     * <p/>
-     * <ul> <li>BATTLE_DIMENSION_SPACE</li> <li>BATTLE_DIMENSION_AIR</li> <li>BATTLE_DIMENSION_GROUND</li>
+     * <ul> 
+     * <li>BATTLE_DIMENSION_SPACE</li> <li>BATTLE_DIMENSION_AIR</li> <li>BATTLE_DIMENSION_GROUND</li>
      * <li>BATTLE_DIMENSION_SEA_SURFACE</li> <li>BATTLE_DIMENSION_SEA_SUBSURFACE</li> <li>BATTLE_DIMENSION_SOF</li>
-     * <li>BATTLE_DIMENSION_OTHER</li> </ul>
+     * <li>BATTLE_DIMENSION_OTHER</li> 
+     * </ul>
      *
      * @param value the new value for the Battle Dimension field. May be <code>null</code>.
      */
@@ -190,23 +206,26 @@ public class SymbolCode extends AVListImpl
     /**
      * Specifies this symbol code's Category field. The meaning of a symbol code's Category and the recognized values
      * depend on the specific MIL-STD-2525 symbology scheme the symbol code belongs to:
-     * <p/>
+     * <p>
      * <strong>Tactical Graphics</strong>
-     * <p/>
-     * <ul> <li>CATEGORY_TASKS</li> <li>CATEGORY_COMMAND_CONTROL_GENERAL_MANEUVER</li>
+     * <ul> 
+     * <li>CATEGORY_TASKS</li> <li>CATEGORY_COMMAND_CONTROL_GENERAL_MANEUVER</li>
      * <li>CATEGORY_MOBILITY_SURVIVABILITY</li> <li>CATEGORY_FIRE_SUPPORT</li> <li>CATEGORY_COMBAT_SERVICE_SUPPORT</li>
-     * <li>CATEGORY_OTHER</li> </ul>
-     * <p/>
+     * <li>CATEGORY_OTHER</li> 
+     * </ul>
+     * <p>
      * <strong>Stability Operations</strong>
-     * <p/>
-     * <ul> <li>CATEGORY_VIOLENT_ACTIVITIES</li> <li>CATEGORY_LOCATIONS</li> <li>CATEGORY_OPERATIONS</li>
+     * <ul> 
+     * <li>CATEGORY_VIOLENT_ACTIVITIES</li> <li>CATEGORY_LOCATIONS</li> <li>CATEGORY_OPERATIONS</li>
      * <li>CATEGORY_ITEMS</li> <li>CATEGORY_INDIVIDUAL</li> <li>CATEGORY_NONMILITARY_GROUP_ORGANIZATION</li>
-     * <li>CATEGORY_RAPE</li> </ul>
-     * <p/>
+     * <li>CATEGORY_RAPE</li> 
+     * </ul>
+     * <p>
      * <strong>Emergency Management</strong>
-     * <p/>
-     * <ul> <li>CATEGORY_INCIDENT</li> <li>CATEGORY_NATURAL_EVENTS</li> <li>CATEGORY_OPERATIONS</li>
-     * <li>CATEGORY_INFRASTRUCTURE</li> </ul>
+     * <ul> 
+     * <li>CATEGORY_INCIDENT</li> <li>CATEGORY_NATURAL_EVENTS</li> <li>CATEGORY_OPERATIONS</li>
+     * <li>CATEGORY_INFRASTRUCTURE</li> 
+     * </ul>
      *
      * @param value the new value for the Category field. May be <code>null</code>.
      */
@@ -232,19 +251,22 @@ public class SymbolCode extends AVListImpl
      * represented object exists at the time the symbol was generated, or is anticipated to exist in the future.
      * Additionally, a symbol code's Status can define its operational condition. The recognized values depend on the
      * specific MIL-STD-2525 symbology scheme the symbol code belongs to:
-     * <p/>
+     * <p>
      * <strong>Warfighting, Signals Intelligence, Stability Operations</strong>
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> <li>STATUS_PRESENT_FULLY_CAPABLE</li>
-     * <li>STATUS_PRESENT_DAMAGED</li> <li>STATUS_PRESENT_DESTROYED</li> <li>STATUS_PRESENT_FULL_TO_CAPACITY</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> <li>STATUS_PRESENT_FULLY_CAPABLE</li>
+     * <li>STATUS_PRESENT_DAMAGED</li> <li>STATUS_PRESENT_DESTROYED</li> <li>STATUS_PRESENT_FULL_TO_CAPACITY</li> 
+     * </ul>
+     * <p>
      * <strong>Tactical Graphics</strong>
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_SUSPECTED</li> <li>STATUS_PRESENT</li> <li>STATUS_KNOWN</li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> <li>STATUS_SUSPECTED</li> <li>STATUS_PRESENT</li> <li>STATUS_KNOWN</li> 
+     * </ul>
+     * <p>
      * <strong>Emergency Management</strong>
-     * <p/>
-     * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> </ul>
+     * <ul> 
+     * <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> 
+     * </ul>
      *
      * @param value the new value for the Status/Operational Condition field. May be <code>null</code>.
      */
@@ -268,12 +290,14 @@ public class SymbolCode extends AVListImpl
     /**
      * Specifies this symbol code's Function ID field. The Function IDs are unique to each symbology schemes that uses
      * them, and are defined in each appendix of the MIL-STD-2525C specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.e (page 51) and table A-I (page 51)</li> <li>Tactical Graphics - section
-     * B.5.2.1.e (page 304) and table B-I (page 305)</li> <li>Meteorological and Oceanographic - section C.5.2.1.d (page
-     * 763) and table C-I (page 763)</li> <li>Signals Intelligence - section D.5.2.1.e (page 964) and table D-I (page
-     * 964)</li> <li>Stability Operations - section E.5.2.1.e (page 991) and table E-I (page 991)</li> <li>Emergency
-     * Management - table G-I (page 1032)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.e (page 51) and table A-I (page 51)</li> 
+     * <li>Tactical Graphics - section B.5.2.1.e (page 304) and table B-I (page 305)</li> 
+     * <li>Meteorological and Oceanographic - section C.5.2.1.d (page 763) and table C-I (page 763)</li> 
+     * <li>Signals Intelligence - section D.5.2.1.e (page 964) and table D-I (page 964)</li> 
+     * <li>Stability Operations - section E.5.2.1.e (page 991) and table E-I (page 991)</li> 
+     * <li>Emergency Management - table G-I (page 1032)</li> 
+     * </ul>
      *
      * @param value the new value for the Function ID field. May be <code>null</code>.
      */
@@ -300,10 +324,11 @@ public class SymbolCode extends AVListImpl
      * installation, equipment mobility, and auxiliary equipment. The recognized values depend on the specific
      * MIL-STD-2525 symbology scheme the symbol code belongs to, and are defined in each appendix of the MIL-STD-2525C
      * specification:
-     * <p/>
-     * <ul> <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> <li>Stability Operations -
-     * section E.5.2.1.f (page 991) and table E-II (pages 992-994)</li> <li>Emergency Management - section G.5.5 (page
-     * 1029) and table EG-II (page 1032)</li> </ul>
+     * <ul> 
+     * <li>Warfighting - section A.5.2.1.f (page 51) and table A-II (pages 52-54)</li> 
+     * <li>Stability Operations - section E.5.2.1.f (page 991) and table E-II (pages 992-994)</li> 
+     * <li>Emergency Management - section G.5.5 (page 1029) and table EG-II (page 1032)</li> 
+     * </ul>
      *
      * @param value the new value for the Symbol Modifier field. May be <code>null</code>.
      */
@@ -327,12 +352,10 @@ public class SymbolCode extends AVListImpl
     /**
      * Specifies this symbol code's Echelon field. A symbol code's Echelon defines the command level of a unit
      * represented by the symbol. The value must be <code>null</code> or one of the following:
-     * <p/>
      * <ul> <li>ECHELON_TEAM_CREW</li> <li>ECHELON_SQUAD</li> <li>ECHELON_SECTION</li>
      * <li>ECHELON_PLATOON_DETACHMENT</li> <li>ECHELON_COMPANY_BATTERY_TROOP</li> <li>ECHELON_BATTALION_SQUADRON</li>
      * <li>ECHELON_REGIMENT_GROUP</li> <li>ECHELON_BRIGADE</li> <li>ECHELON_DIVISION</li> <li>ECHELON_CORPS</li>
      * <li>ECHELON_ARMY</li> <li>ECHELON_ARMY_GROUP_FRONT</li> <li>ECHELON_REGION</li> <li>ECHELON_COMMAND</li> </ul>
-     * <p/>
      *
      * @param value the new value for the Echelon field. May be <code>null</code>.
      */
@@ -381,15 +404,13 @@ public class SymbolCode extends AVListImpl
      * Specifies this symbol code's Order of Battle field. A symbol code's Order of Battle provides additional
      * information about the symbol in the operational environment. The recognized values depend on the specific
      * MIL-STD-2525 symbology scheme the symbol code belongs to:
-     * <p/>
+     * <p>
      * <strong>Warfighting, Signals Intelligence, Stability Operations, Emergency Management</strong>
-     * <p/>
      * <ul> <li>ORDER_OF_BATTLE_AIR</li> <li>ORDER_OF_BATTLE_ELECTRONIC</li> <li>ORDER_OF_BATTLE_CIVILIAN</li>
      * <li>ORDER_OF_BATTLE_GROUND</li> <li>ORDER_OF_BATTLE_MARITIME</li> <li>ORDER_OF_BATTLE_STRATEGIC_FORCE_RELATED</li>
      * </ul>
-     * <p/>
+     * <p>
      * <strong>Tactical Graphics</strong>
-     * <p/>
      * <ul> <li>ORDER_OF_BATTLE_CONTROL_MARKINGS</li> </ul>
      *
      * @param value the new value for the Order of Battle field. May be <code>null</code>.
@@ -451,7 +472,7 @@ public class SymbolCode extends AVListImpl
      * that are unspecified or null are replaced with the MIL-STD-2525 unused position character "-". Field values are
      * either padded or trimmed to fit their portion of the symbol code, adding unused characters to pad or ignoring
      * extra characters to trim.
-     * <p/>
+     * <p>
      * This returns <code>null</code> if this SymbolCode's Coding Scheme is <code>null</code> or unrecognized.
      *
      * @return the MIL-STD-2525 15-character symbol identification code (SIDC) corresponding to this SymbolCode, or
@@ -491,16 +512,24 @@ public class SymbolCode extends AVListImpl
      * schemes: echelon, headquarters, task force, feint/dummy, installation, equipment mobility, and auxiliary
      * equipment. This adds modifier keys only for those modifiers present in the SymbolModifier field. Any modifiers
      * not in the SymbolModifier field are ignored. The following key-value pairs are used to indicate each modifier:
-     * <p/>
-     * <table border="1"> <tr><th>Modifier</th><th>Key</th><th>Value</th></tr> <tr><td>Echelon</td><td>SymbologyConstants.ECHELON</td><td>See
-     * {@link SymbologyConstants#ECHELON}</td></tr> <tr><td>Headquarters</td><td>SymbologyConstants.HEADQUARTERS</td><td>Boolean.TRUE
-     * or <code>null</code></td></tr> <tr><td>Task Force</td><td>SymbologyConstants.TASK_FORCE</td><td>Boolean.TRUE or
-     * <code>null</code></td></tr> <tr><td>Feint/Dummy</td><td>SymbologyConstants.FEINT_DUMMY</td><td>Boolean.TRUE or
-     * <code>null</code></td></tr> <tr><td>Installation</td><td>SymbologyConstants.INSTALLATION</td><td>See {@link
-     * SymbologyConstants#INSTALLATION}</td></tr> <tr><td>Equipment Mobility</td><td>SymbologyConstants.MOBILITY</td><td>See
-     * {@link SymbologyConstants#MOBILITY}</td></tr> <tr><td>Auxiliary Equipment</td><td>SymbologyConstants.AUXILIARY_EQUIPMENT</td><td>See
-     * {@link SymbologyConstants#AUXILIARY_EQUIPMENT}</td></tr> </table>
-     * <p/>
+     * <table border="1"><caption>Modifiers</caption>
+     * <tr><th>Modifier</th><th>Key</th><th>Value</th></tr> 
+     * <tr><td>Echelon</td><td>SymbologyConstants.ECHELON</td><td>See
+     * {@link SymbologyConstants#ECHELON}</td></tr> 
+     * <tr><td>Headquarters</td><td>SymbologyConstants.HEADQUARTERS</td><td>Boolean.TRUE
+     * or <code>null</code></td></tr> 
+     * <tr><td>Task Force</td><td>SymbologyConstants.TASK_FORCE</td><td>Boolean.TRUE or
+     * <code>null</code></td></tr> 
+     * <tr><td>Feint/Dummy</td><td>SymbologyConstants.FEINT_DUMMY</td><td>Boolean.TRUE or
+     * <code>null</code></td></tr> 
+     * <tr><td>Installation</td><td>SymbologyConstants.INSTALLATION</td><td>See {@link
+     * SymbologyConstants#INSTALLATION}</td></tr> 
+     * <tr><td>Equipment Mobility</td><td>SymbologyConstants.MOBILITY</td><td>See
+     * {@link SymbologyConstants#MOBILITY}</td></tr> 
+     * <tr><td>Auxiliary Equipment</td><td>SymbologyConstants.AUXILIARY_EQUIPMENT</td><td>See
+     * {@link SymbologyConstants#AUXILIARY_EQUIPMENT}</td></tr> 
+     * </table>
+     * <p>
      * Note that the installation modifier code indicates that an installation is either a normal installation or a
      * feint/dummy installation. In the latter case, this also sets the modifier key SymbologyConstants.FEINT_DUMMY to
      * Boolean.TRUE. This provides a consistent way to identify feint/dummy modifier status for both units/equipment and
@@ -716,7 +745,7 @@ public class SymbolCode extends AVListImpl
      * fields: Coding Scheme, Standard Identity, Battle Dimension, Status, Function ID, Symbol Modifier, Country Code,
      * Order of Battle. All fields except Function ID, Symbol Modifier, Country Code and Order of Battle must be
      * non-<code>null</code>.
-     * <p/>
+     * <p>
      * The Warfighting coding scheme is defined in MIL-STD-2525C table A-I (page 51).
      *
      * @param symCode the symbol code to parse. Must be non-<code>null</code> and have length of 15 or greater. Any
@@ -795,7 +824,7 @@ public class SymbolCode extends AVListImpl
      * following fields: Coding Scheme, Standard Identity, Category, Status, Function ID, Echelon, Country Code, Order
      * of Battle. All fields except Function ID, Echelon, Country Code and Order of Battle must be
      * non-<code>null</code>.
-     * <p/>
+     * <p>
      * The Tactical Graphics coding scheme is defined in MIL-STD-2525C table B-I (page 305).
      *
      * @param symCode the symbol code to parse. Must be non-<code>null</code> and have length of 15 or greater. Any
@@ -920,7 +949,7 @@ public class SymbolCode extends AVListImpl
      * Parses symbol codes encoded for the Signals Intelligence coding scheme. Signals Intelligence symbol codes contain
      * the following fields: Scheme, Standard Identity, Battle Dimension, Status, Function ID, Country Code, Order of
      * Battle. All fields except Function ID, Country Code and Order of Battle must be non-<code>null</code>.
-     * <p/>
+     * <p>
      * The Signals Intelligence coding scheme is defined in MIL-STD-2525C table D-I (page 964).
      *
      * @param symCode the symbol code to parse. Must be non-<code>null</code> and have length of 15 or greater. Any
@@ -992,7 +1021,7 @@ public class SymbolCode extends AVListImpl
      * the following fields: Scheme, Standard Identity, Category, Status, Function ID, Symbol Modifier, Country Code,
      * Order of Battle. All fields except Function ID, Symbol Modifier, Country Code and Order of Battle must be
      * non-<code>null</code>.
-     * <p/>
+     * <p>
      * The Stability Operations coding scheme is defined in MIL-STD-2525C table E-I (page 991).
      *
      * @param symCode the symbol code to parse. Must be non-<code>null</code> and have length of 15 or greater. Any
@@ -1066,7 +1095,7 @@ public class SymbolCode extends AVListImpl
      * the following fields: Scheme, Standard Identity, Category, Status, Function ID, Symbol Modifier, Country Code,
      * Order of Battle. All fields except Function ID, Symbol Modifier, Country Code and Order of Battle must be
      * non-<code>null</code>.
-     * <p/>
+     * <p>
      * The Emergency Management coding scheme is defined in MIL-STD-2525C table G-I (page 1032).
      *
      * @param symCode the symbol code to parse. Must be non-<code>null</code> and have length of 15 or greater. Any
@@ -1165,7 +1194,7 @@ public class SymbolCode extends AVListImpl
      * unspecified or null are replaced with the MIL-STD-2525 unused position character "-". Field values are either
      * padded or trimmed to fit their portion of the symbol code, adding unused characters to pad or ignoring extra
      * characters to trim.
-     * <p/>
+     * <p>
      * This returns <code>null</code> if this SymbolCode's Coding Scheme is <code>null</code> or unrecognized.
      *
      * @return the MIL-STD-2525 15-character symbol identification code (SIDC) corresponding to this SymbolCode, or
@@ -1219,7 +1248,7 @@ public class SymbolCode extends AVListImpl
      * Composes a 15-character symbol identification code (SIDC) for the Warfighting coding scheme. Warfighting symbol
      * codes contain the following fields: Coding Scheme, Standard Identity, Battle Dimension, Status, Function ID,
      * Symbol Modifier, Country Code, Order of Battle.
-     * <p/>
+     * <p>
      * The Warfighting coding scheme is defined in MIL-STD-2525C table A-I (page 51).
      *
      * @return the MIL-STD-2525 15-character symbol identification code (SIDC) corresponding to this SymbolCode,
@@ -1245,7 +1274,7 @@ public class SymbolCode extends AVListImpl
      * Composes a 15-character symbol identification code (SIDC) for the Tactical Graphics coding scheme. Tactical
      * Graphics symbol codes contain the following fields: Coding Scheme, Standard Identity, Category, Status, Function
      * ID, Echelon, Country Code, Order of Battle.
-     * <p/>
+     * <p>
      * The Tactical Graphics coding scheme is defined in MIL-STD-2525C table B-I (page 305).
      *
      * @return the MIL-STD-2525 15-character symbol identification code (SIDC) corresponding to this SymbolCode,
@@ -1272,7 +1301,7 @@ public class SymbolCode extends AVListImpl
      * Composes a 15-character symbol identification code (SIDC) for the Meteorological and Oceanographic coding scheme.
      * METOC symbol codes contain the following fields: Coding Scheme, Category, Static/Dynamic, Function ID, Graphic
      * Type.
-     * <p/>
+     * <p>
      * The Meteorological and Oceanographic coding scheme is defined in MIL-STD-2525C table C-I (page 763).
      *
      * @return the MIL-STD-2525 15-character symbol identification code (SIDC) corresponding to this SymbolCode,
@@ -1297,7 +1326,7 @@ public class SymbolCode extends AVListImpl
      * Composes a 15-character symbol identification code (SIDC) for the Signals Intelligence coding scheme. Signals
      * Intelligence symbol codes contain the following fields: Scheme, Standard Identity, Battle Dimension, Status,
      * Function ID, Country Code, Order of Battle.
-     * <p/>
+     * <p>
      * The Signals Intelligence coding scheme is defined in MIL-STD-2525C table D-I (page 964).
      *
      * @return the MIL-STD-2525 15-character symbol identification code (SIDC) corresponding to this SymbolCode,
@@ -1323,7 +1352,7 @@ public class SymbolCode extends AVListImpl
      * Composes a 15-character symbol identification code (SIDC) for the Stability Operations coding scheme. Stability
      * Operations symbol codes contain the following fields: Scheme, Standard Identity, Category, Status, Function ID,
      * Symbol Modifier, Country Code, Order of Battle.
-     * <p/>
+     * <p>
      * The Stability Operations coding scheme is defined in MIL-STD-2525C table E-I (page 991).
      *
      * @return the MIL-STD-2525 15-character symbol identification code (SIDC) corresponding to this SymbolCode,
@@ -1349,7 +1378,7 @@ public class SymbolCode extends AVListImpl
      * Composes a 15-character symbol identification code (SIDC) for the Emergency Management coding scheme. Emergency
      * Management symbol codes contain the following fields: Standard Identity, Category, Status, Function ID, Symbol
      * Modifier, Country Code, Order of Battle.
-     * <p/>
+     * <p>
      * The Emergency Management coding scheme is defined in MIL-STD-2525C table G-I (page 1032).
      *
      * @return the MIL-STD-2525 15-character symbol identification code (SIDC) corresponding to this SymbolCode,

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/EmsSidc.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/EmsSidc.java
@@ -10,7 +10,7 @@ package gov.nasa.worldwind.symbology.milstd2525.graphics;
  * SIDC constants for graphics in the "Emergency Management" scheme (MIL-STD-2525C Appendix G). The constants in this
  * interface are "masked" SIDCs. All fields except Scheme, Category, and Function ID are filled with hyphens. (The other
  * fields do not identity a type of graphic, they modify the graphic.)
- * <p/>
+ * <p>
  * Note: this interface only defines constants for tactical graphics in Appendix G.
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/MetocSidc.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/MetocSidc.java
@@ -654,7 +654,7 @@ public interface MetocSidc
     final String OCA_GPHY_MNEWBD_IMTBUR_10_20 = "WO-DGMIBC---A--";
     /** Impact burial,  20-75%. */
     final String OCA_GPHY_MNEWBD_IMTBUR_20_75 = "WO-DGMIBD---A--";
-    /** Impact burial, >75%. */
+    /** Impact burial, {@code >75%}. */
     final String OCA_GPHY_MNEWBD_IMTBUR_75 = "WO-DGMIBE---A--";
     /** Miw bottom category, a. */
     final String OCA_GPHY_MNEWBD_MIWBC_A = "WO-DGMBCA---A--";

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/TacticalGraphicSymbol.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/TacticalGraphicSymbol.java
@@ -23,7 +23,7 @@ import java.util.List;
  * Implementation of TacticalSymbol to render point graphics defined by MIL-STD-2525C Appendix B (Tactical Graphics).
  * This class implements the logic for rendering tactical point graphics, but actually implements the TacticalSymbol
  * interface.
- * <p/>
+ * <p>
  * This class is not meant to be used directly by applications. Instead, apps should use {@link MilStd2525PointGraphic},
  * which implements the {@link TacticalGraphic} interface. (MilStd2525PointGraphic uses TacticalGraphicSymbol internally
  * to render the point graphic.)
@@ -141,17 +141,14 @@ public class TacticalGraphicSymbol extends AbstractTacticalSymbol
      * Specifies this graphic's Status/Operational Condition field. A graphic's Status defines whether the represented
      * object exists at the time the symbol was generated, or is anticipated to exist in the future. Additionally, a
      * graphic's Status can define its operational condition. The recognized values depend on the graphic's scheme:
-     * <p/>
+     * <p>
      * <strong>Tactical graphics</strong>
-     * <p/>
      * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_SUSPECTED</li> <li>STATUS_PRESENT</li> <li>STATUS_KNOWN</li> </ul>
-     * <p/>
+     * <p>
      * <strong>Meteorological and Oceanographic</strong>
-     * <p/>
      * <ul> <li>Not supported</li> </ul>
-     * <p/>
+     * <p>
      * <strong>Emergency Management</strong>
-     * <p/>
      * <ul> <li>STATUS_ANTICIPATED</li> <li>STATUS_PRESENT</li> </ul>
      *
      * @param value the new value for the Status/Operational Condition field.

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/TriangleWavePositionIterator.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/TriangleWavePositionIterator.java
@@ -15,13 +15,14 @@ import java.util.*;
 /**
  * Iterator that computes the positions required to draw a triangle wave along a line specified by control positions.
  * The generated wave looks like this:
- * <p/>
  * <pre>
+ * {@code 
  *           /\             /\         <--- Amplitude
  *          /  \           /  \
  * ________/    \_________/    \_____
  * ^            ^
  * | Wave length|
+ * }
  * </pre>
  *
  * @author pabercrombie
@@ -185,12 +186,12 @@ public class TriangleWavePositionIterator implements Iterator
 
     /**
      * Compute the next position along the line, and transition the state machine to the next state (if appropriate).
-     * <p/>
+     * <p>
      * If the current state is STATE_LINE, this method returns either the next control point (if it is less than
      * waveLength meters from the current position, or a position waveLength meters along the control line. The state
      * machine will transition to STATE_WAVE_START only if the returned position is a full wavelength from the current
      * position.
-     * <p/>
+     * <p>
      * If the current state is STATE_WAVE_START, this method returns a position waveLength meters from the current
      * position along the control line, and transitions to state STATE_WAVE_PEAK.
      *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/AviationZone.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/AviationZone.java
@@ -15,7 +15,6 @@ import java.util.*;
 
 /**
  * Implementation of aviation area graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Restricted Operations Zone (2.X.2.2.3.1)</li> <li>Short Range Air Defense Engagement Zone (2.X.2.2.3.2)</li>
  * <li>High Density Airspace Control Zone (2.X.2.2.3.3)</li> <li>Missile Engagement Zone (2.X.2.2.3.4)</li> <li>Low
  * Altitude Missile Engagement Zone (2.X.2.2.3.4.1)</li> <li>High Altitude Missile Engagement Zone (2.X.2.2.3.4.2)</li>

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/BasicArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/BasicArea.java
@@ -18,10 +18,16 @@ import java.util.*;
 
 /**
  * Implementation of general area graphics. This class implements the following graphics:
- * <p/>
- * <ul> <li>General Area (2.X.2.1.3.1)</li> <li>Assembly Area (2.X.2.1.3.2)</li> <li>Engagement Area (2.X.2.1.3.3)</li>
- * <li>Drop Zone (2.X.2.1.3.5)</li> <li>Extraction Zone (2.X.2.1.3.6)</li> </li><li>Landing Zone (2.X.2.1.3.7)</li>
- * <li>Pickup Zone (2.X.2.1.3.8)</li> <li>Forward Arming and Refueling Area (FARP) (2.X.5.3.3)</li></ul>
+ * <ul>
+ * <li>General Area (2.X.2.1.3.1)</li>
+ * <li>Assembly Area (2.X.2.1.3.2)</li>
+ * <li>Engagement Area (2.X.2.1.3.3)</li>
+ * <li>Drop Zone (2.X.2.1.3.5)</li>
+ * <li>Extraction Zone (2.X.2.1.3.6)</li>
+ * <li>Landing Zone (2.X.2.1.3.7)</li>
+ * <li>Pickup Zone (2.X.2.1.3.8)</li>
+ * <li>Forward Arming and Refueling Area (FARP) (2.X.5.3.3)</li>
+ * </ul>
  *
  * @author pabercrombie
  * @version $Id: BasicArea.java 1171 2013-02-11 21:45:02Z dcollins $

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/BattlePosition.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/BattlePosition.java
@@ -17,10 +17,9 @@ import java.util.*;
 
 /**
  * Implementation of Battle Position graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Battle Position (2.X.2.4.3.1)</li> <li>Battle Position, Prepared But Not Occupied (2.X.2.4.3.1.1)</li>
  * </ul>
- * <p/>
+ * <p>
  * The Echelon label (field B) will be placed between the first and second control points.
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/CircularFireSupportArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/CircularFireSupportArea.java
@@ -17,7 +17,6 @@ import java.util.*;
 
 /**
  * Implementation of circular Fire Support graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Circular Target (2.X.4.3.1.2)</li> <li>Fire Support Area, Circular (2.X.4.3.2.1.3)</li> <li>Free Fire Area
  * (FFA), Circular (2.X.4.3.2.3.3)</li> <li>Restrictive Fire Area (RFA), Circular (2.X.4.3.2.5.3)</li> <li>Airspace
  * Coordination Area (ACA), Circular (2.X.4.3.2.2.3)</li> <li>Sensor Zone, Circular</li> <li>Dead Space Area,

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/CombatSupportArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/CombatSupportArea.java
@@ -12,7 +12,6 @@ import java.util.*;
 
 /**
  * Implementation of combat support area graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Detainee Holding Area (2.X.5.3.1)</li> <li>Enemy Prisoner of War Holding Area (2.X.5.3.2)</li> <li>Forward
  * Arming and Refueling Area (2.X.5.3.3)</li> <li>Refugee Holding Area (2.X.5.3.4)</li> <li>Support Areas Brigade (BSA)
  * (2.X.5.3.5.1)</li> <li>Support Areas Division (DSA) (2.X.5.3.5.2)</li> <li>Support Areas Regimental (RSA)

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/Dummy.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/Dummy.java
@@ -57,7 +57,7 @@ public class Dummy extends AbstractMilStd2525TacticalGraphic
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * The dummy graphic requires exactly three control points. Any positions beyond the first three will be ignored.
      *
      * @throws IllegalArgumentException if less than three control points are provided.

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/Encirclement.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/Encirclement.java
@@ -103,7 +103,6 @@ public class Encirclement extends BasicArea
     /**
      * Indicates the wavelength of the triangle wave that forms the graphic's boundary. This is the length from the
      * start of one "tooth" to the start of the next.
-     * <p/>
      * <pre>
      * __/\__/\__
      *  ^   ^

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/FortifiedArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/FortifiedArea.java
@@ -94,7 +94,6 @@ public class FortifiedArea extends BasicArea
     /**
      * Indicates the wavelength of the square wave that forms the graphic's boundary. This is the length from the start
      * of one square "tooth" to the start of the next.
-     * <p/>
      * <pre>
      *    __    __
      * __|  |__|  |__

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/IrregularFireSupportArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/IrregularFireSupportArea.java
@@ -17,7 +17,6 @@ import java.util.*;
 
 /**
  * Implementation of the irregular Fire Support area graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Area Target (2.X.4.3.1)</li> <li>Bomb (2.X.4.3.1.5)</li> <li>Airspace Coordination Area (ACA), Irregular
  * (2.X.4.3.2.2.1)</li> <li>Free Fire Area (FFA), Irregular (2.X.4.3.2.3.1)</li> <li>Restrictive Fire Area (RFA),
  * Irregular (2.X.4.3.2.5.1)</li> <li>Terminally Guided Munitions Footprint</li> <li>Sensor Zone, Irregular</li>

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/LimitedAccessArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/LimitedAccessArea.java
@@ -136,7 +136,7 @@ public class LimitedAccessArea extends AbstractMilStd2525TacticalGraphic
      * the terrain at the latitude and longitude of its position.</li> <li>WorldWind.RELATIVE_TO_GROUND -- this graphic
      * is placed above the terrain at the latitude and longitude of its position and the distance specified by its
      * elevation.</li> <li>WorldWind.ABSOLUTE -- this graphic is placed at its specified position.</li> </ul>
-     * <p/>
+     * <p>
      * This symbol assumes the altitude mode WorldWind.ABSOLUTE if the specified mode is not recognized.
      *
      * @param altitudeMode this graphic new altitude mode.

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/OffenseArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/OffenseArea.java
@@ -12,7 +12,6 @@ import java.util.*;
 
 /**
  * Implementation of offense area graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Assault Position (2.X.2.5.3.1)</li> <li>Attack Position (2.X.2.5.3.2)</li> <li>Objective (2.X.2.5.3.5)</li>
  * <li>Penetration Box (2.X.2.5.3.6)</li> </ul>
  *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/RectangularFireSupportArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/RectangularFireSupportArea.java
@@ -17,7 +17,6 @@ import java.util.*;
 
 /**
  * Implementation of rectangular Fire Support graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Free Fire Area (FFA), Rectangular (2.X.4.3.2.3.2)</li> <li>Restrictive Fire Area (RFA), Rectangular
  * (2.X.4.3.2.5.2)</li> <li>Airspace Coordination Area (ACA), Rectangular (2.X.4.3.2.2.2)</li> <li>Sensor Zone,
  * Rectangular</li> <li>Dead Space Area, Rectangular</li> <li>Zone of Responsibility, Rectangular</li> <li>Target

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/SectorRangeFan.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/SectorRangeFan.java
@@ -719,7 +719,7 @@ public class SectorRangeFan extends AbstractMilStd2525TacticalGraphic implements
      * Create positions to draw an arc around the graphic's center position. The arc is described by a radius, left
      * azimuth, and right azimuth. The arc positions are added onto an existing list of positions, in left to right
      * order (the arc draws from the left azimuth to the right azimuth).
-     * <p/>
+     * <p>
      * If the left and right azimuths are equal, then this methods adds a single position to the list at the desired
      * azimuth and radius.
      *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/SpecialInterestArea.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/areas/SpecialInterestArea.java
@@ -12,7 +12,6 @@ import java.util.*;
 
 /**
  * Implementation of General Command/Special area graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Area of Operations (2.X.2.6.2.1)</li> <li>Named Area of Interest (2.X.2.6.2.4)</li> <li>Targeted Area of
  * Interest (2.X.2.6.2.5)</li> </ul>
  *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/AbstractAxisArrow.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/AbstractAxisArrow.java
@@ -160,7 +160,6 @@ public abstract class AbstractAxisArrow extends AbstractMilStd2525TacticalGraphi
      * default. However, some applications may prefer to specify the width of the route rather than the width of the
      * arrowhead. In the diagram below, the default behavior is for the final control point to specify point A. When
      * {@code finalPointWidthOfRoute} is true the final control point specifies point B instead.
-     * <p/>
      * <pre>
      *                 A
      *                 |\
@@ -223,7 +222,7 @@ public abstract class AbstractAxisArrow extends AbstractMilStd2525TacticalGraphi
 
     /**
      * Create positions that make up the arrow head.
-     * <p/>
+     * <p>
      * The arrow head is defined by the first two control points, and the last point. Pt. 1' is the point on the center
      * line at the base of the arrow head, and Pt. N' is the reflection of Pt. N about the center line.
      * <pre>

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/DirectionOfAttack.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/DirectionOfAttack.java
@@ -20,7 +20,7 @@ import java.util.*;
 
 /**
  * Direction of Attack graphics. This class implements the following graphics:
- * <p/>
+ * 
  * <ul> <li>Direction of Main Attack graphic (2.X.2.5.2.2.2.1)</li> <li>Direction of Supporting Attack graphic
  * (2.X.2.5.2.2.2.2)</li> </ul>
  *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/DirectionOfAttackAviation.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/DirectionOfAttackAviation.java
@@ -292,10 +292,10 @@ public class DirectionOfAttackAviation extends DirectionOfAttack
 
     /**
      * Compute a point along a Hermite curve defined by two control point and tangent vectors at those points.
-     * <p/>
+     * <p>
      * This function implements the Hermite curve equation from "Mathematics for 3D Game Programming and Computer
      * Graphics, Second Edition" by Eric Lengyel (equation 15.15, pg. 457).
-     * <p/>
+     * <p>
      * H(t) = (1 - 3t<sup>2</sup> + 2t<sup>3</sup>)P<sub>1</sub> + t<sup>2</sup>(3 - 2t)P<sub>2</sub> + t(t -
      * 1)<sup>2</sup>T<sub>1</sub> + t<sup>2</sup>(t - 1)T<sub>2</sub>
      *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/FireSupportLine.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/FireSupportLine.java
@@ -20,7 +20,7 @@ import java.util.*;
 
 /**
  * Implementation of Fire Support line graphics. This class implements the following graphics:
- * <p/>
+ * 
  * <ul> <li>Fire Support Coordination Line (2.X.4.2.2.1)</li> <li>Coordinated Fire Line (2.X.4.2.2.2)</li>
  * <li>Restrictive Fire Line (2.X.4.2.2.4)</li> </ul>
  *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/ForwardLineOfOwnTroops.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/ForwardLineOfOwnTroops.java
@@ -80,7 +80,6 @@ public class ForwardLineOfOwnTroops extends PhaseLine
      * Indicates the wavelength of the semicircle wave that forms the graphic's boundary. This is the length from the
      * start of one "tooth" to the start of the next. If not wave length is specified a default wave length will be
      * computed.
-     * <p/>
      * <pre>
      * /\/\/\/\/\
      * ^ ^

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/HoldingLine.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/HoldingLine.java
@@ -20,9 +20,9 @@ import java.util.*;
 
 /**
  * This class implements the following graphics:
- * <p/>
+ * 
  * <ul> <li>Holding Line (2.X.2.6.1.2)</li> <li>Bridgehead (2.X.2.6.1.4)</li> </ul>
- * <p/>
+ * <p>
  * Note: These graphics require three control points. The first two points define the end points of the graphic, and the
  * third point defines the top of an arc that connects the endpoints. The specification for Holding Line and Bridgehead
  * (MIL-STD-2525C pgs 538 and 540) states that "Additional points can be defined to extend the line". However, the

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/LinearTarget.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/LinearTarget.java
@@ -20,7 +20,7 @@ import java.util.*;
 
 /**
  * Implementation of Linear Target graphics. This class implements the following graphics:
- * <p/>
+ * 
  * <ul> <li>Linear Target (2.X.4.2.1)</li> <li>Linear Smoke Target (2.X.4.2.1.1)</li> <li>Final Protective Fire (FPF)
  * (2.X.4.2.1.2)</li> </ul>
  *

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/PhaseLine.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/PhaseLine.java
@@ -19,7 +19,6 @@ import java.util.*;
 
 /**
  * Implementation of phase line graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Phase Line (2.X.2.1.2.4)</li> <li>Light Line (2.X.2.1.2.5)</li> <li>Final Coordination Line
  * (2.X.2.5.2.3)</li> <li>Limits of Advance (2.X.2.5.2.5)</li> <li>Line of Departure (2.X.2.5.2.6)</li> <li>Line of
  * Departure/Line of Contact (2.X.2.5.2.7)</li> <li>Line of Departure/Line of Contact (2.X.2.5.2.8)</li> <li>Release

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/RoutePoint.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/lines/RoutePoint.java
@@ -17,7 +17,6 @@ import java.util.*;
 
 /**
  * Implementation of aviation route control point graphics. This class implements the following graphics:
- * <p/>
  * <ul> <li>Air Control Point (2.X.2.2.1.1)</li> <li>Communications Checkpoint (2.X.2.2.1.2)</li> </ul>
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwind/terrain/AbstractElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/AbstractElevationModel.java
@@ -251,12 +251,15 @@ abstract public class AbstractElevationModel extends WWObjectImpl implements Ele
 
     /**
      * Appends elevation model configuration parameters as elements to the specified context. This appends elements for
-     * the following parameters: <table> <th><td>Parameter</td><td>Element Path</td><td>Type</td></th> <tr><td>{@link
-     * AVKey#DISPLAY_NAME}</td><td>DisplayName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#NETWORK_RETRIEVAL_ENABLED}</td><td>NetworkRetrievalEnabled</td><td>Boolean</td></tr> <tr><td>{@link
-     * AVKey#MISSING_DATA_SIGNAL}</td><td>MissingData/@signal</td><td>Double</td></tr> <tr><td>{@link
-     * AVKey#MISSING_DATA_REPLACEMENT}</td><td>MissingData/@replacement</td><td>Double</td></tr> <tr><td>{@link
-     * AVKey#DETAIL_HINT}</td><td>DataDetailHint</td><td>Double</td></tr> </table>
+     * the following parameters: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr>
+     * <tr><td>{@link AVKey#DISPLAY_NAME}</td><td>DisplayName</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#NETWORK_RETRIEVAL_ENABLED}</td><td>NetworkRetrievalEnabled</td><td>Boolean</td></tr> 
+     * <tr><td>{@link AVKey#MISSING_DATA_SIGNAL}</td><td>MissingData/@signal</td><td>Double</td></tr> 
+     * <tr><td>{@link AVKey#MISSING_DATA_REPLACEMENT}</td><td>MissingData/@replacement</td><td>Double</td></tr> 
+     * <tr><td>{@link AVKey#DETAIL_HINT}</td><td>DataDetailHint</td><td>Double</td></tr> 
+     * </table>
      *
      * @param params  the key-value pairs which define the elevation model configuration parameters.
      * @param context the XML document root on which to append elevation model configuration elements.
@@ -308,9 +311,11 @@ abstract public class AbstractElevationModel extends WWObjectImpl implements Ele
     /**
      * Parses elevation model configuration parameters from the specified DOM document. This writes output as key-value
      * pairs to params. If a parameter from the XML document already exists in params, that parameter is ignored.
-     * Supported parameters are: <table> <th><td>Parameter</td><td>Element Path</td><td>Type</td></th> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#DISPLAY_NAME}</td><td>DisplayName</td><td>String</td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#NETWORK_RETRIEVAL_ENABLED}</td><td>NetworkRetrievalEnabled</td><td>Boolean</td></tr>
+     * Supported parameters are: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DISPLAY_NAME}</td><td>DisplayName</td><td>String</td></tr> 
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#NETWORK_RETRIEVAL_ENABLED}</td><td>NetworkRetrievalEnabled</td><td>Boolean</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#MISSING_DATA_SIGNAL}</td><td>MissingData/@signal</td><td>Double</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#MISSING_DATA_REPLACEMENT}</td><td>MissingData/@replacement</td><td>Double</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DETAIL_HINT}</td><td>DataDetailHint</td><td>Double</td></tr>

--- a/src/gov/nasa/worldwind/terrain/BasicElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/BasicElevationModel.java
@@ -688,10 +688,10 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all elevations for a given sector and resolution to the
      * current WorldWind file cache, without downloading imagery already in the cache.
-     * <p/>
+     * <p>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link BasicElevationModelBulkDownloader}.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -713,10 +713,10 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
     /**
      * Start a new {@link BulkRetrievalThread} that downloads all elevations for a given sector and resolution to a
      * specified file store, without downloading imagery already in the file store.
-     * <p/>
+     * <p>
      * This method creates and starts a thread to perform the download. A reference to the thread is returned. To create
      * a downloader that has not been started, construct a {@link BasicElevationModelBulkDownloader}.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -751,7 +751,7 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
     /**
      * Get the estimated size in bytes of the elevations not in the WorldWind file cache for the given sector and
      * resolution.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -770,7 +770,7 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
     /**
      * Get the estimated size in bytes of the elevations not in a specified file store for the given sector and
      * resolution.
-     * <p/>
+     * <p>
      * Note that the target resolution must be provided in radians of latitude per texel, which is the resolution in
      * meters divided by the globe radius.
      *
@@ -2149,20 +2149,24 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
 
     /**
      * Appends BasicElevationModel configuration parameters as elements to the specified context. This appends elements
-     * for the following parameters: <table> <th><td>Parameter</td><td>Element Path</td><td>Type</td></th>
-     * <tr><td>{@link AVKey#SERVICE_NAME}</td><td>Service/@serviceName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#IMAGE_FORMAT}</td><td>ImageFormat</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#AVAILABLE_IMAGE_FORMATS}</td><td>AvailableImageFormats/ImageFormat</td><td>String array</td></tr>
-     * <tr><td>{@link AVKey#DATA_TYPE}</td><td>DataType/@type</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#BYTE_ORDER}</td><td>ByteOrder</td><td>DataType/@byteOrder</td></tr> <tr><td>{@link
-     * AVKey#ELEVATION_EXTREMES_FILE}</td><td>ExtremeElevations/FileName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#ELEVATION_MAX}</td><td>ExtremeElevations/@max</td><td>Double</td></tr> <tr><td>{@link
-     * AVKey#ELEVATION_MIN}</td><td>ExtremeElevations/@min</td><td>Double</td></tr> </table> This also writes common
-     * elevation model and LevelSet configuration parameters by invoking {@link gov.nasa.worldwind.terrain.AbstractElevationModel#createElevationModelConfigElements(gov.nasa.worldwind.avlist.AVList,
+     * for the following parameters:
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr>
+     * <tr><td>{@link AVKey#SERVICE_NAME}</td><td>Service/@serviceName</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#IMAGE_FORMAT}</td><td>ImageFormat</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#AVAILABLE_IMAGE_FORMATS}</td><td>AvailableImageFormats/ImageFormat</td><td>String
+     * array</td></tr>
+     * <tr><td>{@link AVKey#DATA_TYPE}</td><td>DataType/@type</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#BYTE_ORDER}</td><td>ByteOrder</td><td>DataType/@byteOrder</td></tr>
+     * <tr><td>{@link AVKey#ELEVATION_EXTREMES_FILE}</td><td>ExtremeElevations/FileName</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#ELEVATION_MAX}</td><td>ExtremeElevations/@max</td><td>Double</td></tr>
+     * <tr><td>{@link AVKey#ELEVATION_MIN}</td><td>ExtremeElevations/@min</td><td>Double</td></tr>
+     * </table>
+     * This also writes common elevation model and LevelSet configuration parameters by invoking {@link gov.nasa.worldwind.terrain.AbstractElevationModel#createElevationModelConfigElements(gov.nasa.worldwind.avlist.AVList,
      * org.w3c.dom.Element)} and {@link DataConfigurationUtils#createLevelSetConfigElements(gov.nasa.worldwind.avlist.AVList,
      * org.w3c.dom.Element)}.
      *
-     * @param params  the key-value pairs which define the BasicElevationModel configuration parameters.
+     * @param params the key-value pairs which define the BasicElevationModel configuration parameters.
      * @param context the XML document root on which to append BasicElevationModel configuration elements.
      *
      * @return a reference to context.
@@ -2268,22 +2272,26 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
     /**
      * Parses BasicElevationModel parameters from a specified DOM document. This writes output as key-value pairs to
      * params. If a parameter from the XML document already exists in params, that parameter is ignored. Supported key
-     * and parameter names are: <table> <th><td>Parameter</td><td>Element Path</td><td>Type</td></th> <tr><td>{@link
-     * AVKey#SERVICE_NAME}</td><td>Service/@serviceName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#IMAGE_FORMAT}</td><td>ImageFormat</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#AVAILABLE_IMAGE_FORMATS}</td><td>AvailableImageFormats/ImageFormat</td><td>String array</td></tr>
-     * <tr><td>{@link AVKey#DATA_TYPE}</td><td>DataType/@type</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#BYTE_ORDER}</td><td>DataType/@byteOrder</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#ELEVATION_EXTREMES_FILE}</td><td>ExtremeElevations/FileName</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#ELEVATION_MAX}</td><td>ExtremeElevations/@max</td><td>Double</td></tr> <tr><td>{@link
-     * AVKey#ELEVATION_MIN}</td><td>ExtremeElevations/@min</td><td>Double</td></tr> </table> This also parses common
-     * elevation model and LevelSet configuration parameters by invoking {@link gov.nasa.worldwind.terrain.AbstractElevationModel#getElevationModelConfigParams(org.w3c.dom.Element,
+     * and parameter names are:
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr>
+     * <tr><td>{@link AVKey#SERVICE_NAME}</td><td>Service/@serviceName</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#IMAGE_FORMAT}</td><td>ImageFormat</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#AVAILABLE_IMAGE_FORMATS}</td><td>AvailableImageFormats/ImageFormat</td><td>String
+     * array</td></tr>
+     * <tr><td>{@link AVKey#DATA_TYPE}</td><td>DataType/@type</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#BYTE_ORDER}</td><td>DataType/@byteOrder</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#ELEVATION_EXTREMES_FILE}</td><td>ExtremeElevations/FileName</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#ELEVATION_MAX}</td><td>ExtremeElevations/@max</td><td>Double</td></tr>
+     * <tr><td>{@link AVKey#ELEVATION_MIN}</td><td>ExtremeElevations/@min</td><td>Double</td></tr>
+     * </table>
+     * This also parses common elevation model and LevelSet configuration parameters by invoking {@link gov.nasa.worldwind.terrain.AbstractElevationModel#getElevationModelConfigParams(org.w3c.dom.Element,
      * gov.nasa.worldwind.avlist.AVList)} and {@link gov.nasa.worldwind.util.DataConfigurationUtils#getLevelSetConfigParams(org.w3c.dom.Element,
      * gov.nasa.worldwind.avlist.AVList)}.
      *
      * @param domElement the XML document root to parse for BasicElevationModel configuration parameters.
-     * @param params     the output key-value pairs which recieve the BasicElevationModel configuration parameters. A
-     *                   null reference is permitted.
+     * @param params the output key-value pairs which recieve the BasicElevationModel configuration parameters. A null
+     * reference is permitted.
      *
      * @return a reference to params, or a new AVList if params is null.
      *

--- a/src/gov/nasa/worldwind/terrain/BasicElevationModelBulkDownloader.java
+++ b/src/gov/nasa/worldwind/terrain/BasicElevationModelBulkDownloader.java
@@ -22,7 +22,7 @@ import java.util.*;
 /**
  * Downloads elevation data not currently available in the WorldWind file cache or a specified {@link FileStore}. The
  * class derives from {@link Thread} and is meant to operate in its own thread.
- * <p/>
+ * <p>
  * The sector and resolution associated with the downloader are specified during construction and are final.
  *
  * @author tag
@@ -40,7 +40,7 @@ public class BasicElevationModelBulkDownloader extends BulkRetrievalThread
 
     /**
      * Constructs a downloader to retrieve elevations not currently available in the WorldWind file cache.
-     * <p/>
+     * <p>
      * The thread returned is not started during construction, the caller must start the thread.
      *
      * @param elevationModel the elevation model for which to download elevations.
@@ -63,7 +63,7 @@ public class BasicElevationModelBulkDownloader extends BulkRetrievalThread
 
     /**
      * Constructs a downloader to retrieve elevations not currently available in a specified file store.
-     * <p/>
+     * <p>
      * The thread returned is not started during construction, the caller must start the thread.
      *
      * @param elevationModel the elevation model for which to download elevations.

--- a/src/gov/nasa/worldwind/terrain/BasicElevationModelFactory.java
+++ b/src/gov/nasa/worldwind/terrain/BasicElevationModelFactory.java
@@ -36,7 +36,7 @@ public class BasicElevationModelFactory extends BasicFactory
      * <li>a {@link java.net.URL}</li> <li>a {@link java.io.File}</li> <li>a {@link java.io.InputStream}</li> <li> an
      * {@link org.w3c.dom.Element}</li> <li>a {@link String} holding a file name, a name of a resource on the classpath,
      * or a string representation of a URL</li> </ul>
-     * <p/>
+     * <p>
      * For non-compound models, this method maps the <code>serviceName</code> attribute of the
      * <code>ElevationModel/Service</code> element of the XML configuration document to the appropriate elevation-model
      * type. Service types recognized are:" <ul> <li>"WMS" for elevation models that draw their data from a WMS web
@@ -115,7 +115,7 @@ public class BasicElevationModelFactory extends BasicFactory
      * @return the requested elevation model, or null if the specified element does not describe an elevation model.
      *
      * @throws Exception if a problem occurs during creation.
-     * @see #createNonCompoundModel(org.w3c.dom.Element, gov.nasa.worldwind.avlist.AVList).
+     * @see #createNonCompoundModel(org.w3c.dom.Element, gov.nasa.worldwind.avlist.AVList)
      */
     @Override
     protected ElevationModel doCreateFromElement(Element domElement, AVList params) throws Exception
@@ -145,7 +145,7 @@ public class BasicElevationModelFactory extends BasicFactory
 
     /**
      * Creates a compound elevation model and populates it with a specified list of elevation models.
-     * <p/>
+     * <p>
      * Any exceptions occurring during creation of the elevation models are logged and not re-thrown. The elevation
      * models associated with the exceptions are not included in the returned compound model.
      *
@@ -155,7 +155,7 @@ public class BasicElevationModelFactory extends BasicFactory
      * @return a compound elevation model populated with the specified elevation models. The compound model will contain
      *         no elevation models if none were specified or exceptions occurred for all that were specified.
      *
-     * @see #createNonCompoundModel(org.w3c.dom.Element, gov.nasa.worldwind.avlist.AVList).
+     * @see #createNonCompoundModel(org.w3c.dom.Element, gov.nasa.worldwind.avlist.AVList)
      */
     protected CompoundElevationModel createCompoundModel(Element[] elements, AVList params)
     {

--- a/src/gov/nasa/worldwind/terrain/CompoundElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/CompoundElevationModel.java
@@ -463,7 +463,7 @@ public class CompoundElevationModel extends AbstractElevationModel
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * NOTE: This method returns only unmapped elevations if the compound model contains more than one elevation model.
      * This enables the compound model's lower resolution elevation models to specify missing data values for the higher
      * resolution elevation models.
@@ -494,7 +494,7 @@ public class CompoundElevationModel extends AbstractElevationModel
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * NOTE: This method returns only unmapped elevations if the compound model contains more than one elevation model.
      * This enables the compound model's lower resolution elevation models to specify missing data values for the higher
      * resolution elevation models.

--- a/src/gov/nasa/worldwind/terrain/HighResolutionTerrain.java
+++ b/src/gov/nasa/worldwind/terrain/HighResolutionTerrain.java
@@ -329,7 +329,7 @@ public class HighResolutionTerrain extends WWObjectImpl implements Terrain
 
     /**
      * Intersect a line with the terrain.
-     * <p/>
+     * <p>
      * Note: This method produces a result only if the line is below the globe's horizon, i.e., it intersects the
      * globe's ellipsoid. If the line is above the horizon, null is returned even if there is terrain in the path of the
      * line.
@@ -447,7 +447,7 @@ public class HighResolutionTerrain extends WWObjectImpl implements Terrain
      *                  positions[3], etc.
      * @param callback  An object to call in order to return the computed intersections.
      *
-     * @throws InterruptedException
+     * @throws InterruptedException on error
      */
     public void intersect(List<Position> positions, final IntersectionCallback callback) throws InterruptedException
     {
@@ -486,7 +486,7 @@ public class HighResolutionTerrain extends WWObjectImpl implements Terrain
     /**
      * Cause the tiles used by subsequent intersection calculations to be cached so that they are available immediately
      * to those subsequent calculations.
-     * <p/>
+     * <p>
      * Pre-caching is unnecessary and is useful only when it can occur before the intersection calculations are needed.
      * It will incur extra overhead otherwise. The normal intersection calculations cause the same caching.
      *
@@ -535,7 +535,7 @@ public class HighResolutionTerrain extends WWObjectImpl implements Terrain
     /**
      * Cause the tiles used by subsequent intersection calculations to be cached so that they are available immediately
      * to those subsequent calculations.
-     * <p/>
+     * <p>
      * Pre-caching is unnecessary and is useful only when it can occur before the intersection calculations are needed.
      * It will incur extra overhead otherwise. The normal intersection calculations cause the same caching.
      *
@@ -1130,7 +1130,7 @@ public class HighResolutionTerrain extends WWObjectImpl implements Terrain
 
     /**
      * Computes the Cartesian, model-coordinate point of a location within a terrain tile.
-     * <p/>
+     * <p>
      * This operation fails with a {@link gov.nasa.worldwind.exception.WWTimeoutException} if a timeout has been
      * specified and it is exceeded during the operation.
      *
@@ -1175,7 +1175,7 @@ public class HighResolutionTerrain extends WWObjectImpl implements Terrain
 
     /**
      * Computes the Cartesian, model-coordinate point of a location within a terrain tile.
-     * <p/>
+     * <p>
      * This operation fails with a {@link gov.nasa.worldwind.exception.WWTimeoutException} if a timeout has been
      * specified and it is exceeded during the operation.
      *

--- a/src/gov/nasa/worldwind/terrain/LocalElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/LocalElevationModel.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Implements an elevation model for a local file or collection of files containing elevation data.
- * <p/>
+ * <p>
  * Note: Unless the amount of data associated with the local elevation models is small, it's best to construct and add
  * elevations to a local elevation model on a thread other than the event dispatch thread in order to avoid freezing the
  * user interface.

--- a/src/gov/nasa/worldwind/terrain/LocalRasterServerElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/LocalRasterServerElevationModel.java
@@ -26,9 +26,9 @@ public class LocalRasterServerElevationModel extends BasicElevationModel
 {
     /**
      * Constructs an elevation model from a list of parameters describing the elevation model.
-     * <p/>
+     * <p>
      * Parameter values for DATASET_NAME and DATA_CACHE_NAME are required.
-     * <p/>
+     * <p>
      * TODO: Enumerate the other required and optional parameters.
      *
      * @param params the parameters describing the dataset.
@@ -45,9 +45,9 @@ public class LocalRasterServerElevationModel extends BasicElevationModel
 
     /**
      * Constructs an elevation model from an XML document description.
-     * <p/>
+     * <p>
      * Either the specified XML document or parameter list must contain values for DATASET_NAME and DATA_CACHE_NAME.
-     * <p/>
+     * <p>
      * TODO: Enumerate the other required and optional parameters.
      *
      * @param dom    the XML document describing the dataset.
@@ -67,9 +67,9 @@ public class LocalRasterServerElevationModel extends BasicElevationModel
 
     /**
      * Constructs an elevation model from an XML document {@link Element}.
-     * <p/>
+     * <p>
      * Either the specified XML element or parameter list must contain values for DATASET_NAME and DATA_CACHE_NAME.
-     * <p/>
+     * <p>
      * TODO: Enumerate the other required and optional parameters.
      *
      * @param domElement the XML document describing the dataset.

--- a/src/gov/nasa/worldwind/terrain/RectangularTessellator.java
+++ b/src/gov/nasa/worldwind/terrain/RectangularTessellator.java
@@ -1190,7 +1190,7 @@ public class RectangularTessellator extends WWObjectImpl implements Tessellator
 
     /**
      * Render each triangle of a tile in a unique color. Used during picking to identify triangles at the pick points.
-     * <p/>
+     * <p>
      * Note: This method modifies the GL_VERTEX_ARRAY and GL_COLOR_ARRAY state and does not restore it. Callers should
      * ensure that GL_CLIENT_VERTEX_ARRAY_BIT has been pushed, and eventually pop it when done using this method.
      *

--- a/src/gov/nasa/worldwind/terrain/SectorGeometry.java
+++ b/src/gov/nasa/worldwind/terrain/SectorGeometry.java
@@ -14,7 +14,7 @@ import java.nio.DoubleBuffer;
 
 /**
  * This interface provides access to individual terrain tiles, which are contained in a {@link SectorGeometryList}.
- * <p/>
+ * <p>
  * Note: Three methods of this class assume that the {@link SectorGeometryList#beginRendering(gov.nasa.worldwind.render.DrawContext)}
  * method of the containing sector geometry list has been called prior to calling them. They are {@link
  * #pick(gov.nasa.worldwind.render.DrawContext, java.awt.Point)}, {@link #pick(gov.nasa.worldwind.render.DrawContext,
@@ -41,7 +41,7 @@ public interface SectorGeometry extends Renderable
     /**
      * Performs a pick on the geometry. The result, if any, is added to the draw context's picked-object list. See
      * {@link gov.nasa.worldwind.render.DrawContext#getPickedObjects()}.
-     * <p/>
+     * <p>
      * Note: This method assumes that {@link SectorGeometryList#beginRendering(gov.nasa.worldwind.render.DrawContext)}
      * was called prior to this method.
      *
@@ -85,7 +85,7 @@ public interface SectorGeometry extends Renderable
     /**
      * Displays the geometry. The number of texture units to use may be specified, but at most only the number of
      * available units are used.
-     * <p/>
+     * <p>
      * Note: This method assumes that {@link SectorGeometryList#beginRendering(gov.nasa.worldwind.render.DrawContext)}
      * was called prior to this method.
      *
@@ -128,7 +128,7 @@ public interface SectorGeometry extends Renderable
 
     /**
      * Performs a pick on the geometry.
-     * <p/>
+     * <p>
      * Note: This method assumes that {@link SectorGeometryList#beginRendering(gov.nasa.worldwind.render.DrawContext)}
      * was called prior to this method.
      *
@@ -184,7 +184,7 @@ public interface SectorGeometry extends Renderable
     /**
      * Displays the geometry. The number of texture units to use may be specified, but at most only the number of
      * available units are used.
-     * <p/>
+     * <p>
      * Note: This method allows but does not require that {@link SectorGeometryList#beginRendering(gov.nasa.worldwind.render.DrawContext)}
      * was called prior to this method. See the description of the <code>beginRenderingCalled</code> argument.
      *
@@ -192,7 +192,7 @@ public interface SectorGeometry extends Renderable
      * @param numTextureUnits      the number of texture units to attempt to use.
      * @param beginRenderingCalled indicates whether this sector geometry's <code>beginRendering</code> method has been
      *                             called prior to calling this method. True indicated it was called, false indicates
-     *                             that it was not. Calling <beginRendering> eliminates redundant rendering set-up and
+     *                             that it was not. Calling {@code <beginRendering>} eliminates redundant rendering set-up and
      *                             is used when this sector geometry is rendered several times in succession.
      *
      * @throws IllegalArgumentException if the draw context is null or the number of texture units is less than one.
@@ -202,14 +202,14 @@ public interface SectorGeometry extends Renderable
 
     /**
      * Displays the geometry.
-     * <p/>
+     * <p>
      * Note: This method allows but does not require that {@link SectorGeometryList#beginRendering(gov.nasa.worldwind.render.DrawContext)}
      * was called prior to this method. See the description of the <code>beginRenderingCalled</code> argument.
      *
      * @param dc                   the current draw context.
      * @param beginRenderingCalled indicates whether this sector geometry's <code>beginRendering</code> method has been
      *                             called prior to calling this method. True indicated it was called, false indicates
-     *                             that it was not. Calling <beginRendering> eliminates redundant rendering set-up and
+     *                             that it was not. Calling <code>beginRendering</code> eliminates redundant rendering set-up and
      *                             is used when this sector geometry is rendered several times in succession.
      *
      * @throws IllegalArgumentException if the draw context is null or the number of texture units is less than one.

--- a/src/gov/nasa/worldwind/terrain/SectorGeometryList.java
+++ b/src/gov/nasa/worldwind/terrain/SectorGeometryList.java
@@ -103,7 +103,7 @@ public class SectorGeometryList extends ArrayList<SectorGeometry>
 
     /**
      * Detects the locations of the sector geometries in this list that intersect a specified screen point.
-     * <p/>
+     * <p>
      * Note: Prior to calling this method, {@link #beginRendering(gov.nasa.worldwind.render.DrawContext)} must be
      * called.
      *
@@ -163,7 +163,7 @@ public class SectorGeometryList extends ArrayList<SectorGeometry>
     /**
      * Detects the locations of the sector geometries in this list that intersect any of the points in a specified list
      * of screen points.
-     * <p/>
+     * <p>
      * Note: Prior to calling this method, {@link #beginRendering(gov.nasa.worldwind.render.DrawContext)} must be
      * called.
      *
@@ -382,7 +382,7 @@ public class SectorGeometryList extends ArrayList<SectorGeometry>
      *
      * @param line the <code>Line</code> for which an intersection is to be found.
      *
-     * @return the <Vec4> point closest to the ray origin where an intersection has been found or null if no
+     * @return the <code>Vec4</code> point closest to the ray origin where an intersection has been found or null if no
      *         intersection was found.
      */
     public Intersection[] intersect(Line line)
@@ -436,10 +436,10 @@ public class SectorGeometryList extends ArrayList<SectorGeometry>
 
     /**
      * Determines if and where the geometry intersects the ellipsoid at a given elevation.
-     * <p/>
+     * <p>
      * The returned array of <code>Intersection</code> describes a list of individual segments - two
      * <code>Intersection</code> for each, corresponding to each geometry triangle that intersects the given elevation.
-     * <p/>
+     * <p>
      * Note that the provided bounding <code>Sector</code> only serves as a 'hint' to avoid processing unnecessary
      * geometry tiles. The returned intersection list may contain segments outside that sector.
      *

--- a/src/gov/nasa/worldwind/terrain/Terrain.java
+++ b/src/gov/nasa/worldwind/terrain/Terrain.java
@@ -32,7 +32,7 @@ public interface Terrain
 
     /**
      * Computes the Cartesian, model-coordinate point of a position on the terrain.
-     * <p/>
+     * <p>
      * This operation fails with a {@link gov.nasa.worldwind.exception.WWTimeoutException} if a timeout has been
      * specified and it is exceeded during the operation.
      *
@@ -51,7 +51,7 @@ public interface Terrain
 
     /**
      * Computes the Cartesian, model-coordinate point of a location on the terrain.
-     * <p/>
+     * <p>
      * This operation fails with a {@link gov.nasa.worldwind.exception.WWTimeoutException} if a timeout has been
      * specified and it is exceeded during the operation.
      *
@@ -74,7 +74,7 @@ public interface Terrain
      * Computes the intersections of a line with the terrain. The line is specified by two positions whose altitude
      * field indicates the height above the terrain (not the altitude relative to sea level). All intersection points
      * are returned.
-     * <p/>
+     * <p>
      * This operation fails with a {@link gov.nasa.worldwind.exception.WWTimeoutException} if a timeout has been
      * specified and it is exceeded during the operation.
      *
@@ -95,7 +95,7 @@ public interface Terrain
     /**
      * Computes the intersections of a line with the terrain. The line is specified by two positions whose altitude
      * field is interpreted according to the specified altitude mode. All intersection points are returned.
-     * <p/>
+     * <p>
      * This operation fails with a {@link gov.nasa.worldwind.exception.WWTimeoutException} if a timeout has been
      * specified and it is exceeded during the operation.
      *
@@ -116,7 +116,7 @@ public interface Terrain
 
     /**
      * Computes the elevation at a specified location.
-     * <p/>
+     * <p>
      * This operation fails with a {@link gov.nasa.worldwind.exception.WWTimeoutException} if a timeout has been
      * specified and it is exceeded during the operation.
      *

--- a/src/gov/nasa/worldwind/terrain/WMSBasicElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/WMSBasicElevationModel.java
@@ -266,11 +266,14 @@ public class WMSBasicElevationModel extends BasicElevationModel
 
     /**
      * Parses WMSBasicElevationModel configuration parameters from a specified WMS Capabilities source. This writes
-     * output as key-value pairs to params. Supported key and parameter names are: <table>
-     * <th><td>Parameter</td><td>Value</td><td>Type</td></th> <tr><td>{@link AVKey#ELEVATION_MAX}</td><td>WMS layer's
-     * maximum extreme elevation</td><td>Double</td></tr> <tr><td>{@link AVKey#ELEVATION_MIN}</td><td>WMS layer's
-     * minimum extreme elevation</td><td>Double</td></tr> <tr><td>{@link AVKey#DATA_TYPE}</td><td>Translate WMS layer's
-     * image format to a matching data type</td><td>String</td></tr> </table> This also parses common WMS layer
+     * output as key-value pairs to params. Supported key and parameter names are: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Value</th><th>Type</th></tr> 
+     * <tr><td>{@link AVKey#ELEVATION_MAX}</td><td>WMS layer's maximum extreme elevation</td><td>Double</td></tr> 
+     * <tr><td>{@link AVKey#ELEVATION_MIN}</td><td>WMS layer's minimum extreme elevation</td><td>Double</td></tr> 
+     * <tr><td>{@link AVKey#DATA_TYPE}</td><td>Translate WMS layer's image format to a matching data type</td><td>String</td></tr> 
+     * </table> 
+     * This also parses common WMS layer
      * parameters by invoking {@link DataConfigurationUtils#getWMSLayerConfigParams(gov.nasa.worldwind.ogc.wms.WMSCapabilities,
      * String[], gov.nasa.worldwind.avlist.AVList)}.
      *

--- a/src/gov/nasa/worldwind/util/AbstractResizeHotSpot.java
+++ b/src/gov/nasa/worldwind/util/AbstractResizeHotSpot.java
@@ -17,9 +17,9 @@ import java.awt.event.*;
  * the resize controls. The HotSpot is defined by a direction, for example, {@link AVKey#NORTH} indicates that the
  * HotSpot resizes the frame vertically from the north edge (the user clicks the top edge of the frame and drags
  * vertically).
- * <p/>
+ * <p>
  * An instance of this class should be added to the picked object when the edge or corner of the frame is picked.
- * <p/>
+ * <p>
  * Subclasses must the implement {#getSize}, {#setSize}, {#getScreenPoint}, and {#setScreenPoint} to manipulate the
  * frame that they want to resize.
  *

--- a/src/gov/nasa/worldwind/util/BasicDragger.java
+++ b/src/gov/nasa/worldwind/util/BasicDragger.java
@@ -60,6 +60,8 @@ public class BasicDragger implements SelectListener
     /**
      * Ignores the useTerrain argument as it has been deprecated and utilizes the single parameter constructor.
      *
+     * @param wwd the WorldWindow
+     * @param useTerrain flag
      * @deprecated the useTerrain property has been deprecated in favor of the {@link Draggable} interface which allows
      * the object to define the drag behavior.
      */
@@ -89,7 +91,7 @@ public class BasicDragger implements SelectListener
     }
 
     /**
-     * @param useTerrain
+     * @param useTerrain setting
      *
      * @deprecated definition of dragging behavior now defined by the object in the {@link Draggable} interface.
      */

--- a/src/gov/nasa/worldwind/util/BasicGLCapabilitiesChooser.java
+++ b/src/gov/nasa/worldwind/util/BasicGLCapabilitiesChooser.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * BasicGLCapabilitiesChooser provides an implementation of {@link com.jogamp.opengl.GLCapabilitiesChooser} for use
  * with WorldWindow implementations (for example, WorldWindowGLCanvas and WorldWindowGLJPanel).
- * <p/>
+ * <p>
  * BasicGLCapabilitiesChooser extends the behavior of the default GLCapabilitiesChooser by implementing a fallback
  * behavior when device supported stereo is requested but is not supported by the hardware. In this case,
  * BasicGLCapabilitiesChooser attempts to find a match to the desired capabilities, but without device supported stereo.

--- a/src/gov/nasa/worldwind/util/BasicNamespaceContext.java
+++ b/src/gov/nasa/worldwind/util/BasicNamespaceContext.java
@@ -25,9 +25,12 @@ public class BasicNamespaceContext implements NamespaceContext
     private Map<String, Set<String>> prefixesByURI = new HashMap<String, Set<String>>();
 
     /**
-     * Sole constructor for BasicNamespaceContext. This configures the following namespaces: <table>
-     * <tr><th>Prefix</th><th>URI</th></tr> <tr><td>xml</td><td>http://www.w3.org/XML/1998/namespace</td></tr>
-     * <tr><td>xmlns</td><td>http://www.w3.org/2000/xmlns/</td></tr> <tr><td>xlink</td><td>http://www.w3.org/1999/xlink</td></tr>
+     * Sole constructor for BasicNamespaceContext. This configures the following namespaces: 
+     * <table><caption>Namespaces</caption>
+     * <tr><th>Prefix</th><th>URI</th></tr> 
+     * <tr><td>xml</td><td>http://www.w3.org/XML/1998/namespace</td></tr>
+     * <tr><td>xmlns</td><td>http://www.w3.org/2000/xmlns/</td></tr> 
+     * <tr><td>xlink</td><td>http://www.w3.org/1999/xlink</td></tr>
      * </table>
      */
     public BasicNamespaceContext()

--- a/src/gov/nasa/worldwind/util/BasicQuadTree.java
+++ b/src/gov/nasa/worldwind/util/BasicQuadTree.java
@@ -14,10 +14,10 @@ import java.util.*;
 /**
  * Implements a quadtree backed by a bit-set index. A bit-set provides a minimal-memory index. Each bit identifies one
  * cell in the quadtree.
- * <p/>
+ * <p>
  * This class provides methods to add and remove items from the quadtree, and to determine the items intersecting
  * specified regions.
- * <p/>
+ * <p>
  * Items can be added with an associated name, and can be retrieved and removed by name.
  *
  * @author tag
@@ -34,7 +34,7 @@ public class BasicQuadTree<T> extends BitSetQuadTreeFilter implements Iterable<T
 
     /**
      * Constructs a quadtree of a specified level and spanning a specified region.
-     * <p/>
+     * <p>
      * The number of levels in the quadtree must be specified to the constructor. The more levels there are the more
      * discriminating searches will be, but at the cost of some performance because more cells are searched. For the
      * Earth, a level count of 8 provides leaf cells about 75 km along their meridian edges (edges of constant Earth, a
@@ -66,7 +66,7 @@ public class BasicQuadTree<T> extends BitSetQuadTreeFilter implements Iterable<T
 
     /**
      * Constructs a quadtree of a specified level and spanning a specified region.
-     * <p/>
+     * <p>
      * The number of levels in the quadtree must be specified to the constructor. The more levels there are the more
      * discriminating searches will be, but at the cost of some performance because more cells are searched. For the
      * Earth, a level count of 8 provides leaf cells about 75 km along their meridian edges (edges of constant Earth, a
@@ -216,7 +216,7 @@ public class BasicQuadTree<T> extends BitSetQuadTreeFilter implements Iterable<T
 
     /**
      * Removes an item from the tree.
-     * <p/>
+     * <p>
      * <em>Note:</em> For large collections, this can be an expensive operation.
      *
      * @param item the item to remove. If null, no item is removed.
@@ -249,7 +249,7 @@ public class BasicQuadTree<T> extends BitSetQuadTreeFilter implements Iterable<T
 
     /**
      * Removes an item from the tree by name.
-     * <p/>
+     * <p>
      * <em>Note:</em> For large collections, this can be an expensive operation.
      *
      * @param name the name of the item to remove. If null, no item is removed.
@@ -296,7 +296,7 @@ public class BasicQuadTree<T> extends BitSetQuadTreeFilter implements Iterable<T
     /**
      * Returns an iterator over the items in the tree. There is no specific iteration order and the iterator may return
      * duplicate entries.
-     * <p/>
+     * <p>
      * <em>Note</em> The {@link java.util.Iterator#remove()} operation is not supported.
      *
      * @return an iterator over the items in the tree.

--- a/src/gov/nasa/worldwind/util/BitSetQuadTreeFilter.java
+++ b/src/gov/nasa/worldwind/util/BitSetQuadTreeFilter.java
@@ -15,7 +15,7 @@ import java.util.*;
  * tree's cells. For each submitted item, this class' {@link #doOperation} method is called for each leaf or
  * intermediate cell that intersects the item. That method typically stores the item's association with the intersecting
  * cell, either to populate a quadtree membership list or to mark it as a visible item.
- * <p/>
+ * <p>
  * The filter uses a bit-set to identify cells that intersect submitted items. This minimal memory eliminates the need
  * to retain cell information other than identity. Only cell identities are retained by this abstract class. Subclasses
  * provide the means to retain item information associated with intersecting cells.
@@ -258,7 +258,7 @@ public abstract class BitSetQuadTreeFilter
      * A quadtree filter that determines the bit positions of cells associated with items and intersecting a specified
      * region. Typically used to traverse the bit-set index of a populated quadtree to determine potentially visible
      * items.
-     * <p/>
+     * <p>
      * This class requires a previously populated filter and determines which of its cells intersect a specified
      * sector.
      */

--- a/src/gov/nasa/worldwind/util/BoundedHashMap.java
+++ b/src/gov/nasa/worldwind/util/BoundedHashMap.java
@@ -7,7 +7,7 @@ package gov.nasa.worldwind.util;
 
 /**
  * BoundedHashMap is a map with a fixed capacity. When the map's size exceeds its capacity, it automatically removes
- * elements until its size is equal to its capacity. <p/> BoundedHashMap can operate in two ordering modes: insertion
+ * elements until its size is equal to its capacity. <p> BoundedHashMap can operate in two ordering modes: insertion
  * order and access order. The mode specified which entries are automatically removed when the map is over capacity. In
  * insertion order mode the map removes the eldest entry (the first entry added). In access order mode, the map
  * automatically removes the least recently used entry.

--- a/src/gov/nasa/worldwind/util/BufferFactory.java
+++ b/src/gov/nasa/worldwind/util/BufferFactory.java
@@ -10,7 +10,7 @@ package gov.nasa.worldwind.util;
  * gov.nasa.worldwind.util.BufferWrapper}, without having to know the underlying data type. Once created, a
  * BufferWrapper abstracts reading and writing buffer data from the underlying data type. When BufferWrapper is combined
  * with BufferFactory, a component may create and work with buffer data in a type agnostic manner.
- * <p/>
+ * <p>
  * BufferFactory is itself abstract and defines the factory interface. It defines several implementations as static
  * inner classes, which serve the most common data types: {@link gov.nasa.worldwind.util.BufferFactory.ByteBufferFactory},
  * {@link gov.nasa.worldwind.util.BufferFactory.ShortBufferFactory}, {@link gov.nasa.worldwind.util.BufferFactory.IntBufferFactory},

--- a/src/gov/nasa/worldwind/util/ClippingTessellator.java
+++ b/src/gov/nasa/worldwind/util/ClippingTessellator.java
@@ -85,6 +85,10 @@ public class ClippingTessellator
      * Computes a 4-bit code indicating the vertex's location in the 9 cell grid defined by the clip coordinates and the
      * eight adjacent spaces defined by extending the min/max boundaries to infinity. 0 indicates that the vertex is
      * inside the clip coordinates.
+     * 
+     * @param degreesLatitude the latitude in degrees.
+     * @param degreesLongitude the longitude in degrees.
+     * @return The clip code. 0 indicates that the vertex is inside the clip coordinates.
      */
     protected int clipCode(double degreesLatitude, double degreesLongitude)
     {

--- a/src/gov/nasa/worldwind/util/CompoundVecBuffer.java
+++ b/src/gov/nasa/worldwind/util/CompoundVecBuffer.java
@@ -15,10 +15,10 @@ import java.util.*;
  * gov.nasa.worldwind.util.VecBuffer} objects. Each VecBuffer is retrieved via an index. The range of valid indices in a
  * CompoundVecBuffer is [0, size() - 1], inclusive. Implementations of CompoundVecBuffer define how each VecBuffer is
  * stored and retrieved according to its index.
- * <p/>
+ * <p>
  * To retrieve a single VecBuffer given an index, invoke {@link #subBuffer(int)}. To retrieve a VecBuffer's size, in
  * number of logical tuples, invoke {@link #subBufferSize(int)}.
- * <p/>
+ * <p>
  * To create a new view of this CompoundVecBuffer from one or many VecBuffers, invoke one of the <code>slice</code>
  * methods: <ul> <li>{@link #slice(int, int)} creates a view of this CompoundVecbufer given a contiguous sequence of
  * VecBuffer indices.</li> <li>{@link #slice(int[], int, int)} creates a view of this CompoundVecBuffer given an array
@@ -187,8 +187,8 @@ public abstract class CompoundVecBuffer
      *
      * @return a new CompoundVecBuffer representing a subset of this CompoundVecBuffer.
      *
-     * @throws IllegalArgumentException if beginIndex is out of range, if endIndex is out of range, or if beginIndex >
-     *                                  endIndex.
+     * @throws IllegalArgumentException if beginIndex is out of range, if endIndex is out of range, or if {@code beginIndex >
+     *                                  endIndex}.
      */
     public CompoundVecBuffer slice(int beginIndex, int endIndex)
     {

--- a/src/gov/nasa/worldwind/util/ContourBuilder.java
+++ b/src/gov/nasa/worldwind/util/ContourBuilder.java
@@ -16,12 +16,12 @@ import java.util.*;
  * two-dimensional scalar data, whereas the ContourLine shape operates only on elevation values associated with a World
  * Wind globe. Note that ContourBuilder can be used to compute contour line coordinates within a rectangular array of
  * elevation values.
- * <p/>
+ * <p>
  * ContourBuilder operates on a caller specified rectangular array. The array is specified as a one dimensional array of
  * floating point numbers, and is understood to be organized in row-major order, with the first index indicating the
  * value at the rectangle's upper-left corner. The domain of array values is any value that fits in a 64-bit floating
  * point number.
- * <p/>
+ * <p>
  * Contour lines may be computed at any threshold value (i.e. isovalue) by calling {@link #buildContourLines(double)} or
  * {@link #buildContourLines(double, gov.nasa.worldwind.geom.Sector, double)}. The latter method maps contour line
  * coordinates to geographic positions by associating the rectangular array with a geographic sector. It is valid to
@@ -237,8 +237,7 @@ public class ContourBuilder
      * list of two-element arrays, with the X coordinate at index 0 and the Y coordinate at index 1. The domain of
      * contour line coordinates is the XY Cartesian space defined by the rectangular array's width and height. X
      * coordinates range from 0 to width-1, and Y coordinates range from 0 to height-1.
-     * <p/>
-     * <p/>
+     * <p>
      * This returns an empty list if there are no contour lines associated with the value. This occurs when the value is
      * less than the rectangular array's minimum value, or when the value is greater than the rectangular array's
      * maximum value.
@@ -265,13 +264,13 @@ public class ContourBuilder
      * coordinates to geographic positions by associating the rectangular array with a geographic sector. The array's
      * upper left corner is mapped to the sector's Northwest corner, and the array's lower right corner is mapped to the
      * sector's Southeast corner.
-     * <p/>
+     * <p>
      * The domain of contour line coordinates is the geographic space defined by the specified sector. Prior to the
      * mapping into geographic coordinates, contour line X coordinates range from 0 to width-1, and Y coordinates range
      * from 0 to height-1. After the mapping into geographic coordinates, contour line X coordinates range from
      * sector.getMinLongitude() to sector.getMaxLongitude(), and Y coordinates range from sector.getMaxLatitude() to
      * sector.getMinLatitude().
-     * <p/>
+     * <p>
      * This returns an empty list if there are no contour lines associated with the value. This occurs when the value is
      * less than the rectangular array's minimum value, or when the value is greater than the rectangular array's
      * maximum value.

--- a/src/gov/nasa/worldwind/util/DataConfigurationUtils.java
+++ b/src/gov/nasa/worldwind/util/DataConfigurationUtils.java
@@ -125,7 +125,9 @@ public class DataConfigurationUtils
     /**
      * Returns the specified data configuration document's display name as a string, or null if the document is not one
      * of the recognized types. This determines the display name for each type of data configuration document as
-     * follows: <table> <tr><th>Document Type</th><th>Path to Display Name</th></tr> <tr><td>Layer
+     * follows: 
+     * <table><caption>Document Types</caption>
+     * <tr><th>Document Type</th><th>Path to Display Name</th></tr> <tr><td>Layer
      * Configuration</td><td>./DisplayName</td></tr> <tr><td>Elevation Model Configuration</td><td>./DisplayName</td></tr>
      * <tr><td>Installed DataDescriptor</td><td>./property[@name="dataSet"]/property[@name="gov.nasa.worldwind.avkey.DatasetNameKey"]</td></tr>
      * <tr><td>WorldWind .NET LayerSet</td><td>./QuadTileSet/Name</td></tr> <tr><td>Other</td><td>null</td></tr>
@@ -169,8 +171,9 @@ public class DataConfigurationUtils
 
     /**
      * Returns the specified data configuration document's type as a string, or null if the document is not one of the
-     * recognized types. This maps data configuration documents to a type string as follows: <table> <tr><th>Document
-     * Type</th><th>Type String</th></tr> <tr><td>Layer Configuration</td><td>"Layer"</td></tr> <tr><td>Elevation Model
+     * recognized types. This maps data configuration documents to a type string as follows: 
+     * <table><caption>Document Types</caption>
+     * <tr><th>Document Type</th><th>Type String</th></tr> <tr><td>Layer Configuration</td><td>"Layer"</td></tr> <tr><td>Elevation Model
      * Configuration</td><td>"Elevation Model"</td></tr> <tr><td>Installed DataDescriptor</td><td>"Layer" or
      * "ElevationModel"</td></tr> <tr><td>WorldWind .NET LayerSet</td><td>"Layer"</td></tr>
      * <tr><td>Other</td><td>null</td></tr> </table>
@@ -270,7 +273,7 @@ public class DataConfigurationUtils
      * Convenience method for computing a data configuration file's cache name in a FileStore, given the file's cache
      * path. This writes the computed cache name to the specified parameter list under the key {@link
      * gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}. If the parameter already exists, it's left unchanged.
-     * <p/>
+     * <p>
      * A data configuration file's cache name is its parent directory in the cache. The cache name therefore points to
      * the directory containing both the configuration file and any cached data associated with it. Determining the
      * cache name at run time - instead of hard wiring it in the data configuration file - enables cache data to be
@@ -460,14 +463,17 @@ public class DataConfigurationUtils
 
     /**
      * Appends WMS layer parameters as elements to a specified context. This appends elements for the following
-     * parameters: <table> <th><td>Parameter</td><td>Element Path</td><td>Type</td></th> <tr><td>{@link
-     * AVKey#WMS_VERSION}</td><td>Service/@version</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#LAYER_NAMES}</td><td>Service/LayerNames</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#STYLE_NAMES}</td><td>Service/StyleNames</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#GET_MAP_URL}</td><td>Service/GetMapURL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#GET_CAPABILITIES_URL}</td><td>Service/GetCapabilitiesURL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#SERVICE}</td><td>AVKey#GET_MAP_URL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#DATASET_NAME}</td><td>AVKey.LAYER_NAMES</td><td>String</td></tr> </table>
+     * parameters: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> 
+     * <tr><td>{@link AVKey#WMS_VERSION}</td><td>Service/@version</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#LAYER_NAMES}</td><td>Service/LayerNames</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#STYLE_NAMES}</td><td>Service/StyleNames</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#GET_MAP_URL}</td><td>Service/GetMapURL</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#GET_CAPABILITIES_URL}</td><td>Service/GetCapabilitiesURL</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#SERVICE}</td><td>AVKey#GET_MAP_URL</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#DATASET_NAME}</td><td>AVKey.LAYER_NAMES</td><td>String</td></tr> 
+     * </table>
      *
      * @param params  the key-value pairs which define the WMS layer configuration parameters.
      * @param context the XML document root on which to append WMS layer configuration elements.
@@ -537,13 +543,16 @@ public class DataConfigurationUtils
 
     /**
      * Appends WCS layer parameters as elements to a specified context. This appends elements for the following
-     * parameters: <table> <th><td>Parameter</td><td>Element Path</td><td>Type</td></th> <tr><td>{@link
-     * AVKey#WCS_VERSION}</td><td>Service/@version</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#COVERAGE_IDENTIFIERS}</td><td>Service/coverageIdentifiers</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#GET_COVERAGE_URL}</td><td>Service/GetCoverageURL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#GET_CAPABILITIES_URL}</td><td>Service/GetCapabilitiesURL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#SERVICE}</td><td>AVKey#GET_COVERAGE_URL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#DATASET_NAME}</td><td>AVKey.COVERAGE_IDENTIFIERS</td><td>String</td></tr> </table>
+     * parameters: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> 
+     * <tr><td>{@link AVKey#WCS_VERSION}</td><td>Service/@version</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#COVERAGE_IDENTIFIERS}</td><td>Service/coverageIdentifiers</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#GET_COVERAGE_URL}</td><td>Service/GetCoverageURL</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#GET_CAPABILITIES_URL}</td><td>Service/GetCapabilitiesURL</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#SERVICE}</td><td>AVKey#GET_COVERAGE_URL</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#DATASET_NAME}</td><td>AVKey.COVERAGE_IDENTIFIERS</td><td>String</td></tr> 
+     * </table>
      *
      * @param params  the key-value pairs which define the WMS layer configuration parameters.
      * @param context the XML document root on which to append WMS layer configuration elements.
@@ -613,14 +622,18 @@ public class DataConfigurationUtils
     /**
      * Parses WMS layer parameters from the XML configuration document starting at domElement. This writes output as
      * key-value pairs to params. If a parameter from the XML document already exists in params, that parameter is
-     * ignored. Supported key and parameter names are: <table> <th><td>Parameter</td><td>Element
-     * Path</td><td>Type</td></th> <tr><td>{@link AVKey#WMS_VERSION}</td><td>Service/@version</td><td>String</td></tr>
-     * <tr><td>{@link AVKey#LAYER_NAMES}</td><td>Service/LayerNames</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#STYLE_NAMES}</td><td>Service/StyleNames</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#GET_MAP_URL}</td><td>Service/GetMapURL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#GET_CAPABILITIES_URL}</td><td>Service/GetCapabilitiesURL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#SERVICE}</td><td>AVKey#GET_MAP_URL</td><td>String</td></tr> <tr><td>{@link
-     * AVKey#DATASET_NAME}</td><td>AVKey.LAYER_NAMES</td><td>String</td></tr> </table>
+     * ignored. Supported key and parameter names are:
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element
+     * Path</th><th>Type</th></tr> 
+     * <tr><td>{@link AVKey#WMS_VERSION}</td><td>Service/@version</td><td>String</td></tr>
+     * <tr><td>{@link AVKey#LAYER_NAMES}</td><td>Service/LayerNames</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#STYLE_NAMES}</td><td>Service/StyleNames</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#GET_MAP_URL}</td><td>Service/GetMapURL</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#GET_CAPABILITIES_URL}</td><td>Service/GetCapabilitiesURL</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#SERVICE}</td><td>AVKey#GET_MAP_URL</td><td>String</td></tr> 
+     * <tr><td>{@link AVKey#DATASET_NAME}</td><td>AVKey.LAYER_NAMES</td><td>String</td></tr> 
+     * </table>
      *
      * @param domElement the XML document root to parse for WMS layer parameters.
      * @param params     the output key-value pairs which receive the WMS layer parameters. A null reference is
@@ -1218,20 +1231,23 @@ public class DataConfigurationUtils
 
     /**
      * Appends LevelSet configuration parameters as elements to the specified context. This appends elements for the
-     * following parameters: <table> <th><td>Key</td><td>Name</td><td>Path</td></th> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td>DatasetName</td><td>String</td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}</td><td>DataCacheName</td><td>String</td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#SERVICE}</td><td>Service/URL</td><td>String</td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#EXPIRY_TIME}</td><td>ExpiryTime</td><td>Long</td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#EXPIRY_TIME}</td><td>LastUpdate</td><td>Long</td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#FORMAT_SUFFIX}</td><td>FormatSuffix</td><td>String</td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#NUM_LEVELS}</td><td>NumLevels/@count</td><td>Integer</td></tr> <tr><td>{@link
-     * gov.nasa.worldwind.avlist.AVKey#NUM_EMPTY_LEVELS}</td><td>NumLevels/@numEmpty</td><td>Integer</td></tr>
+     * following parameters: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Key</th><th>Name</th><th>Path</th></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td>DatasetName</td><td>String</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}</td><td>DataCacheName</td><td>String</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#SERVICE}</td><td>Service/URL</td><td>String</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#EXPIRY_TIME}</td><td>ExpiryTime</td><td>Long</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#EXPIRY_TIME}</td><td>LastUpdate</td><td>Long</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#FORMAT_SUFFIX}</td><td>FormatSuffix</td><td>String</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#NUM_LEVELS}</td><td>NumLevels/@count</td><td>Integer</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#NUM_EMPTY_LEVELS}</td><td>NumLevels/@numEmpty</td><td>Integer</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#INACTIVE_LEVELS}</td><td>NumLevels/@inactive</td><td>String</td></tr>
-     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#SECTOR}</td><td>Sector</td><td>{@link
-     * gov.nasa.worldwind.geom.Sector}</td></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#SECTOR_RESOLUTION_LIMITS}</td><td>SectorResolutionLimit</td>
-     * <td>{@link LevelSet.SectorResolution}</td></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#TILE_ORIGIN}</td><td>TileOrigin/LatLon</td><td>{@link
-     * gov.nasa.worldwind.geom.LatLon}</td></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#TILE_WIDTH}</td><td>TileSize/Dimension/@width</td><td>Integer</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#SECTOR}</td><td>Sector</td><td>{@link gov.nasa.worldwind.geom.Sector}</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#SECTOR_RESOLUTION_LIMITS}</td><td>SectorResolutionLimit</td>
+     * <td>{@link LevelSet.SectorResolution}</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#TILE_ORIGIN}</td><td>TileOrigin/LatLon</td><td>{@link gov.nasa.worldwind.geom.LatLon}</td></tr>
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#TILE_WIDTH}</td><td>TileSize/Dimension/@width</td><td>Integer</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#TILE_HEIGHT}</td><td>TileSize/Dimension/@height</td><td>Integer</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#LEVEL_ZERO_TILE_DELTA}</td><td>LastUpdate</td><td>LatLon</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#MAX_ABSENT_TILE_ATTEMPTS}</td><td>MaxAbsentTileAttempts</td><td>Integer</td></tr>
@@ -1338,7 +1354,8 @@ public class DataConfigurationUtils
     /**
      * Parses LevelSet configuration parameters from the specified DOM document. This writes output as key-value pairs
      * to params. If a parameter from the XML document already exists in params, that parameter is ignored. Supported
-     * key and parameter names are: <table> <th><td>Parameter</td><td>Element path</td><td>Type</td></th> <tr><td>{@link
+     * key and parameter names are: <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element path</th><th>Type</th></tr> <tr><td>{@link
      * gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td>DatasetName</td><td>String</td></tr> <tr><td>{@link
      * gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}</td><td>DataCacheName</td><td>String</td></tr> <tr><td>{@link
      * gov.nasa.worldwind.avlist.AVKey#SERVICE}</td><td>Service/URL</td><td>String</td></tr> <tr><td>{@link
@@ -1421,7 +1438,9 @@ public class DataConfigurationUtils
     /**
      * Gathers LevelSet configuration parameters from a specified LevelSet reference. This writes output as key-value
      * pairs params. If a parameter from the XML document already exists in params, that parameter is ignored. Supported
-     * key and parameter names are: <table> <th><td>Parameter</td><td>Element Path</td><td>Type</td></th> <tr><td>{@link
+     * key and parameter names are: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> <tr><td>{@link
      * gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td>First Level's dataset</td><td>String</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DATA_CACHE_NAME}</td><td>First Level's
      * cacheName</td><td>String</td></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#SERVICE}</td><td>First Level's
@@ -1938,8 +1957,10 @@ public class DataConfigurationUtils
     /**
      * Parses WorldWind .NET LayerSet configuration parameters from the specified document. This writes output as
      * key-value pairs to params. If a parameter from the LayerSet document already exists in params, that parameter is
-     * ignored. Supported key and parameter names are: <table> <tr><th>Parameter</th><th>Element
-     * Path</th><th>Type</th></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DISPLAY_NAME}</td><td>QuadTileSet/Name<td></td><td>String</td></tr>
+     * ignored. Supported key and parameter names are: 
+     * <table><caption>Parameters</caption>
+     * <tr><th>Parameter</th><th>Element Path</th><th>Type</th></tr> 
+     * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DISPLAY_NAME}</td><td>QuadTileSet/Name<td></td><td>String</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#DATASET_NAME}</td><td>QuadTileSet/Name<td></td><td>String</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#OPACITY}</td><td>QuadTileSet/Opacity<td></td><td>Double</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#SERVICE_NAME}</td><td>"Offline" (string
@@ -1957,7 +1978,8 @@ public class DataConfigurationUtils
      * constant)<td></td><td>Boolean</td></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#TEXTURE_FORMAT}</td><td>"image/dds"<td></td><td>String</td></tr>
      * <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#USE_MIP_MAPS}</td><td>true (boolean
      * constant)<td></td><td>Boolean</td></tr> <tr><td>{@link gov.nasa.worldwind.avlist.AVKey#USE_TRANSPARENT_TEXTURES}</td><td>true
-     * (boolean constant)<td></td><td>Boolean</td></tr> </table>
+     * (boolean constant)<td></td><td>Boolean</td></tr>
+     * </table>
      *
      * @param domElement the XML document root to parse for LayerSet configuration parameters.
      * @param params     the output key-value pairs which receive the LayerSet configuration parameters. A null

--- a/src/gov/nasa/worldwind/util/DecisionTree.java
+++ b/src/gov/nasa/worldwind/util/DecisionTree.java
@@ -8,17 +8,17 @@ package gov.nasa.worldwind.util;
 
 /**
  * Traverses an implicit tree and makes decisions at tree nodes visited in depth-first order.
- * <p/>
+ * <p>
  * Users provide an object at construction that implements the {@link gov.nasa.worldwind.util.DecisionTree.Controller}
  * interface. This controller provides methods to determine node inclusion, to terminate traversal, and to create
  * descendant nodes. It is carried to each node during traversal.
- * <p/>
+ * <p>
  * Users also provide a user-defined context object to carry state and other information to each node. The context can
  * hold information to assist in decisions or to retains objects or information gathered during traversal.
- * <p/>
+ * <p>
  * At the start of traversal a user-defined object is specified as the object defining the decision. It's the object
  * against which decisions are made at each node.
- * <p/>
+ * <p>
  * See the source code of {@link gov.nasa.worldwind.util.SectorVisibilityTree} for example usage.
  *
  * @author tag

--- a/src/gov/nasa/worldwind/util/EGM96.java
+++ b/src/gov/nasa/worldwind/util/EGM96.java
@@ -14,11 +14,11 @@ import java.io.*;
 
 /**
  * Computes EGM96 geoid offsets.
- * <p/>
+ * <p>
  * A file with the offset grid must be passed to the constructor. This file must have 721 rows of 1440 2-byte integer
  * values. Each row corresponding to a latitude, with the first row corresponding to +90 degrees (90 North). The integer
  * values must be in centimeters.
- * <p/>
+ * <p>
  * Once constructed, the instance can be passed to {@link gov.nasa.worldwind.globes.EllipsoidalGlobe#applyEGMA96Offsets(String)}
  * to apply the offets to elevations produced by the globe.
  *
@@ -35,6 +35,7 @@ public class EGM96
      *
      * @param offsetsFilePath a path pointing to a file with the geoid offsets. See the class description above for a
      *                        description of the file.
+     * @throws java.io.IOException on error.
      */
     public EGM96(String offsetsFilePath) throws IOException
     {

--- a/src/gov/nasa/worldwind/util/GLUTessellatorSupport.java
+++ b/src/gov/nasa/worldwind/util/GLUTessellatorSupport.java
@@ -15,13 +15,25 @@ import java.util.*;
 /**
  * GLUTessellatorSupport is a utility class for configuring and using a {@link com.jogamp.opengl.glu.GLUtessellator} to
  * tessellate complex polygons into triangles.
- * <p/>
- * The standard pattern for using GLUTessellatorSupport to prepare a GLUtessellator is as follows: <code>
- * GLUTessellatorSupport glts = new GLUTessellatorSupport();<br/> GLUtessellatorCallback cb = ...; // Reference to an
- * implementation of GLUtessellatorCallback.<br/> Vec4 normal = new Vec4(0, 0, 1); // The polygon's normal. This example
- * shows an appropriate normal for tessellating x-y coordinates.<br/> <br/><br/> glts.beginTessellation(cb, new Vec4(0,
- * 0, 1));<br/> try<br/> {<br/> GLUtessellator tess = glts.getGLUtessellator();<br/> }<br/> finally<br/> {<br/>
- * glts.endTessellation();<br/> }<br/> </code>
+ * <p>
+ * The standard pattern for using GLUTessellatorSupport to prepare a GLUtessellator is as follows: 
+ * <pre>
+ * <code>
+ * GLUTessellatorSupport glts = new GLUTessellatorSupport();
+ * GLUtessellatorCallback cb = ...; 
+ * // Reference to an implementation of GLUtessellatorCallback.
+ * Vec4 normal = new Vec4(0, 0, 1); 
+ * 
+ * // The polygon's normal. This example shows an appropriate normal for tessellating x-y coordinates.
+ * 
+ * glts.beginTessellation(cb, new Vec4(0, * 0, 1));
+ * try {
+ *      GLUtessellator tess = glts.getGLUtessellator();
+ * } finally {
+ *      glts.endTessellation();
+ * } 
+ * </code>
+ * </pre>
  *
  * @author dcollins
  * @version $Id: GLUTessellatorSupport.java 3427 2015-09-30 23:24:13Z dcollins $
@@ -384,7 +396,7 @@ public class GLUTessellatorSupport
     /**
      * Recursively forwards boundary tessellation results from one GLU tessellator to another. The GLU tessellator this
      * callback forwards to may be configured in any way the caller chooses.
-     * <p/>
+     * <p>
      * RecursiveCallback must be used as the GLUtessellatorCallback for the begin, end, vertex, and combine callbacks
      * for a GLU tessellator configured to generate line loops. A GLU tessellator can be configured generate line loops
      * by calling gluTessProperty(GLU_TESS_BOUNDARY_ONLY, GL_TRUE). Additionally, the caller specified vertex data

--- a/src/gov/nasa/worldwind/util/GeometryBuilder.java
+++ b/src/gov/nasa/worldwind/util/GeometryBuilder.java
@@ -7445,10 +7445,10 @@ public class GeometryBuilder
      * Creates a vertex buffer for a two-dimensional ellipse centered at the specified location and with the specified
      * radii. The ellipse's center is placed at <code>(x, y)</code>, it has a width of <code>2 * majorRadius</code>, and
      * a height of <code>2 * minorRadius</code>.
-     * <p/>
+     * <p>
      * If the specified <code>slices</code> is greater than 1 this returns a buffer with vertices evenly spaced along
      * the circumference of the ellipse. Otherwise this returns a buffer with one vertex.
-     * <p/>
+     * <p>
      * The returned buffer contains pairs of xy coordinates representing the location of each vertex in the ellipse in a
      * counter-clockwise winding order relative to the z axis. The buffer may be rendered in OpenGL as either a triangle
      * fan or a line loop.
@@ -7520,10 +7520,10 @@ public class GeometryBuilder
      * Creates a vertex buffer for a two-dimensional ellipse centered at the specified location and with the specified
      * radii. The ellipse's center is placed at <code>(x, y)</code>, it has a width of <code>2 * majorRadius</code>, and
      * a height of <code>2 * minorRadius</code>.
-     * <p/>
+     * <p>
      * If the specified <code>slices</code> is greater than 1 this returns a buffer with vertices evenly spaced along
      * the circumference of the ellipse. Otherwise this returns a buffer with one vertex.
-     * <p/>
+     * <p>
      * If the specified <code>leaderWidth</code> is greater than zero and the location <code>(leaderX, leaderY)</code>
      * is outside of the rectangle that encloses the ellipse, the ellipse has a triangle attached to one side with with
      * its top pointing at <code>(leaderX, leaderY)</code>. Otherwise this returns an ellipse with no leader and is
@@ -7684,7 +7684,7 @@ public class GeometryBuilder
      * Creates a vertex buffer for a two-dimensional rectangle at the specified location, and with the specified size.
      * The rectangle's lower left corner is placed at <code>(x, y)</code>, and its upper right corner is placed at
      * <code>(x + width, y + height)</code>.
-     * <p/>
+     * <p>
      * The returned buffer contains pairs of xy coordinates representing the location of each vertex in the rectangle in
      * a counter-clockwise winding order relative to the z axis. The buffer may be rendered in OpenGL as either a
      * triangle fan or a line loop.
@@ -7737,7 +7737,7 @@ public class GeometryBuilder
      * Creates a vertex buffer for a two-dimensional rectangle at the specified location, with the specified size, and
      * with optionally rounded corners. The rectangle's lower left corner is placed at the <code>(x, y)</code>, and its
      * upper right corner is placed at <code>(x + width, y + height)</code>.
-     * <p/>
+     * <p>
      * If the specified <code>cornerRadius</code> and <code>cornerSlices</code> are greater than 0, the rectangle's
      * corners have a rounded appearance. The radius specifies the size of a rounded corner, and the slices specifies
      * the number of segments that make a rounded corner. If either <code>cornerRadius</code> or
@@ -7745,7 +7745,7 @@ public class GeometryBuilder
      * <code>{@link #makeRectangle(float, float, float, float)}</code>. The <code>cornerRadius</code> is limited by the
      * rectangle's width and height. For example, if the corner radius is 100 and the width and height are 50 and 100,
      * the actual corner radius used is 25 - half of the rectangle's smallest dimension.
-     * <p/>
+     * <p>
      * The returned buffer contains pairs of xy coordinates representing the location of each vertex in the rectangle in
      * a counter-clockwise winding order relative to the z axis. The buffer may be rendered in OpenGL as either a
      * triangle fan or a line loop.
@@ -7842,7 +7842,7 @@ public class GeometryBuilder
      * Creates a vertex buffer for a two-dimensional rectangle at the specified location, with the specified size, and
      * with an optional leader pointing to the specified leader location. The rectangle's lower left corner is placed at
      * <code>(x, y)</code>, and its upper right corner is placed at <code>(x + width, y + height)</code>.
-     * <p/>
+     * <p>
      * If the specified <code>leaderWidth</code> is greater than zero and the location <code>(leaderX, leaderY)</code>
      * is outside of the rectangle, the rectangle has a triangle attached to one side with with its top pointing at
      * <code>(leaderX, leaderY)</code>. Otherwise this returns a rectangle with no leader and is equivalent to calling
@@ -7850,7 +7850,7 @@ public class GeometryBuilder
      * the top, bottom, left, or right side, depending on the leader's location relative to the rectangle. The leader
      * width is limited in size by the side it is attached to. For example, if the leader is attached to the rectangle's
      * bottom, its width is limited by the rectangle's width.
-     * <p/>
+     * <p>
      * The returned buffer contains pairs of xy coordinates representing the location of each vertex in the rectangle in
      * a counter-clockwise winding order relative to the z axis. The buffer may be rendered in OpenGL as either a
      * triangle fan or a line loop.
@@ -8053,7 +8053,7 @@ public class GeometryBuilder
      * Creates a vertex buffer for a two-dimensional rectangle at the specified location, with the specified size, and
      * with optionally rounded corners. The rectangle's lower left corner is placed at the <code>(x, y)</code>, and its
      * upper right corner is placed at <code>(x + width, y + height)</code>.
-     * <p/>
+     * <p>
      * If the specified <code>cornerRadius</code> and <code>cornerSlices</code> are greater than 0, the rectangle's
      * corners have a rounded appearance. The radius specifies the size of a rounded corner, and the slices specifies
      * the number of segments that make a rounded corner. If either <code>cornerRadius</code> or
@@ -8062,7 +8062,7 @@ public class GeometryBuilder
      * <code>cornerRadius</code> is limited by the rectangle's width and height. For example, if the corner radius is
      * 100 and the width and height are 50 and 100, the actual corner radius used is 25 - half of the rectangle's
      * smallest dimension.
-     * <p/>
+     * <p>
      * If the specified <code>leaderWidth</code> is greater than zero and the location <code>(leaderX, leaderY)</code>
      * is outside of the rectangle, the rectangle has a triangle attached to one side with with its top pointing at
      * <code>(leaderX, leaderY)</code>. Otherwise this returns a rectangle with no leader and is equivalent to calling
@@ -8070,7 +8070,7 @@ public class GeometryBuilder
      * of either the top, bottom, left, or right side, depending on the leader's location relative to the rectangle. The
      * leader width is limited in size by the side it is attached to. For example, if the leader is attached to the
      * rectangle's bottom, its width is limited by the rectangle's width minus any area used by the rounded corners.
-     * <p/>
+     * <p>
      * The returned buffer contains pairs of xy coordinates representing the location of each vertex in the rectangle in
      * a counter-clockwise winding order relative to the z axis. The buffer may be rendered in OpenGL as either a
      * triangle fan or a line loop.

--- a/src/gov/nasa/worldwind/util/ImageUtil.java
+++ b/src/gov/nasa/worldwind/util/ImageUtil.java
@@ -520,7 +520,7 @@ public class ImageUtil
      * @param aspectRatio  the aspect ratio, width/height, of the assembled image. If the aspect ratio is greater than
      *                     or equal to one, the assembled image uses the full width of the canvas; the height used is
      *                     proportional to the inverse of the aspect ratio. If the aspect ratio is less than one, the
-     *                     full height of the canvas is used; the width used is proportional to the aspect ratio. <p/>
+     *                     full height of the canvas is used; the width used is proportional to the aspect ratio. <p>
      *                     The aspect ratio is typically used to maintain consistent width and height units while
      *                     assembling multiple images into a canvas of a different aspect ratio than the canvas sector,
      *                     such as drawing a non-square region into a 1024x1024 canvas. An aspect ratio of 1 causes the
@@ -832,7 +832,7 @@ public class ImageUtil
      * Returns a copy of the specified image such that the new dimensions are powers of two. The new image dimensions
      * will be equal to or greater than the original image. The flag <code>scaleToFit</code> determines whether the
      * original image should be drawn into the new image with no special scaling, or whether the original image should
-     * be scaled to fit exactly in the new image. <p/> If the original image dimensions are already powers of two, this
+     * be scaled to fit exactly in the new image. <p> If the original image dimensions are already powers of two, this
      * method will simply return the original image.
      *
      * @param image      the BufferedImage to convert to a power of two image.

--- a/src/gov/nasa/worldwind/util/IntSet.java
+++ b/src/gov/nasa/worldwind/util/IntSet.java
@@ -9,7 +9,7 @@ package gov.nasa.worldwind.util;
  * A collection of 32-bit integer primitives that contains no duplicate elements. IntSet provides the minimal operations
  * for working with on a set of integers: add, remove, contains, and clear. Additionally, IntSet provides methods for
  * determining the number of integers in the set, and for retrieving the integers as an array.
- * <p/>
+ * <p>
  * IntSet
  *
  * @author dcollins

--- a/src/gov/nasa/worldwind/util/Logging.java
+++ b/src/gov/nasa/worldwind/util/Logging.java
@@ -55,7 +55,7 @@ public class Logging
     /**
      * Returns a specific logger. Does not access {@link gov.nasa.worldwind.Configuration} to determine the configured
      * WorldWind logger.
-     * <p/>
+     * <p>
      * This is needed by {@link gov.nasa.worldwind.Configuration} to avoid calls back into itself when its singleton
      * instance is not yet instantiated.
      *

--- a/src/gov/nasa/worldwind/util/NetworkStatus.java
+++ b/src/gov/nasa/worldwind/util/NetworkStatus.java
@@ -15,16 +15,16 @@ import java.util.List;
  * implementing object's tracking list. When a host has been logged a specified number of times, it is marked as
  * unreachable. Users can query instances of classes implementing this interface to determine whether a host has been
  * marked as unreachable.
- * <p/>
+ * <p>
  * Users are expected to invoke the {@link #logUnavailableHost(java.net.URL)} method when an attempt to contact a host
  * fails. Each invocation increments the failure count by one. When the count exceeds the attempt limit, the host is
  * marked as unreachable. When attempts to contact the host <em>are</em> successful, users should invoke {@link
  * #logAvailableHost(java.net.URL)} method to clear its status.
- * <p/>
+ * <p>
  * A host may become reachable at a time subsequent to its being logged. To detect this, the implementation marks a host
  * as not unreachable after a specifiable interval of time. If the host is once more logged as unavailable, its entry
  * returns to the unavailable state. This cycle continues indefinitely.
- * <p/>
+ * <p>
  * Methods are provided to determine whether the public network can be reached and whether the NASA WorldWind servers
  * cab be reached. The addresses used to detect public network access can be explicitly specified.
  *

--- a/src/gov/nasa/worldwind/util/OGLRenderToTextureSupport.java
+++ b/src/gov/nasa/worldwind/util/OGLRenderToTextureSupport.java
@@ -14,7 +14,7 @@ import com.jogamp.opengl.*;
  * OGLRenderToTextureSupport encapsulates the pattern of rendering GL commands to a destination texture. Currently only
  * the color pixel values are written to the destination texture, but other values (depth, stencil) should be possible
  * with modification or extension.
- * <p/>
+ * <p>
  * OGLRenderToTextureSupport is compatible with GL version 1.1 or greater, but it attempts to use more recent features
  * whenever possible. Different GL feature sets result in different approaches to rendering to texture, therefore the
  * caller cannot depend on the mechanism by which OGLRenderToTextureSupport will write pixel values to the destination
@@ -26,15 +26,27 @@ import com.jogamp.opengl.*;
  * contents before rendering anything into the texture. Do this by invoking {@link
  * #clear(gov.nasa.worldwind.render.DrawContext, java.awt.Color)} immediately after any call to {@link
  * #beginRendering(gov.nasa.worldwind.render.DrawContext, int, int, int, int)}.
- * <p/>
- * The common usage pattern for OGLRenderToTextureSupport is as follows: <br/><code> DrawContext dc = ...; // Typically
- * passed in as an argument to the containing method.<br/> Texture texture = TextureIO.newTexture(new
- * TextureData(...);<br/> <br/> // Setup the drawing rectangle to match the texture dimensions, and originate from the
- * texture's lower left corner.<br/> OGLRenderToTextureSupport rttSupport = new OGLRenderToTextureSupport();<br/>
- * rttSupport.beginRendering(dc, 0, 0, texture.getWidth(), texture.getHeight());<br/> try<br/> {<br/> // Bind the
- * texture as the destination for color pixel writes.<br/> rttSupport.setColorTarget(dc, texture);<br/> // Clear the
- * texture contents with transparent black.<br/> rttSupport.clear(dc, new Color(0, 0, 0, 0));<br/> // Invoke desired GL
- * rendering commands.<br/> }<br/> finally<br/> {<br/> rttSupport.endRendering(dc);<br/> }<br/> </code>
+ * <p>
+ * The common usage pattern for OGLRenderToTextureSupport is as follows: 
+ * <pre>
+ * <code> 
+ * DrawContext dc = ...; 
+ * // Typically passed in as an argument to the containing method.
+ * Texture texture = TextureIO.newTexture(new TextureData(...);
+ * // Setup the drawing rectangle to match the texture dimensions, and originate from the
+ * texture's lower left corner.
+ * OGLRenderToTextureSupport rttSupport = new OGLRenderToTextureSupport();
+ * rttSupport.beginRendering(dc, 0, 0, texture.getWidth(), texture.getHeight());
+ * try {
+ *  // Bind the texture as the destination for color pixel writes.
+ *  rttSupport.setColorTarget(dc, texture);
+ *  // Clear the texture contents with transparent black.
+ *  rttSupport.clear(dc, new Color(0, 0, 0, 0));
+ *  // Invoke desired GLrendering commands.
+ * } finally {
+ * rttSupport.endRendering(dc);
+ * }
+ * </code></pre>
  *
  * @author dcollins
  * @version $Id: OGLRenderToTextureSupport.java 1676 2013-10-21 18:32:30Z dcollins $
@@ -92,7 +104,7 @@ public class OGLRenderToTextureSupport
      * current color target texture is the same reference as the specified texture, this does nothing. Otherwise this
      * flushes any buffered pixel values to the current color target, and assigns the specified texture as the new color
      * target.
-     * <p/>
+     * <p>
      * If {@link #isEnableFramebufferObject()} is false, the supported texture formats for the color target are limited
      * only by the OpenGL implementation's supported formats. If {@link #isEnableFramebufferObject()} is true and the
      * DrawContext supports OpenGL framebuffer objects, the supported texture formats for the color target are as

--- a/src/gov/nasa/worldwind/util/OGLUtil.java
+++ b/src/gov/nasa/worldwind/util/OGLUtil.java
@@ -231,7 +231,9 @@ public class OGLUtil
 
     /**
      * Returns an OpenGL pixel format corresponding to the specified texture internal format. This maps internal format
-     * to pixel format as follows: <code> <table> <tr><th>Internal Format</th><th>Pixel Format</th></tr>
+     * to pixel format as follows: 
+     * <table><caption>Formats</caption>
+     * <tr><th>Internal Format</th><th>Pixel Format</th></tr>
      * <tr><td>GL2.GL_ALPHA</td><td>GL2.GL_ALPHA</td></tr> <tr><td>GL2.GL_ALPHA4</td><td>GL2.GL_ALPHA</td></tr>
      * <tr><td>GL2.GL_ALPHA8</td><td>GL2.GL_ALPHA</td></tr> <tr><td>GL2.GL_ALPHA12</td><td>GL2.GL_ALPHA</td></tr>
      * <tr><td>GL2.GL_ALPHA16</td><td>GL2.GL_ALPHA</td></tr> <tr><td>GL2.GL_COMPRESSED_ALPHA</td><td>GL2.GL_ALPHA</td></tr>
@@ -260,8 +262,8 @@ public class OGLUtil
      * <tr><td>GL2.GL_SLUMINANCE_ALPHA</td><td>GL2.GL_LUMINANCE_ALPHA</td></tr> <tr><td>GL2.GL_SLUMINANCE8_ALPHA8</td><td>GL2.GL_LUMINANCE_ALPHA<td></tr>
      * <tr><td>GL2.GL_SRGB</td><td>GL2.GL_RGB</td></tr> <tr><td>GL2.GL_SRGB8</td><td>GL2.GL_RGB</td></tr>
      * <tr><td>GL2.GL_SRGB_ALPHA</td><td>GL2.GL_RGBA</td></tr> <tr><td>GL2.GL_SRGB8_ALPHA8</td><td>GL2.GL_RGBA</td></tr>
-     * </code>
-     * <p/>
+     * </table>
+     * <p>
      * This returns 0 if the internal format is not one of the recognized types.
      *
      * @param internalFormat the OpenGL texture internal format.
@@ -348,7 +350,9 @@ public class OGLUtil
 
     /**
      * Returns an OpenGL pixel format corresponding to the specified texture internal format. This maps internal format
-     * to pixel format as follows: <code> <table> <tr><th>Internal Format</th><th>Estimated Bits Per Pixel</th></tr>
+     * to pixel format as follows: 
+     * <table><caption>Pixel Formats</caption>
+     * <tr><th>Internal Format</th><th>Estimated Bits Per Pixel</th></tr>
      * <tr><td>GL2.GL_ALPHA</td><td>8</td></tr> <tr><td>GL2.GL_ALPHA4</td><td>4</td></tr>
      * <tr><td>GL2.GL_ALPHA8</td><td>8</td></tr> <tr><td>GL2.GL_ALPHA12</td><td>12</td></tr>
      * <tr><td>GL2.GL_ALPHA16</td><td>16</td></tr> <tr><td>GL2.GL_COMPRESSED_ALPHA</td><td>0</td></tr>
@@ -377,8 +381,9 @@ public class OGLUtil
      * <tr><td>GL2.GL_SLUMINANCE8</td><td>8</td></tr> <tr><td>GL2.GL_SLUMINANCE_ALPHA</td><td>16</td></tr>
      * <tr><td>GL2.GL_SLUMINANCE8_ALPHA8</td><td>16<td></tr> <tr><td>GL2.GL_SRGB</td><td>24</td></tr>
      * <tr><td>GL2.GL_SRGB8</td><td>24</td></tr> <tr><td>GL2.GL_SRGB_ALPHA</td><td>32</td></tr>
-     * <tr><td>GL2.GL_SRGB8_ALPHA8</td><td>32</td></tr> </code>
-     * <p/>
+     * <tr><td>GL2.GL_SRGB8_ALPHA8</td><td>32</td></tr> 
+     * </table>
+     * <p>
      * The returned estimate assumes that the driver provides does not convert the formats to another supported, such
      * converting as <code>GL2.GL_ALPHA4</code> to <code>GL2.GL_ALPHA8</code>. This returns 0 if the internal format is
      * not one of the recognized types. This does not attempt to estimate a memory size for compressed internal

--- a/src/gov/nasa/worldwind/util/PolygonTessellator2.java
+++ b/src/gov/nasa/worldwind/util/PolygonTessellator2.java
@@ -325,6 +325,10 @@ public class PolygonTessellator2
      * Computes a 4-bit code indicating the vertex's location in the 9 cell grid defined by the clip bounds and the
      * eight adjacent spaces defined by extending the min/max boundaries to infinity. 0 indicates that the vertex is
      * inside the clip bounds.
+     * @param x x coordinate
+     * @param y y coordinate
+     * @param z z coordinate
+     * @return the clip code.
      */
     protected int clipCode(double x, double y, double z)
     {

--- a/src/gov/nasa/worldwind/util/RestorableSupport.java
+++ b/src/gov/nasa/worldwind/util/RestorableSupport.java
@@ -19,10 +19,10 @@ import java.util.List;
  * <code>stateObject</code> elements. Each <code>stateObject</code> element is identified by its <code>name</code>
  * attribute. The value of a <code>stateObject</code> can either be simple text content, or nested
  * <code>stateObject</code> elements.
- * <p/>
+ * <p>
  * For example, this document stores four states: the string "Hello World!", the largest value an unsigned byte can
- * hold, the value of PI to six digits, and a boolean "true". <code>
- * <pre>
+ * hold, the value of PI to six digits, and a boolean "true". 
+ * <pre><code>
  * {@literal <?xml version="1.0" encoding="UTF-8"?>}
  * {@literal <restorableState>}
  *   {@literal <stateObject name="helloWorldString">Hello World!</stateObject>}
@@ -30,8 +30,8 @@ import java.util.List;
  *   {@literal <stateObject name="pi">3.141592</stateObject>}
  *   {@literal <stateObject name="booleanTrue">true</stateObject>}
  * {@literal </restorableState>}
- * </pre>
- * </code> Callers can create a new RestorableSupport with no state content, or create a RestorableSupport from an
+ * </code> </pre>
+ * Callers can create a new RestorableSupport with no state content, or create a RestorableSupport from an
  * existing XML document string. Callers can then add state by name and value, and query state by name.
  * RestorableSupport provides convenience methods for addding and querying state values as Strings, Integers, Doubles,
  * and Booleans.
@@ -1278,11 +1278,11 @@ public class RestorableSupport
     }
 
     /**
-     * Returns the value of the StateObject as a HashMap of <Integer, OffsetsList> pairs.
+     * Returns the value of the StateObject as a HashMap of {@code <Integer, OffsetsList>} pairs.
      *
      * @param stateObject the StateObject that is converted to a HashMap of OffsetsLists.
      *
-     * @return the value of the StateObject as a HashMap of <Integer, OffsetsList> pairs.
+     * @return the value of the StateObject as a HashMap of {@code <Integer, OffsetsList>} pairs.
      *
      * @throws IllegalArgumentException If <code>stateObject</code> is null, or does not belong to this
      *                                  RestorableSupport.
@@ -1457,12 +1457,12 @@ public class RestorableSupport
     }
 
     /**
-     * Returns the value of the StateObject as a HashMap of <Integer, Object> pairs, representing the shape's
+     * Returns the value of the StateObject as a HashMap of {@code <Integer, Object>} pairs, representing the shape's
      * imageSources.
      *
      * @param stateObject the StateObject that is converted to a HashMap of imageSources.
      *
-     * @return the value of the StateObject as a HashMap of <Integer, Object> pairs.
+     * @return the value of the StateObject as a HashMap of {@code <Integer, Object>} pairs.
      *
      * @throws IllegalArgumentException If <code>stateObject</code> is null, or does not belong to this
      *                                  RestorableSupport.

--- a/src/gov/nasa/worldwind/util/SectorVisibilityTree.java
+++ b/src/gov/nasa/worldwind/util/SectorVisibilityTree.java
@@ -106,7 +106,7 @@ public class SectorVisibilityTree
      *
      * @param dc         the current draw context
      * @param sectorSize the granularity of sector visibility, in degrees. All visible sectors of this size are found.
-     *                   The value must be in the range, 1 second <= sectorSize <= 180 degrees.
+     *                   The value must be in the range, {@code 1 second <= sectorSize <= 180 degrees}.
      *
      * @return the list of visible sectors. The list will be empty if no sectors are visible.
      *
@@ -145,7 +145,7 @@ public class SectorVisibilityTree
      *
      * @param dc           the current draw context
      * @param sectorSize   the granularity of sector visibility, in degrees. All visible sectors of this size are found.
-     *                     The value must be in the range, 1 second <= sectorSize <= 180 degrees.
+     *                     The value must be in the range,{@code 1 second <= sectorSize <= 180 degrees}.
      * @param searchSector the overall sector for which to determine visibility. May be null, in which case the current
      *                     visible sector of the draw context is used.
      *
@@ -193,7 +193,7 @@ public class SectorVisibilityTree
      *
      * @param dc            the current draw context
      * @param sectorSize    the granularity of sector visibility, in degrees. All visible sectors of this size are The
-     *                      value must be in the range, 1 second <= sectorSize <= 180 degrees. found.
+     *                      value must be in the range, {@code 1 second <= sectorSize <= 180 degrees}. found.
      * @param searchSectors the sectors for which to determine visibility.
      *
      * @return the list of visible sectors. The list will be empty if no sectors are visible.

--- a/src/gov/nasa/worldwind/util/ShapeEditor.java
+++ b/src/gov/nasa/worldwind/util/ShapeEditor.java
@@ -28,14 +28,14 @@ import java.util.List;
 /**
  * Provides a user interface for editing a shape and performs editing. Depending on the shape type, the shape is shown
  * with control points for vertex locations and size. All shapes are shown with a handle that provides rotation.
- * <p/>
+ * <p>
  * Left-drag on the shape's body moves the whole shape. Left-drag on a control point performs the action associated with
  * that control point. The editor provides vertex insertion and removal for airspace Polygon, Curtain, Route and Track
  * shapes, and SurfacePolygon and SurfacePolyline. Shift-left-click when the cursor is over the shape inserts a control
  * point at the cursor's position. Alt-left-click when the cursor is over a control point removes that control point.
  * Control points are added to the ends of airspace Polygon, Curtain, Route and Track, and SurfacePolyline by
  * shift-left-click on the first or last control point of the shape.
- * <p/>
+ * <p>
  * This editor supports airspaces other than Cake and all surface shapes except SurfaceMultiPolygon and SurfaceImage.
  *
  * @author tag

--- a/src/gov/nasa/worldwind/util/TextDecoder.java
+++ b/src/gov/nasa/worldwind/util/TextDecoder.java
@@ -32,7 +32,7 @@ public interface TextDecoder
     /**
      * Get the time at which the decoded text last changed. The text can change because new source text is set, or
      * because an external resource required for decoding has been resolved.
-     * <p/>
+     * <p>
      * <em>The update time does not change until {@link #getDecodedText()} is called.</em> An application should call
      * {@link #getDecodedText()}, and then call this method to compare the timestamp with some previous timestamp to
      * determine if the decoded text has changed since {@link #getDecodedText()} was last called.

--- a/src/gov/nasa/worldwind/util/TextureAtlas.java
+++ b/src/gov/nasa/worldwind/util/TextureAtlas.java
@@ -21,9 +21,8 @@ import java.util.Queue;
 /**
  * Represents a texture composed of multiple independent images. The independent images are referred to as
  * <i>elements</i>, and are packed into non-overlapping sub-rectangles within the texture atlas. The following NVIDIA
- * document describes this technique: <a title="Improve Batching Using Texture Atlases" target="blank_"
- * href="ftp://download.nvidia.com/developer/NVTextureSuite/Atlas_Tools/Texture_Atlas_Whitepaper.pdf">Improve Batching
- * Using Texture Atlases</a>
+ * document describes this technique: <a target="blank_" href="ftp://download.nvidia.com/developer/NVTextureSuite/Atlas_Tools/Texture_Atlas_Whitepaper.pdf">
+ * Improve Batching Using Texture Atlases</a>
  *
  * @author dcollins
  * @version $Id: TextureAtlas.java 1171 2013-02-11 21:45:02Z dcollins $
@@ -38,7 +37,7 @@ public class TextureAtlas
     {
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Calls {@link TextureAtlas#createBackingImage(int, int)} with the specified width and height.
          */
         public Object allocateBackingStore(int w, int h)
@@ -48,7 +47,7 @@ public class TextureAtlas
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Calls {@link TextureAtlas#disposeBackingImage()}.
          */
         public void deleteBackingStore(Object backingStore)
@@ -58,7 +57,7 @@ public class TextureAtlas
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Returns <code>true</code>. The texture atlas can always attempt to expand or compact.
          */
         public boolean canCompact()
@@ -68,7 +67,7 @@ public class TextureAtlas
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Returns <code>false</code>, indicating that the rectangle packer should just expand. When configured to do
          * so, texture atlas evicts old elements in <code>additionFailed</code> if this texture atlas is full and the
          * addition would otherwise fail.
@@ -80,7 +79,7 @@ public class TextureAtlas
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * If this texture atlas is configured to evicts old elements, this attempts to remove the oldest one then
          * exits, allowing the caller to attempt the addition again. This throws a WWRuntimeException if this texture
          * atlas is not configured to evict old elements, or if there are no more elements to evict.
@@ -97,7 +96,7 @@ public class TextureAtlas
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Calls {@link TextureAtlas#beginMoveEntries(java.awt.image.BufferedImage, java.awt.image.BufferedImage)},
          * casting the specified backing stores to BufferedImages.
          */
@@ -108,7 +107,7 @@ public class TextureAtlas
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Calls {@link TextureAtlas#moveEntry(java.awt.image.BufferedImage, com.jogamp.opengl.util.packrect.Rect,
          * java.awt.image.BufferedImage, com.jogamp.opengl.util.packrect.Rect)}, casting the specified backing stores to
          * BufferedImages.
@@ -120,7 +119,7 @@ public class TextureAtlas
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Calls {@link TextureAtlas#endMoveEntries(java.awt.image.BufferedImage, java.awt.image.BufferedImage)},
          * casting the specified backing stores to BufferedImages.
          */
@@ -496,7 +495,7 @@ public class TextureAtlas
      * than or equal to this texture atlas' maximum dimensions. If this texture atlas is not configured to evict old
      * entries, this throws an exception if the image does not fit in the current atlas layout and the atlas cannot be
      * expanded.
-     * <p/>
+     * <p>
      * This adds a one pixel border around the specified image in this texture atlas' backing image by copying the
      * image's outer pixels into a border surrounding the original image. This border avoids sampling pixels from
      * neighboring atlas elements when an OpenGL box filter is applied to this image. This means that the atlas actually
@@ -702,7 +701,7 @@ public class TextureAtlas
     /**
      * Returns the OpenGL texture coordinates associated with an element in this texture atlas. This returns
      * <code>null</code> if this texture atlas does not contain the element.
-     * <p/>
+     * <p>
      * The returned texture coordinates can change any time an element is added or removed from this texture atlas, and
      * therefore should not be cached unless the caller has explicit knowledge of when this texture atlas has changed.
      *

--- a/src/gov/nasa/worldwind/util/TextureAtlasElement.java
+++ b/src/gov/nasa/worldwind/util/TextureAtlasElement.java
@@ -19,7 +19,7 @@ import java.net.URL;
 
 /**
  * Represents a texture defined by a sub-image within a {@link TextureAtlas}.
- * <p/>
+ * <p>
  * TextureAtlasElement performs lazy retrieval and loading of its image source into its texture atlas. This loads the
  * image source and adds it to the atlas only when the {@link #load(gov.nasa.worldwind.render.DrawContext)} method is
  * called. If the image source is a {@link BufferedImage} it is added to the atlas immediately when <code>load</code> is
@@ -158,7 +158,7 @@ public class TextureAtlasElement implements Disposable
     /**
      * Returns the OpenGL texture coordinates associated this texture atlas element. Always call <code>load</code>
      * before calling this method to ensure that the element is loaded into its texture atlas.
-     * <p/>
+     * <p>
      * The returned texture coordinates can change any time an element is added or removed from this element's texture
      * atlas, and therefore should not be cached unless the caller has explicit knowledge of when this element's texture
      * atlas has changed.

--- a/src/gov/nasa/worldwind/util/Tile.java
+++ b/src/gov/nasa/worldwind/util/Tile.java
@@ -16,7 +16,7 @@ import java.util.Random;
  * to a common spatial resolution is typically maintained in a {@link Level}. A collection of levels of progressive
  * resolutions are maintained in a {@link LevelSet}. The <code>Tile</code> class represents a single tile of a
  * subdivided image or elevation raster.
- * <p/>
+ * <p>
  * Individual tiles are identified by the level, row and column of the tile within its containing level set.
  *
  * @author tag

--- a/src/gov/nasa/worldwind/util/TileKey.java
+++ b/src/gov/nasa/worldwind/util/TileKey.java
@@ -20,10 +20,10 @@ public class TileKey implements Comparable<TileKey>
     private final int hash;
 
     /**
-     * @param level
-     * @param row
-     * @param col
-     * @param cacheName
+     * @param level the level
+     * @param row the row
+     * @param col the column
+     * @param cacheName the cache name
      * @throws IllegalArgumentException if <code>level</code>, <code>row</code> or <code>column</code> is negative or if
      *                                  <code>cacheName</code> is null or empty
      */
@@ -61,9 +61,10 @@ public class TileKey implements Comparable<TileKey>
     }
 
     /**
-     * @param latitude
-     * @param longitude
-     * @param levelNumber
+     * @param latitude the latitude
+     * @param longitude the longitude
+     * @param levelSet the level set
+     * @param levelNumber the level number
      * @throws IllegalArgumentException if any parameter is null
      */
     public TileKey(Angle latitude, Angle longitude, LevelSet levelSet, int levelNumber)
@@ -89,7 +90,7 @@ public class TileKey implements Comparable<TileKey>
     }
 
     /**
-     * @param tile
+     * @param tile the tile.
      * @throws IllegalArgumentException if <code>tile</code> is null
      */
     public TileKey(Tile tile)

--- a/src/gov/nasa/worldwind/util/UnitsFormat.java
+++ b/src/gov/nasa/worldwind/util/UnitsFormat.java
@@ -107,7 +107,7 @@ public class UnitsFormat extends AVListImpl
      * Constructs an instance that display length and area in specified units, and angles in decimal degrees.
      *
      * @param lengthUnits the desired length units. Available length units are <code>METERS, KILOMETERS, MILES,
-     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code.
+     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code>.
      * @param areaUnits   the desired area units. Available area units are <code>SQUARE_METERS, SQUARE_KILOMETERS,
      *                    HECTARE, ACRE, SQUARE_YARD</code> and <code>SQUARE_FEET</code>.
      *
@@ -122,7 +122,7 @@ public class UnitsFormat extends AVListImpl
      * Constructs an instance that display length and area in specified units, and angles in a specified format.
      *
      * @param lengthUnits the desired length units. Available length units are <code>METERS, KILOMETERS, MILES,
-     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code.
+     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code>.
      * @param areaUnits   the desired area units. Available area units are <code>SQUARE_METERS, SQUARE_KILOMETERS,
      *                    HECTARE, ACRE, SQUARE_YARD</code> and <code>SQUARE_FEET</code>.
      * @param showDMS     true if the desired angle format is degrees-minutes-seconds, false if the format is decimal
@@ -638,7 +638,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of latitude and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_LATITUDE} and angle format.
      *
      * @param angle the angle to format.
@@ -661,7 +661,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of latitude.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_LATITUDE} and angle format.
      *
      * @param angle the angle to format.
@@ -684,7 +684,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of longitude and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_LONGITUDE} and angle format.
      *
      * @param angle the angle to format.
@@ -705,7 +705,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of longitude.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_LONGITUDE} and angle format.
      *
      * @param angle the angle to format.
@@ -728,7 +728,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of heading according to the current angle format, and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_HEADING} and angle format.
      *
      * @param angle the heading angle to format.
@@ -744,7 +744,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of heading according to the current angle format.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_HEADING} and angle format.
      *
      * @param angle the heading angle to format.
@@ -767,7 +767,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of heading in degrees according to the current angle format, and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_HEADING} and {@link #FORMAT_HEADING}. The default
      * <code>FORMAT_HEADING</code> is " %9.2f\u00b0".
      *
@@ -782,7 +782,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of heading in degrees according to the current angle format.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_HEADING} and {@link #FORMAT_HEADING}. The default
      * <code>FORMAT_HEADING</code> is " %9.2f\u00b0".
      *
@@ -797,7 +797,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format angles of latitude and longitude according to the current angle format, and append a new-line character.
-     * <p/>
+     * <p>
      * The values are formatted using the current {@link #LABEL_LATLON_LAT}, {@link #LABEL_LATLON_LON} and angle
      * format.
      *
@@ -821,7 +821,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format angles of latitude and longitude according to the current angle format.
-     * <p/>
+     * <p>
      * The values are formatted using the current {@link #LABEL_LATLON_LAT}, {@link #LABEL_LATLON_LON} and angle
      * format.
      *
@@ -947,7 +947,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an eye altitude according to the current eye altitude format, and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_EYE_ALTITUDE}, {@link #FORMAT_EYE_ALTITUDE} and length
      * format.
      *
@@ -962,7 +962,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an eye altitude according to the current eye altitude format.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_EYE_ALTITUDE}, {@link #FORMAT_EYE_ALTITUDE} and length
      * format.
      *
@@ -984,7 +984,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of pitch according to the current angle format, and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_PITCH} and {@link #FORMAT_PITCH}. The default
      * <code>FORMAT_PITCH</code> is " %9.2f\u00b0".
      *
@@ -999,7 +999,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an angle of pitch according to the current angle format.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_PITCH} and {@link #FORMAT_PITCH}. The default
      * <code>FORMAT_PITCH</code> is " %9.2f\u00b0".
      *
@@ -1014,7 +1014,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format a UTM zone according to the current UTM zone format and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_UTM_ZONE}.
      *
      * @param zone the UTM zone to format.
@@ -1028,7 +1028,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format a UTM zone according to the current UTM zone format.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_UTM_ZONE}.
      *
      * @param zone the UTM zone to format.
@@ -1042,7 +1042,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format a UTM northing value according to the current UTM northing format and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_UTM_NORTHING} and current {@link #FORMAT_UTM_NORTHING}.
      * The default UTM northing format is " %,11.1f". No units symbol is included in the formatted string because UTM
      * northing units are always meters.
@@ -1058,7 +1058,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format a UTM northing value according to the current UTM northing format.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_UTM_NORTHING} and current {@link #FORMAT_UTM_NORTHING}.
      * The default UTM northing format is " %,11.1f". No units symbol is included in the formatted string because UTM
      * northing units are always meters.
@@ -1074,7 +1074,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format a UTM easting value according to the current UTM easting format and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_UTM_EASTING} and current {@link #FORMAT_UTM_EASTING}. The
      * default UTM easting format is " %,11.1f". No units symbol is included in the formatted string because UTM easting
      * units are always meters.
@@ -1090,7 +1090,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format a UTM easting value according to the current UTM easting format.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_UTM_EASTING} and current {@link #FORMAT_UTM_EASTING}. The
      * default UTM easting format is " %,11.1f". No units symbol is included in the formatted string because UTM easting
      * units are always meters.
@@ -1120,12 +1120,12 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format a terrain height value according to the current configuration and append a new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #LABEL_TERRAIN_HEIGHT}, {@link #FORMAT_TERRAIN_HEIGHT} and length
      * units symbol. The default terrain height format is " (ve %3.1f): %,6d %s", where the %3.1f specifier stands for
      * the vertical exaggeration, the %,6d specifier stands for the terrain height, and the %s specifier stands for the
      * units symbol.
-     * <p/>
+     * <p>
      * Note: While the <code>FORMAT_TERRAIN_HEIGHT</code> string may be specified by the application, the terrain height
      * components are always passed to the internal formatter in the order: vertical exaggeration, terrain height, units
      * symbol.
@@ -1158,7 +1158,7 @@ public class UnitsFormat extends AVListImpl
     /**
      * Format a length according to the current length configuration. Prepend a specified label and append a new-line
      * character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #FORMAT_LENGTH} and length units symbol,  and is converted to the
      * current length units prior to formatting. The default length format is " %,12.1f %s", where the %s specifier
      * stands for the units symbol.
@@ -1175,7 +1175,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format a length according to the current length configuration. Prepend a specified label.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #FORMAT_LENGTH} and length units symbol,  and is converted to the
      * current length units prior to formatting. The default length format is " %,12.1f %s", where the %s specifier
      * stands for the units symbol.
@@ -1196,7 +1196,7 @@ public class UnitsFormat extends AVListImpl
     /**
      * Format an area value according to the current length configuration. Prepend a specified label and append a
      * new-line character.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #FORMAT_AREA} and area units symbol,  and is converted to the
      * current area units prior to formatting. The default area format is " %,12.1f %s", where the %s specifier stands
      * for the units symbol.
@@ -1213,7 +1213,7 @@ public class UnitsFormat extends AVListImpl
 
     /**
      * Format an area value according to the current length configuration and prepend a specified label.
-     * <p/>
+     * <p>
      * The value is formatted using the current {@link #FORMAT_AREA} and area units symbol,  and is converted to the
      * current area units prior to formatting. The default area format is " %,12.1f %s", where the %s specifier stands
      * for the units symbol.

--- a/src/gov/nasa/worldwind/util/WWIO.java
+++ b/src/gov/nasa/worldwind/util/WWIO.java
@@ -377,14 +377,14 @@ public class WWIO
     /**
      * Maps the specified File's bytes directly into memory as a {@link java.nio.MappedByteBuffer} according to the
      * specified mode.
-     * <p/>
+     * <p>
      * If the mode is {@link java.nio.channels.FileChannel.MapMode#READ_ONLY}, the file is mapped in read-only mode, and
      * any attempt to modify the contents of the returned MappedByteBuffer causes a {@link ReadOnlyBufferException}.
-     * <p/>
+     * <p>
      * If the mode is {@link java.nio.channels.FileChannel.MapMode#READ_WRITE}, the file is mapped in read-write mode.
      * Changing the contents of the returned MappedByteBuffer to be eventually propagated to the file. The specified
      * file must be avialable for both reading and writing.
-     * <p/>
+     * <p>
      * If the mode is {@link java.nio.channels.FileChannel.MapMode#PRIVATE}, the file is mapped in copy-on-write mode.
      * Changing the contents of the returned MappedByteBuffer causes private copies of portions of the buffer to be
      * created. The specified file must be avialable for both reading and writing.
@@ -521,7 +521,7 @@ public class WWIO
      * @param url      the URL to read.
      * @param encoding the encoding do use. If <code>null</code> is specified then UTF-8 is used.
      *
-     * @return the string representation of the bytes at the <code<URL</code> decoded according to the specified
+     * @return the string representation of the bytes at the <code>URL</code> decoded according to the specified
      *         encoding.
      *
      * @throws IllegalArgumentException if the <code>url</code> is null.
@@ -1258,7 +1258,7 @@ public class WWIO
 
     /**
      * Indicates whether a {@link File} contains content of a specified mime type.
-     * <p/>
+     * <p>
      * Only the filename suffix is consulted to determine the file's content type.
      *
      * @param file      the file to test.
@@ -1470,11 +1470,14 @@ public class WWIO
 
     /**
      * Returns the data type constant corresponding to the specified mime type string. Supported mime types are as
-     * mapped to data types as follows: <table> <tr><th>Mime Type</th><th>Data Type</th></tr>
+     * mapped to data types as follows:
+     * <table><caption>Mime Types</caption>
+     * <tr><th>Mime Type</th><th>Data Type</th></tr>
      * <tr><td>application/bil32</td><td>{@link gov.nasa.worldwind.avlist.AVKey#FLOAT32}</td></tr>
      * <tr><td>application/bil16</td><td>{@link gov.nasa.worldwind.avlist.AVKey#INT16}</td></tr>
      * <tr><td>application/bil</td><td>{@link gov.nasa.worldwind.avlist.AVKey#INT16}</td></tr>
-     * <tr><td>image/bil</td><td>{@link gov.nasa.worldwind.avlist.AVKey#INT16}</td></tr> </table>
+     * <tr><td>image/bil</td><td>{@link gov.nasa.worldwind.avlist.AVKey#INT16}</td></tr> 
+     * </table>
      *
      * @param mimeType the mime type who's data type is returned.
      *
@@ -2044,7 +2047,7 @@ public class WWIO
     /**
      * Open a reader on an input source. The source may be one of the following: <ul> <li>{@link Reader}</li> <li>{@link
      * InputStream}</li> <li>{@link File}</li> <li>{@link URL}</li> <li>{@link String}</li> </ul>
-     * <p/>
+     * <p>
      * Readers are used to read character streams.
      *
      * @param src the input source of one of the above types.
@@ -2507,7 +2510,7 @@ public class WWIO
      * Determines whether a jar URL is a reference to a local jar file or an entry in a local jar file. See {@link
      * java.net.JarURLConnection} for a description of jar URLs.
      *
-     * @param jarUrl the jar URL, in the form jar:<url>!{entry}. (Omit <, >, { and } in the actual URL}
+     * @param jarUrl the jar URL, in the form {@code jar:<url>!{entry}}. (Omit {@code <, >, { and }} in the actual URL}
      *
      * @return true if the URL refers to a local resource, otherwise false.
      */

--- a/src/gov/nasa/worldwind/util/WWMath.java
+++ b/src/gov/nasa/worldwind/util/WWMath.java
@@ -125,7 +125,7 @@ public class WWMath
      * @param min the floor.
      * @param max the ceiling
      *
-     * @return the nearest value such that min <= v <= max.
+     * @return the nearest value such that {@code min <= v <= max}.
      */
     public static double clamp(double v, double min, double max)
     {
@@ -139,7 +139,7 @@ public class WWMath
      * @param min the floor.
      * @param max the ceiling
      *
-     * @return the nearest value such that min <= v <= max.
+     * @return the nearest value such that {@code min <= v <= max}.
      */
     public static int clamp(int v, int min, int max)
     {
@@ -150,10 +150,13 @@ public class WWMath
      * Returns a number between 0.0 and 1.0 indicating whether a specified floating point value is before, between or
      * after the specified min and max. Returns a linear interpolation of min and max when the value is between the
      * two.
-     * <p/>
-     * The returned number is undefined if min > max. Otherwise, the returned number is equivalent to the following:
-     * <ul> <li>0.0 - If value < min</li> <li>1.0 - If value > max</li> <li>Linear interpolation of min and max - If min
-     * <= value <= max</li> </ul>
+     * <p>
+     * The returned number is undefined if {@code min > max}. Otherwise, the returned number is equivalent to the following:
+     * <ul>
+     * <li>0.0 - If {@code value < min}</li> 
+     * <li>1.0 - If {@code value > max}</li> 
+     * <li>Linear interpolation of min and max - If {@code min <= value <= max}</li> 
+     * </ul>
      *
      * @param value the value to compare to the minimum and maximum.
      * @param min   the minimum value.
@@ -185,16 +188,18 @@ public class WWMath
      * Returns a number between 0.0 and 1.0 indicating whether a specified floating point value is before, between or
      * after the specified min and max. Returns a smooth interpolation of min and max when the value is between the
      * two.
-     * <p/>
+     * <p>
      * This method's smooth interpolation is similar to the interpolation performed by {@link #stepValue(double, double,
      * double)}, except that the first derivative of the returned number approaches zero as the value approaches the
      * minimum or maximum. This causes the returned number to ease-in and ease-out as the value travels between the
      * minimum and maximum.
-     * <p/>
-     * The returned number is undefined if min > max. Otherwise, the returned number is equivalent to the following:
-     * <p/>
-     * <ul> <li>0.0 - If value < min</li> <li>1.0 - If value > max</li> <li>Smooth interpolation of min and max - If min
-     * <= value <= max</li> </ul>
+     * <p>
+     * The returned number is undefined if {@code min > max}. Otherwise, the returned number is equivalent to the following:
+     * <ul> 
+     * <li>0.0 - If {@code value < min}</li> 
+     * <li>1.0 - If {@code value > max}</li> 
+     * <li>Smooth interpolation of min and max - If {@code min * <= value <= max}</li> 
+     * </ul>
      *
      * @param value the value to compare to the minimum and maximum.
      * @param min   the minimum value.
@@ -495,7 +500,7 @@ public class WWMath
      * viewport. The returned value is the screen area that the sphere covers in the infinite plane defined by the
      * <code>view's</code> viewport. This area is not limited to the size of the <code>view's</code> viewport, and
      * portions of the sphere are not clipped by the <code>view's</code> frustum.
-     * <p/>
+     * <p>
      * This returns zero if the specified <code>radius</code> is zero.
      *
      * @param view   the <code>View</code> for which to compute a projected screen area.
@@ -887,7 +892,7 @@ public class WWMath
      * the specified buffer of points, sorted from the most prominent axis to the least prominent. This returns null if
      * the buffer is empty. The returned array contains three normalized orthogonal vectors defining a coordinate system
      * which best fits the distribution of the points about its arithmetic mean.
-     * <p/>
+     * <p>
      * The buffer must contain XYZ coordinate tuples which are either tightly packed or offset by the specified stride.
      * The stride specifies the number of buffer elements between the first coordinate of consecutive tuples. For
      * example, a stride of 3 specifies that each tuple is tightly packed as XYZXYZXYZ, whereas a stride of 5 specifies
@@ -1161,7 +1166,7 @@ public class WWMath
 
     /**
      * Intersect a line with a convex polytope and return the intersection points.
-     * <p/>
+     * <p>
      * See "3-D Computer Graphics" by Samuel R. Buss, 2005, Section X.1.4.
      *
      * @param line   the line to intersect with the polytope.
@@ -1260,7 +1265,7 @@ public class WWMath
      * com.jogamp.opengl.GL2#glDrawElements(int, int, int, java.nio.Buffer)}, where <code>mode</code> is {@link
      * com.jogamp.opengl.GL#GL_TRIANGLE_STRIP}, <code>count</code> is the number of elements remaining in the buffer,
      * and <code>type</code> is {@link com.jogamp.opengl.GL#GL_UNSIGNED_INT}.
-     * <p/>
+     * <p>
      * For details the drawing OpenGL primitives, see <a href="http://www.glprogramming.com/red/chapter02.html#name14">http://www.glprogramming.com/red/chapter02.html#name14</a>.
      *
      * @param width  the patch width, in vertices.
@@ -1316,7 +1321,7 @@ public class WWMath
      * com.jogamp.opengl.GL2#glDrawElements(int, int, int, java.nio.Buffer)}, where <code>mode</code> is {@link
      * com.jogamp.opengl.GL#GL_LINE_STRIP}, <code>count</code> is the number of elements remaining in the buffer, and
      * <code>type</code> is {@link com.jogamp.opengl.GL#GL_UNSIGNED_INT}.
-     * <p/>
+     * <p>
      * For details the drawing OpenGL primitives, see <a href="http://www.glprogramming.com/red/chapter02.html#name14">http://www.glprogramming.com/red/chapter02.html#name14</a>.
      *
      * @param width  the patch width, in vertices.
@@ -1375,7 +1380,7 @@ public class WWMath
      * to store the same number of vertices as the vertex buffer. The vertex buffer is assumed to contain tightly packed
      * 3-coordinate tuples. The 3-coordinate normal for each vertex is stored in the normal buffer at the same position
      * each vertex appears in the vertex buffer.
-     * <p/>
+     * <p>
      * For details the drawing OpenGL primitives, see <a href="http://www.glprogramming.com/red/chapter02.html#name14">http://www.glprogramming.com/red/chapter02.html#name14</a>.
      *
      * @param indices  indices into the vertex buffer defining a triangle strip.

--- a/src/gov/nasa/worldwind/util/WWUtil.java
+++ b/src/gov/nasa/worldwind/util/WWUtil.java
@@ -378,7 +378,7 @@ public class WWUtil
      * Generates a random {@link Color} by scaling each of the red, green and blue components of a specified color with
      * independent random numbers. The alpha component is not scaled and is copied to the new color. The returned color
      * can be any value between white (0x000000aa) and black (0xffffffaa).
-     * <p/>
+     * <p>
      * Unless there's a reason to use a specific input color, the best color to use is white.
      *
      * @param color the color to generate a random color from. If null, the color white (0x000000aa) is used.
@@ -402,7 +402,7 @@ public class WWUtil
      * Generates a random {@link Color} by scaling each of the red, green and blue components of a specified color with
      * independent random numbers. The alpha component is not scaled and is copied to the new color. The returned color
      * can be any value between white (0x000000aa) and a specified darkest color.
-     * <p/>
+     * <p>
      * Unless there's a reason to use a specific input color, the best color to use is white.
      *
      * @param color        the color to generate a random color from. If null, the color white (0x000000aa) is used.
@@ -528,7 +528,7 @@ public class WWUtil
      * @param color1 the first color.
      * @param color2 the second color.
      *
-     * @return this returns the linear interpolation of <code>color1</code> and <code>color2</code> if <amount> is
+     * @return this returns the linear interpolation of <code>color1</code> and <code>color2</code> if <code>amount</code> is
      *         between 0 and 1, a color equivalent to color1 if <code>amount</code> is 0 or less, or a color equivalent
      *         to <code>color2</code> if <code>amount</code> is 1 or more.
      *
@@ -1050,7 +1050,7 @@ public class WWUtil
     }
 
     /**
-     * Strips leading period from a string (Example: input -> ".ext", output -> "ext")
+     * Strips leading period from a string (Example: {@code input -> ".ext", output -> "ext"})
      *
      * @param s String to test, must not be null
      *

--- a/src/gov/nasa/worldwind/util/WWXML.java
+++ b/src/gov/nasa/worldwind/util/WWXML.java
@@ -3651,8 +3651,12 @@ public class WWXML
 
     /**
      * Returns the byte order constant for a specified string. This performs a mapping between text and an AVKey
-     * constant: <table> <th><td>Text</td><td>Constant</td></th> <tr><td>LittleEndian</td><td>{@link
-     * AVKey#LITTLE_ENDIAN}</td></tr> <tr><td>BigEndian</td><td>{@link AVKey#BIG_ENDIAN}</td></tr> </table>
+     * constant: 
+     * <table><caption>Key/Values</caption>
+     * <tr><th>Text</th><th>Constant</th></tr> 
+     * <tr><td>LittleEndian</td><td>{@link AVKey#LITTLE_ENDIAN}</td></tr> 
+     * <tr><td>BigEndian</td><td>{@link AVKey#BIG_ENDIAN}</td></tr> 
+     * </table>
      *
      * @param s the string to parse as a byte order.
      *
@@ -3684,8 +3688,12 @@ public class WWXML
 
     /**
      * Returns the string text for a specified byte order constant. This performs a mapping between text and an AVKey
-     * constant: <table> <th><td>Text</td><td>Constant</td></th> <tr><td>LittleEndian</td><td>{@link
-     * AVKey#LITTLE_ENDIAN}</td></tr> <tr><td>BigEndian</td><td>{@link AVKey#BIG_ENDIAN}</td></tr> </table>
+     * constant: 
+     * <table><caption>Key/Values</caption>
+     * <tr><th>Text</th><th>Constant</th></tr> 
+     * <tr><td>LittleEndian</td><td>{@link AVKey#LITTLE_ENDIAN}</td></tr> 
+     * <tr><td>BigEndian</td><td>{@link AVKey#BIG_ENDIAN}</td></tr> 
+     * </table>
      *
      * @param byteOrder the byte order constant to encode as a string.
      *
@@ -3716,9 +3724,14 @@ public class WWXML
 
     /**
      * Returns the data type constant for a specified string. This performs a mapping between text and an AVKey
-     * constant: <table> <th><td>Text</td><td>Constant</td></th> <tr><td>Float32</td><td>{@link AVKey#FLOAT32}</td></tr>
-     * <tr><td>Int32</td><td>{@link AVKey#INT32}</td></tr> <tr><td>Int16</td><td>{@link AVKey#INT16}</td></tr>
-     * <tr><td>Int8</td><td>{@link AVKey#INT8}</td></tr> </table>
+     * constant: 
+     * <table><caption>Key/Values</caption>
+     * <tr><th>Text</th><th>Constant</th></tr> 
+     * <tr><td>Float32</td><td>{@link AVKey#FLOAT32}</td></tr>
+     * <tr><td>Int32</td><td>{@link AVKey#INT32}</td></tr> 
+     * <tr><td>Int16</td><td>{@link AVKey#INT16}</td></tr>
+     * <tr><td>Int8</td><td>{@link AVKey#INT8}</td></tr> 
+     * </table>
      *
      * @param s the string to parse as a data type.
      *
@@ -3753,7 +3766,10 @@ public class WWXML
 
     /**
      * Returns the string text for a specified data type constant. This performs a mapping between text and an AVKey
-     * constant: <table> <th><td>Text</td><td>Constant</td></th> <tr><td>Float32</td><td>{@link AVKey#FLOAT32}</td></tr>
+     * constant: 
+     * <table><caption>Key/Values</caption>
+     * <tr><th>Text</th><th>Constant</th></tr> 
+     * <tr><td>Float32</td><td>{@link AVKey#FLOAT32}</td></tr>
      * <tr><td>Int32</td><td>{@link AVKey#INT32}</td></tr> <tr><td>Int16</td><td>{@link AVKey#INT16}</td></tr>
      * <tr><td>Int8</td><td>{@link AVKey#INT8}</td></tr> </table>
      *

--- a/src/gov/nasa/worldwind/util/combine/Combinable.java
+++ b/src/gov/nasa/worldwind/util/combine/Combinable.java
@@ -12,7 +12,6 @@ package gov.nasa.worldwind.util.combine;
  * as {@link gov.nasa.worldwind.util.combine.ShapeCombiner}. When combine is called, the Combinable draws its contours
  * using the GLU tessellator attached to the provided CombineContext. When the CombineContext is in bounding sector
  * mode, the Combinable adds its geographic bounding sector to the CombineContext's bounding sector list.
- * <p/>
  * <h2>Drawing Contours</h2> Shapes are combined into a complex set of contours by drawing their individual contours
  * using the GLU tessellator attached to a CombineContext. A controller that implements the boolean operation configures
  * the CombineContext then calls combine on each shape. It is the responsibility of the controller to configure the GLU
@@ -21,14 +20,13 @@ package gov.nasa.worldwind.util.combine;
  * winding order of each contour defines whether the contour is an exterior region or an interior region.
  * Counterclockwise contours define the outer boundaries, and clockwise contours define holes or inner boundaries.
  * Contours may be nested, but a nested contour must be oriented oppositely from the contour that contains it.
- * <p/>
  * <h2>Bounding Sector Mode</h2> CombineContext may be configured in bounding sector mode by returning true from
  * isBoundingSectorMode(). When combine is called in this mode, a shape adds its geographic bounding sector to the
  * context by calling addBoundingSector(Sector). CombineContext assumes that each shape either contributes one bounding
  * sector or does not contribute anything.
- * <p/>
  * <h2>Example Implementation</h2>
  * <pre>
+ * {@code 
  * public class CombinableSector implements Combinable
  * {
  *     protected Sector sector = Sector.fromDegrees(-10, 10, -10, 10);
@@ -73,6 +71,7 @@ package gov.nasa.worldwind.util.combine;
  *             GLU.gluTessEndContour(tess);
  *         }
  *     }
+ * }
  * }
  * </pre>
  *

--- a/src/gov/nasa/worldwind/util/combine/CombineContext.java
+++ b/src/gov/nasa/worldwind/util/combine/CombineContext.java
@@ -23,7 +23,7 @@ import java.util.*;
  * The globe is used by shapes that define geometry relative to a globe. The resolution is used to filter shape detail
  * and compute geometry for resolution independent shapes. Shape geometry outside of the region of interest may be
  * ignored, clipped, or simplified at the discretion of the shape.
- * <p/>
+ * <p>
  * CombineContext initializes its GLU tessellator according to the conventions for Combinable shapes. See the {@link
  * gov.nasa.worldwind.util.combine.Combinable} interface documentation for information on drawing Combinable contours.
  * The complex set of contours computed as a result of drawing shapes into the tessellator are collected in the

--- a/src/gov/nasa/worldwind/util/gdal/GDALUtils.java
+++ b/src/gov/nasa/worldwind/util/gdal/GDALUtils.java
@@ -1244,75 +1244,74 @@ public class GDALUtils
      * @throws IllegalArgumentException when the passed dataset is null pr emtpy, or any of the dimension is 0
      * @throws gov.nasa.worldwind.exception.WWRuntimeException
      *                                  if GDAL is not available, or a dataset contains no bands
-     *                                  <p/>
+     *                                  <p>
      *                                  The extractRasterParameters() sets next key/value pairs:
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.WIDTH - the maximum width of the image
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.HEIGHT - the maximum height of the image
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.COORDINATE_SYSTEM - one of the next values: AVKey.COORDINATE_SYSTEM_SCREEN
      *                                  AVKey.COORDINATE_SYSTEM_GEOGRAPHIC AVKey.COORDINATE_SYSTEM_PROJECTED
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.SECTOR - in case of Geographic CS, contains a regular Geographic Sector
      *                                  defined by lat/lon coordinates of corners in case of Projected CS, contains a
      *                                  bounding box of the area
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.COORDINATE_SYSTEM_NAME
-     *                                  <p/>
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.PIXEL_WIDTH (Double) pixel size, UTM images usually specify 1 (1 meter);
      *                                  if missing and Geographic Coordinate System is specified will be calculated as
      *                                  LongitudeDelta/WIDTH
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.PIXEL_HEIGHT (Double) pixel size, UTM images usually specify 1 (1 meter);
      *                                  if missing and Geographic Coordinate System is specified will be calculated as
      *                                  LatitudeDelta/HEIGHT
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.ORIGIN (LatLon) specifies coordinate of the image's origin (one of the
      *                                  corners, or center) If missing, upper left corner will be set as origin
-     *                                  <p/>
-     *                                  AVKey.DATE_TIME (0 terminated String, length == 20) if missing, current date &
+     *                                  <p>
+     *                                  AVKey.DATE_TIME (0 terminated String, length == 20) if missing, current date and
      *                                  time will be used
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.PIXEL_FORMAT required (valid values: AVKey.ELEVATION | AVKey.IMAGE }
      *                                  specifies weather it is a digital elevation model or image
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.IMAGE_COLOR_FORMAT required if AVKey.PIXEL_FORMAT is AVKey.IMAGE (valid
      *                                  values: AVKey.COLOR and AVKey.MONOCHROME)
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.DATA_TYPE required ( valid values: AVKey.INT16, and AVKey.FLOAT32 )
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.VERSION optional, if missing a default will be used "NASA WorldWind"
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.DISPLAY_NAME, (String) optional, specifies a name of the document/image
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.DESCRIPTION (String) optional, for any kind of descriptions
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.MISSING_DATA_SIGNAL optional, set the AVKey.MISSING_DATA_SIGNAL ONLY if
      *                                  you know for sure that the specified value actually represents void (NODATA)
      *                                  areas. Elevation data usually has "-32767" (like DTED), or "-32768" like SRTM,
      *                                  but some has "0" (mostly images) and "-9999" like NED. Note! Setting "-9999" is
      *                                  very ambiguos because -9999 for elevation is valid value;
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.MISSING_DATA_REPLACEMENT (String type forced by spec) Most images have
      *                                  "NODATA" as "0", elevations have as "-9999", or "-32768" (sometimes "-32767")
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.COORDINATE_SYSTEM required, valid values AVKey.COORDINATE_SYSTEM_GEOGRAPHIC
      *                                  or AVKey.COORDINATE_SYSTEM_PROJECTED
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.COORDINATE_SYSTEM_NAME Optional, A name of the Coordinates System as a
      *                                  String
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.PROJECTION_EPSG_CODE Required; Integer; EPSG code or Projection Code If CS
      *                                  is Geodetic and EPSG code is not specified, a default WGS84 (4326) will be used
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.PROJECTION_DATUM  Optional, AVKey.PROJECTION_DESC   Optional,
      *                                  AVKey.PROJECTION_NAME   Optional, AVKey.PROJECTION_UNITS  Optional,
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.ELEVATION_UNIT Required, if AVKey.PIXEL_FORMAT = AVKey.ELEVATION, value:
      *                                  AVKey.UNIT_FOOT or AVKey.UNIT_METER (default, if not specified)
-     *                                  <p/>
+     *                                  <p>
      *                                  AVKey.RASTER_PIXEL, optional, values: AVKey.RASTER_PIXEL_IS_AREA or
      *                                  AVKey.RASTER_PIXEL_IS_POINT if not specified, default for images is
      *                                  RASTER_PIXEL_IS_AREA, and AVKey.RASTER_PIXEL_IS_POINT for elevations

--- a/src/gov/nasa/worldwind/util/layertree/KMLFeatureTreeNode.java
+++ b/src/gov/nasa/worldwind/util/layertree/KMLFeatureTreeNode.java
@@ -14,7 +14,7 @@ import gov.nasa.worldwind.util.EntityMap;
 /**
  * A <code>TreeNode</code> that represents a KML feature defined by a <code>{@link
  * gov.nasa.worldwind.ogc.kml.KMLAbstractFeature}</code>.
- * <p/>
+ * <p>
  * The node's selection state is synchronized with its KML feature's visibility state. <code>{@link
  * #isSelected()}</code> returns whether the node's feature is visible. Calling <code>{@link
  * #setSelected(boolean)}</code> specifies both the the node's selection state, and whether its feature should be
@@ -125,9 +125,9 @@ public class KMLFeatureTreeNode extends BasicTreeNode
     /**
      * Expands paths in the specified <code>tree</code> corresponding to open KML container elements. This assumes that
      * the <code>tree</code>'s model contains this node.
-     * <p/>
+     * <p>
      * This node's path is expanded if the feature's <code>open</code> property is <code>true</code>.
-     * <p/>
+     * <p>
      * This calls <code>expandOpenContainers</code> on all children which are instances of
      * <code>KMLFeatureTreeNode</code>.
      *

--- a/src/gov/nasa/worldwind/util/layertree/KMLLayerTreeNode.java
+++ b/src/gov/nasa/worldwind/util/layertree/KMLLayerTreeNode.java
@@ -109,11 +109,11 @@ public class KMLLayerTreeNode extends LayerTreeNode
 
     /**
      * Adds a new <code>KMLFeatureTreeNode</code> to this node for each KML feature in the <code>KMLRoot</code>.
-     * <p/>
+     * <p>
      * If the <code>KMLRoot</code>'s top level feature is a <code>Document</code> or <code>Folder</code>, this method
      * ignores this container and adds its children directly to this node. Creating a node for the container adds an
      * extra level to the tree node that doesn't provide any meaningful grouping.
-     * <p/>
+     * <p>
      * This does nothing if the <code>KMLRoot</code>'s top level feature is <code>null</code>.
      */
     protected void addChildFeatures()
@@ -183,10 +183,10 @@ public class KMLLayerTreeNode extends LayerTreeNode
     /**
      * Expands paths in the specified <code>tree</code> corresponding to open KML container elements. This assumes that
      * the <code>tree</code>'s model contains this node.
-     * <p/>
+     * <p>
      * This node's path is expanded if it's top level KML feature is an open KML container, an open KML network link, or
      * is any other kind of KML feature.
-     * <p/>
+     * <p>
      * This calls <code>expandOpenContainers</code> on all children which are instances of
      * <code>KMLFeatureTreeNode</code>.
      *

--- a/src/gov/nasa/worldwind/util/layertree/KMLNetworkLinkTreeNode.java
+++ b/src/gov/nasa/worldwind/util/layertree/KMLNetworkLinkTreeNode.java
@@ -14,7 +14,7 @@ import java.beans.*;
 /**
  * A <code>KMLFeatureTreeNode</code> that represents a KML network link defined by a <code>{@link
  * gov.nasa.worldwind.ogc.kml.KMLNetworkLink}</code>.
- * <p/>
+ * <p>
  * <code>KMLNetworkLinkTreeNode</code>  automatically repopulates its hierarchy when its <code>KMLNetworkLink</code> is
  * refreshed, and notifies its listeners when this happens.
  *
@@ -49,7 +49,7 @@ public class KMLNetworkLinkTreeNode extends KMLContainerTreeNode
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Additionally, this node's hierarchy is populated from the KML features in its <code>KMLNetworkLink</code>, and
      * this registers a <code>RETRIEVAL_STATE_SUCCESSFUL</code> property change listener on the
      * <code>KMLNetworkLink</code>.
@@ -96,7 +96,7 @@ public class KMLNetworkLinkTreeNode extends KMLContainerTreeNode
      * Called when this node's <code>KMLNetworkLink</code> refreshes. Clears this node's hierarchy by removing its
      * children, then adds a new <code>KMLFeatureTreeNode</code> to this node for each KML feature in the
      * <code>KMLNetworkLink</code>.
-     * <p/>
+     * <p>
      * If the <code>KMLNetworkLink</code>'s top level feature is a <code>KMLDocument</code>, this method ignores the
      * document and adds its children directly to this node. Creating a node for the document adds an extra level to the
      * tree node that doesn't provide any meaningful grouping.

--- a/src/gov/nasa/worldwind/util/layertree/LayerTreeModel.java
+++ b/src/gov/nasa/worldwind/util/layertree/LayerTreeModel.java
@@ -15,16 +15,16 @@ import gov.nasa.worldwind.util.tree.*;
  * <code>LayerTreeModel</code> initializes itself with a default root node. By default, this root node is of type
  * <code>BasicTreeNode</code> and its text is "Layers". Nodes added under the tree model's root should always be of type
  * <code>{@link LayerTreeNode}</code>. a <code>LayerTreeNode</code> may be of any type.
- * <p/>
+ * <p>
  * <code>LayerTreeModel</code> provides operations for performing the following common tasks on a layer tree: <ul>
  * <li>Adding a layer node.</li> <li>Removing all layer nodes.</li> <li>Refreshing the layer nodes from a <code>{@link
  * gov.nasa.worldwind.layers.LayerList}</code>.</li> </ul>
- * <p/>
+ * <p>
  * By default, the tree model does not include layers marked as hidden. This allows an application to prevent certain
  * layers in a <code>LayerList</code> from appearing in the tree. For example, the layer that renders the tree itself
  * usually should not appear in the tree. If it did then the user could turn off the tree layer and have no way of
  * getting it back. A layer can be marked as hidden by setting <code>AVKey.HIDDEN</code> to <code>true</code>:
- * <p/>
+ * 
  * <pre>hiddenLayer.setValue(AVKey.HIDDEN, true); // Prevent layer from being displayed in the layer tree</pre>
  *
  * @author dcollins

--- a/src/gov/nasa/worldwind/util/layertree/LayerTreeNode.java
+++ b/src/gov/nasa/worldwind/util/layertree/LayerTreeNode.java
@@ -13,7 +13,7 @@ import gov.nasa.worldwind.util.tree.BasicTreeNode;
 
 /**
  * A <code>TreeNode</code> that represents a <code>{@link gov.nasa.worldwind.layers.Layer}</code>.
- * <p/>
+ * <p>
  * The node's selection state is synchronized with its <code>Layer</code>'s enabled state. <code>{@link
  * #isSelected()}</code> returns whether the node's <code>Layer</code> is enabled. Calling <code>{@link
  * #setSelected(boolean)}</code> specifies both the the node's selection state, and whether its <code>Layer</code>

--- a/src/gov/nasa/worldwind/util/measure/LengthMeasurer.java
+++ b/src/gov/nasa/worldwind/util/measure/LengthMeasurer.java
@@ -14,16 +14,19 @@ import gov.nasa.worldwind.render.Polyline;
 import java.util.ArrayList;
 
 /**
- * Utility class to measure length along a path on a globe. <p/> <p>The measurer must be provided a list of at least two
- * positions to be able to compute a distance.</p> <p/> <p>Segments which are longer then the current maxSegmentLength
- * will be subdivided along lines following the current pathType - Polyline.LINEAR, Polyline.RHUMB_LINE or
- * Polyline.GREAT_CIRCLE.</p> <p/> <p>If the measurer is set to follow terrain, the computed length will account for
- * terrain deformations as if someone was walking along that path. Otherwise the length is the sum of the cartesian
- * distance between the positions.</p>
- * <p/>
- * <p>When following terrain the measurer will sample terrain elevations at regular intervals along the path. The
- * minimum number of samples used for the whole length can be set with setLengthTerrainSamplingSteps(). However, the
- * minimum sampling interval is 30 meters.
+ * Utility class to measure length along a path on a globe.
+ * <p>
+ * The measurer must be provided a list of at least two positions to be able to compute a distance.
+ * <p>
+ * Segments which are longer then the current maxSegmentLength will be subdivided along lines following the current
+ * pathType - Polyline.LINEAR, Polyline.RHUMB_LINE or Polyline.GREAT_CIRCLE.
+ * <p>
+ * If the measurer is set to follow terrain, the computed length will account for terrain deformations as if someone was
+ * walking along that path. Otherwise the length is the sum of the cartesian distance between the positions.
+ * <p>
+ * When following terrain the measurer will sample terrain elevations at regular intervals along the path. The minimum
+ * number of samples used for the whole length can be set with setLengthTerrainSamplingSteps(). However, the minimum
+ * sampling interval is 30 meters.
  *
  * @author Patrick Murris
  * @version $Id: LengthMeasurer.java 2261 2014-08-23 00:31:54Z tgaskins $
@@ -226,9 +229,11 @@ public class LengthMeasurer implements MeasurableLength
     }
 
     /**
-     * Get the path length in meter. <p/> <p>If the measurer is set to follow terrain, the computed length will account
+     * Get the path length in meter. 
+     * <p>
+     * If the measurer is set to follow terrain, the computed length will account
      * for terrain deformations as if someone was walking along that path. Otherwise the length is the sum of the
-     * cartesian distance between each positions.</p>
+     * cartesian distance between each positions.
      *
      * @param globe the globe to draw terrain information from.
      *
@@ -302,16 +307,17 @@ public class LengthMeasurer implements MeasurableLength
 //    }
 
     /**
-     * Subdivide a list of positions so that no segment is longer then the provided maxLength. <p/> <p>If needed, new
-     * intermediate positions will be created along lines that follow the given pathType - one of Polyline.LINEAR,
-     * Polyline.RHUMB_LINE or Polyline.GREAT_CIRCLE. All position elevations will be either at the terrain surface if
-     * followTerrain is true, or interpolated according to the original elevations.</p>
+     * Subdivide a list of positions so that no segment is longer then the provided maxLength.
+     * <p>
+     * If needed, new intermediate positions will be created along lines that follow the given pathType - one of
+     * Polyline.LINEAR, Polyline.RHUMB_LINE or Polyline.GREAT_CIRCLE. All position elevations will be either at the
+     * terrain surface if followTerrain is true, or interpolated according to the original elevations.
      *
-     * @param globe         the globe to draw elevations and points from.
-     * @param positions     the original position list
-     * @param maxLength     the maximum length for one segment.
+     * @param globe the globe to draw elevations and points from.
+     * @param positions the original position list
+     * @param maxLength the maximum length for one segment.
      * @param followTerrain true if the positions should be on the terrain surface.
-     * @param pathType      the type of path to use in between two positions.
+     * @param pathType the type of path to use in between two positions.
      *
      * @return a list of positions with no segment longer then maxLength and elevations following terrain or not.
      */
@@ -324,10 +330,11 @@ public class LengthMeasurer implements MeasurableLength
 
     /**
      * Subdivide a list of positions so that no segment is longer then the provided maxLength. Only the positions
-     * between start and start + count - 1 will be processed. <p/> <p>If needed, new intermediate positions will be
-     * created along lines that follow the given pathType - one of Polyline.LINEAR, Polyline.RHUMB_LINE or
-     * Polyline.GREAT_CIRCLE. All position elevations will be either at the terrain surface if followTerrain is true, or
-     * interpolated according to the original elevations.</p>
+     * between start and start + count - 1 will be processed.
+     * <p> 
+     * If needed, new intermediate positions will be created along lines that follow the given pathType - one of
+     * Polyline.LINEAR, Polyline.RHUMB_LINE or Polyline.GREAT_CIRCLE. All position elevations will be either at the
+     * terrain surface if followTerrain is true, or interpolated according to the original elevations.
      *
      * @param globe         the globe to draw elevations and points from.
      * @param positions     the original position list

--- a/src/gov/nasa/worldwind/util/measure/MeasureTool.java
+++ b/src/gov/nasa/worldwind/util/measure/MeasureTool.java
@@ -22,46 +22,76 @@ import java.util.List;
  * A utility class to interactively draw shapes and measure distance and area across the terrain. When armed, the class
  * monitors mouse events to allow the definition of a measure shape that can be one of {@link #SHAPE_LINE}, {@link
  * #SHAPE_PATH}, {@link #SHAPE_POLYGON}, {@link #SHAPE_CIRCLE}, {@link #SHAPE_ELLIPSE}, {@link #SHAPE_SQUARE} or {@link
- * #SHAPE_QUAD}. <p/> <p>In order to allow user interaction with the measuring shape, a controller must be set by
- * calling {@link #setController(MeasureToolController)} with a new instance of a <code>MeasureToolController</code>.</p>
- * <p/> <p>The interaction sequence for drawing a shape and measuring is as follows: <ul> <li>Set the measure
- * shape.</li> <li>Arm the <code>MeasureTool</code> object by calling its {@link #setArmed(boolean)} method with an
- * argument of true.</li> <li>Click on the terrain to add points.</li> <li>Disarm the <code>MeasureTool</code> object by
- * calling its {@link #setArmed(boolean)} method with an argument of false. </li> <li>Read the measured length or area
- * by calling the <code>MeasureTool</code> {@link #getLength()} or {@link #getArea()} method. Note that the length and
- * area can be queried at any time during or after the process.</li> </ul> </p> <p>While entering points or after the
- * measure tool has been disarmed, dragging the control points allow to change the initial points positions and alter
- * the measure shape.</p> <p/> <p> While the <code>MeasureTool</code> is armed, pressing and immediately releasing mouse
- * button one while also pressing the control key (Ctl) removes the last point entered. Once the
- * <code>MeasureTool</code> is disarmed, a measure shape of type SHAPE_POLYGON can be moved by dragging a control point
- * while pressing the alt/option key.</p> <p/> <p>Arming and disarming the <code>MeasureTool</code> does not change the
- * contents or attributes of the measure tool's layer. Note that the measure tool will NOT disarm itself after the
- * second point of a line or a regular shape has been entered - the MeasureToolController has that responsibility.</p>
- * <p/> <p><b>Setting the measure shape from the application</b></p> <p/> <p>The application can set the measure shape
- * to an arbitrary list of positions using {@link #setPositions(java.util.ArrayList)}. If the provided list contains two
- * positions, the measure shape will be set to {@link #SHAPE_LINE}. If more then two positions are provided, the measure
- * shape will be set to {@link #SHAPE_PATH} if the last position differs from the first (open path), or {@link
- * #SHAPE_POLYGON} if the path is closed.</p> <p/> <p>The application can also set the measure shape to a predefined
- * regular shape by calling {@link #setMeasureShapeType(String, Position, double, double, Angle)}, providing a shape
- * type (one of {@link #SHAPE_CIRCLE}, {@link #SHAPE_ELLIPSE}, {@link #SHAPE_SQUARE} or {@link #SHAPE_QUAD}), a center
- * position, a width, a height (in meters) and a heading angle.</p> <p/> <p>Finally, the application can use an existing
- * <code>Polyline</code> or <code>SurfaceShape</code> by using {@link #setMeasureShape(Polyline)} or {@link
+ * #SHAPE_QUAD}.
+ * <p>
+ * In order to allow user interaction with the measuring shape, a controller must be set by calling
+ * {@link #setController(MeasureToolController)} with a new instance of a <code>MeasureToolController</code>.</p>
+ * <p>
+ * The interaction sequence for drawing a shape and measuring is as follows:</p>
+ * <ul> <li>Set the measure shape.</li> <li>Arm the <code>MeasureTool</code> object by calling its
+ * {@link #setArmed(boolean)} method with an argument of true.</li> <li>Click on the terrain to add points.</li>
+ * <li>Disarm the <code>MeasureTool</code> object by calling its {@link #setArmed(boolean)} method with an argument of
+ * false. </li> <li>Read the measured length or area by calling the <code>MeasureTool</code> {@link #getLength()} or
+ * {@link #getArea()} method. Note that the length and area can be queried at any time during or after the process.</li>
+ * </ul> 
+ * <p>
+ * While entering points or after the measure tool has been disarmed, dragging the control points allow to change the
+ * initial points positions and alter the measure shape.</p>
+ * <p>
+ * While the <code>MeasureTool</code> is armed, pressing and immediately releasing mouse button one while also pressing
+ * the control key (Ctl) removes the last point entered. Once the <code>MeasureTool</code> is disarmed, a measure shape
+ * of type SHAPE_POLYGON can be moved by dragging a control point while pressing the alt/option key.</p>
+ * <p>
+ * Arming and disarming the <code>MeasureTool</code> does not change the contents or attributes of the measure tool's
+ * layer. Note that the measure tool will NOT disarm itself after the second point of a line or a regular shape has been
+ * entered - the MeasureToolController has that responsibility.</p>
+ * <p>
+ * <b>Setting the measure shape from the application</b></p>
+ * <p>
+ * The application can set the measure shape to an arbitrary list of positions using
+ * {@link #setPositions(java.util.ArrayList)}. If the provided list contains two positions, the measure shape will be
+ * set to {@link #SHAPE_LINE}. If more then two positions are provided, the measure shape will be set to
+ * {@link #SHAPE_PATH} if the last position differs from the first (open path), or {@link
+ * #SHAPE_POLYGON} if the path is closed.</p>
+ * <p>
+ * The application can also set the measure shape to a predefined regular shape by calling
+ * {@link #setMeasureShapeType(String, Position, double, double, Angle)}, providing a shape type (one of
+ * {@link #SHAPE_CIRCLE}, {@link #SHAPE_ELLIPSE}, {@link #SHAPE_SQUARE} or {@link #SHAPE_QUAD}), a center position, a
+ * width, a height (in meters) and a heading angle.</p>
+ * <p>
+ * Finally, the application can use an existing <code>Polyline</code> or <code>SurfaceShape</code> by using
+ * {@link #setMeasureShape(Polyline)} or {@link
  * #setMeasureShape(SurfaceShape)}. The surface shape can be one of <code>SurfacePolyline</code>,
  * <code>SurfacePolygon</code>, <code>SurfaceQuad</code>, <code>SurfaceSquare</code>, <code>SurfaceEllipse</code> or
- * <code>SurfaceCircle</code>. <p/> <p><b>Measuring</b></p> <p/> <p>The application can read the measured length or area
- * by calling the <code>MeasureTool</code> {@link #getLength()} or {@link #getArea()} method. These methods will return
- * -1 when no value is available.</p> <p/> <p>Regular shapes are defined by a center position, a width a height and a
- * heading angle. Those attributes can be accessed by calling the {@link #getCenterPosition()}, {@link #getWidth()},
- * {@link #getHeight()} and {@link #getOrientation()} methods.</p> <p/> <p>The measurements are displayed in units
- * specified in the measure tool's {@link UnitsFormat} object. Access to the units format is via the method {@link
- * #getUnitsFormat()}. <p/> <p><b>Events</b></p> <p/> <p>The <code>MeasureTool</code> will send events on several
- * occasions: when the position list has changed - {@link #EVENT_POSITION_ADD}, {@link #EVENT_POSITION_REMOVE} or {@link
+ * <code>SurfaceCircle</code>. </p>
+ * <p>
+ * <b>Measuring</b></p>
+ * <p>
+ * The application can read the measured length or area by calling the <code>MeasureTool</code> {@link #getLength()} or
+ * {@link #getArea()} method. These methods will return -1 when no value is available.</p>
+ * <p>
+ * Regular shapes are defined by a center position, a width a height and a heading angle. Those attributes can be
+ * accessed by calling the {@link #getCenterPosition()}, {@link #getWidth()},
+ * {@link #getHeight()} and {@link #getOrientation()} methods.</p>
+ * <p>
+ * The measurements are displayed in units specified in the measure tool's {@link UnitsFormat} object. Access to the
+ * units format is via the method {@link
+ * #getUnitsFormat()}.
+ * <p>
+ * <b>Events</b></p>
+ * <p>
+ * The <code>MeasureTool</code> will send events on several occasions: when the position list has changed -
+ * {@link #EVENT_POSITION_ADD}, {@link #EVENT_POSITION_REMOVE} or {@link
  * #EVENT_POSITION_REPLACE}, when metrics has changed {@link #EVENT_METRIC_CHANGED} or when the tool is armed or
- * disarmed {@link #EVENT_ARMED}.</p> <p/> <p>Events will also be fired at the start and end of a rubber band operation
- * during shape creation: {@link #EVENT_RUBBERBAND_START} and {@link #EVENT_RUBBERBAND_STOP}.</p> <p/> <p>See {@link
- * gov.nasa.worldwindx.examples.MeasureToolPanel} for some events usage.</p> <p/> <p>Several instances of this class can
- * be used simultaneously. However, each instance should be disposed of after usage by calling the {@link #dispose()}
- * method.</p>
+ * disarmed {@link #EVENT_ARMED}.</p>
+ * <p>
+ * Events will also be fired at the start and end of a rubber band operation during shape creation:
+ * {@link #EVENT_RUBBERBAND_START} and {@link #EVENT_RUBBERBAND_STOP}.</p>
+ * <p>
+ * See {@link gov.nasa.worldwindx.examples.MeasureToolPanel} for some events usage.</p>
+ * <p>
+ * Several instances of this class can be used simultaneously. However, each instance should be disposed of after usage
+ * by calling the {@link #dispose()} method.</p>
  *
  * @author Patrick Murris
  * @version $Id: MeasureTool.java 3297 2015-07-03 16:21:05Z dcollins $

--- a/src/gov/nasa/worldwind/util/tree/BasicTreeLayout.java
+++ b/src/gov/nasa/worldwind/util/tree/BasicTreeLayout.java
@@ -1747,13 +1747,13 @@ public class BasicTreeLayout extends WWObjectImpl implements TreeLayout, Scrolla
      * Toggles the selection state of the specified <code>node</code>. In order to provide an intuitive tree selection
      * model to the application, this changes the selection state of the <code>node</code>'s ancestors and descendants
      * as follows:
-     * <p/>
-     * <ul> <li>The branch beneath the node it also set to the node's new selection state. Toggling an interior node's
-     * selection state causes that entire branch to toggle.</li> <li>The node's ancestors are set to match the node's
-     * new selection state. If the new state is <code>false</code>, this stops at the first ancestor with another branch
-     * that has a selected node. When an interior or leaf node is toggled, the path to that node is also toggled, except
-     * when doing so would clear a selected path to another interior or leaf node.</li> </ul>
-     * <p/>
+     * <ul>
+     * <li>The branch beneath the node it also set to the node's new selection state. Toggling an interior node's
+     * selection state causes that entire branch to toggle.</li>
+     * <li>The node's ancestors are set to match the node's new selection state. If the new state is <code>false</code>,
+     * this stops at the first ancestor with another branch that has a selected node. When an interior or leaf node is
+     * toggled, the path to that node is also toggled, except when doing so would clear a selected path to another
+     * interior or leaf node.</li> </ul>
      *
      * @param node the <code>TreeNode</code> who's selection state should be toggled.
      */

--- a/src/gov/nasa/worldwind/util/tree/ScrollBar.java
+++ b/src/gov/nasa/worldwind/util/tree/ScrollBar.java
@@ -20,7 +20,6 @@ import java.awt.event.*;
  * A scrollbar component. The scrollable range is defined by four values: min, max, value, and extent. {@code value} is
  * the current position of the scroll bar. {@code extent} represents the visible region. The four values must always
  * satisfy this relationship:
- * <p/>
  * <pre>
  *   min &lt;= value &lt;= value + extent &lt;= max
  * </pre>
@@ -1046,7 +1045,7 @@ public class ScrollBar implements Renderable
 
         /**
          * {@inheritDoc}
-         * <p/>
+         * <p>
          * Overridden to stop autoscroll operations when the scrollbar becomes inactive.
          *
          * @param active {@code true} if the scrollbar is being activated, {@code false} if the scrollbar is being

--- a/src/gov/nasa/worldwind/util/tree/ScrollFrame.java
+++ b/src/gov/nasa/worldwind/util/tree/ScrollFrame.java
@@ -28,7 +28,7 @@ import java.util.List;
  * A frame that can scroll its contents. The frame can be interactively resized by dragging the border, and be moved by
  * dragging the frame or title bar. The frame can be minimized. The frame displays scroll bars if the size of the
  * content exceeds the size of the frame, and optionally displays a title bar with a text string and an icon.
- * <p/>
+ * <p>
  * The frame renders its contents into a texture, and then draws the texture when the frame is rendered. This provides
  * good performance for content that is expensive to draw, and changes infrequently. If the frame is sized so large that
  * the visible portion of the contents cannot be rendered into a single texture, then the contents will be drawn
@@ -954,9 +954,10 @@ public class ScrollFrame extends DragControl implements PreRenderable, Renderabl
 
     /**
      * Returns a new tile texture with the specified width and height.
-     * <p/>
+     * <p>
      * The returned texture's internal format is RGBA8.
      *
+     * @param dc the draw context.
      * @param width  the texture's width, in pixels.
      * @param height the texture's height, in pixels.
      *

--- a/src/gov/nasa/worldwind/util/webview/WebView.java
+++ b/src/gov/nasa/worldwind/util/webview/WebView.java
@@ -18,22 +18,22 @@ import java.net.URL;
  * interacting with the rendered content. This functionality is divided into four main tasks: <ul> <li>Loading web
  * content into a WebView's frame.</li> <li>Sending input events to the WebView's frame.</li> <li>Receiving information
  * about links in the WebView's frame.</li> <li>Receiving a rendered representation of the WebView's frame.</li> </ul>
- * <p/>
+ * <p>
  * A WebView is configured by specifying its text content and the size of the WebView's frame. The text may be an HTML
  * document, an HTML fragment, simple text, <code>null</code>, or another text format supported by the implementation.
  * The size of the WebView's frame is specified in pixels, and may not exceed an implementation-defined maximum. Most
  * implementations define the maximum value to be 4096 - the maximum texture size on most platforms.
- * <p/>
+ * <p>
  * The user can interact with the WebView using the mouse and keyboard. The application must send input events to the
  * WebView's frame because WebView is not associated with any windowing system. Input events are received and processed
  * in an implementation-defined manner. Applications can suppress WebView navigation by drawing the link rectangles
  * during the picking phase, and consuming link clicked <code>SelectEvents</code> before they are sent to the WebView.
- * <p/>
+ * <p>
  * The WebView provides a representation of itself as an OpenGL texture. On machines that support non-power-of-two sized
  * textures, this texture has dimensions equal to the WebView's frame size. Otherwise, the texture's dimensions are the
  * smallest power-of-two that captures the WebView's frame size. The WebView's texture representation is standard
  * two-dimensional OpenGL texture that may be mapped onto any OpenGL primitive using texture coordinates.
- * <p/>
+ * <p>
  * When the WebView's texture representation changes as a result of an internal event it fires a property change event
  * with the key {@link gov.nasa.worldwind.avlist.AVKey#REPAINT}. This can happen from web content loading, user
  * interaction, or from a programmatic change such as JavaScript.
@@ -46,13 +46,16 @@ public interface WebView extends AVList, Disposable
     /**
      * Specifies this <code>WebView's</code> HTML content as a string. The specified <code>htmlString</code> may be one
      * of the following:
-     * <p/>
-     * <ul> <li>HTML document</li> <li>HTML fragment</li> <li>Simple text</li> <li><code>null</code></li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>HTML document</li> 
+     * <li>HTML fragment</li> 
+     * <li>Simple text</li> 
+     * <li><code>null</code></li> 
+     * </ul>
      * The WebView displays nothing if <code>htmlString</code> is <code>null</code> or empty. If the
      * <code>htmlString</code> contains relative paths, they are not resolved and are interpreted as unresolved
      * references.
-     * <p/>
+     * <p>
      * If the application sends input events to the WebView, the user may navigate away from the specified HTML content
      * by interacting with links or buttons in the content.
      *
@@ -64,13 +67,17 @@ public interface WebView extends AVList, Disposable
     /**
      * Specifies this <code>WebView's</code> HTML content as a string. The specified <code>htmlString</code> may be one
      * of the following:
-     * <p/>
-     * <ul> <li>HTML document</li> <li>HTML fragment</li> <li>Simple text</li> <li><code>null</code></li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>HTML document</li> 
+     * <li>HTML fragment</li> 
+     * <li>Simple text</li> 
+     * <li><code>null</code></li> 
+     * </ul>
+     * <p>
      * The WebView displays nothing if <code>htmlString</code> is <code>null</code> or empty. The <code>baseURL</code>
      * is used to resolve relative paths in the specified <code>htmlString</code>. If the <code>baseURL</code> is
      * <code>null</code>, relative paths are not resolved and are interpreted as unresolved references.
-     * <p/>
+     * <p>
      * If the application sends input events to the WebView, the user may navigate away from the specified HTML content
      * by interacting with links or buttons in the content. Once the user navigates away from the content specified
      * here, the <code>htmlString</code> and <code>baseURL</code> are no longer used.
@@ -86,14 +93,18 @@ public interface WebView extends AVList, Disposable
     /**
      * Specifies this <code>WebView's</code> HTML content as a string. The specified <code>htmlString</code> may be one
      * of the following:
-     * <p/>
-     * <ul> <li>HTML document</li> <li>HTML fragment</li> <li>Simple text</li> <li><code>null</code></li> </ul>
-     * <p/>
+     * <ul> 
+     * <li>HTML document</li> 
+     * <li>HTML fragment</li> 
+     * <li>Simple text</li> 
+     * <li><code>null</code></li> 
+     * </ul>
+     * <p>
      * The WebView displays nothing if <code>htmlString</code> is <code>null</code> or empty. The
      * <code>WebResourceResolver</code> is used to resolve relative paths in the specified <code>htmlString</code>. If
      * the <code>WebResourceResolver</code> is <code>null</code>, relative paths are not resolved and are interpreted as
      * unresolved references.
-     * <p/>
+     * <p>
      * If the application sends input events to the WebView, the user may navigate away from the specified HTML content
      * by interacting with links or buttons in the content. Once the user navigates away from the content specified
      * here, the <code>htmlString</code> and <code>resourceResolver</code> are no longer used.
@@ -132,7 +143,7 @@ public interface WebView extends AVList, Disposable
      * determined. This WebView attempts to determine its current content's size each time an HTML frame is loaded and
      * its layout is performed. If the content is plain text or has no HTML frames, this WebView determines its content
      * size after the text is loaded.
-     * <p/>
+     * <p>
      * The returned size changes as this WebView navigates to new content or navigates within its history, and always
      * reflects the size of the current content. The returned size is limited by this WebView's minimum content size.
      * See {@link #getMinContentSize()} for more information on how the minimum content size is used.
@@ -146,7 +157,7 @@ public interface WebView extends AVList, Disposable
 
     /**
      * Returns the minimum size in pixels of this WebView's content area.
-     * <p/>
+     * <p>
      * HTML content can expand to fit its frame, so it is impossible to determine the size of content without laying out
      * the content in a frame of some size. The minimum content size determines the size of the frame used to compute
      * the content layout and size. If the content is simple text, the text will wrap to the minimum content width.
@@ -178,15 +189,19 @@ public interface WebView extends AVList, Disposable
      * returned iterable has no elements if this <code>WebView</code> has no links, or if none of the links are
      * currently in the <code>WebView's</code> visible area. Each <code>AVList</code> describes the parameters for one
      * link as follows:
-     * <p/>
-     * <ul> <li><code>AVKey.URL</code> - a <code>String</code> containing the link's destination.</li>
+     * <ul> 
+     * <li><code>AVKey.URL</code> - a <code>String</code> containing the link's destination.</li>
      * <li><code>AVKey.MIME_TYPE</code> - a <code>String</code> mime type describing the content type of the link's
-     * destination.</li> <li><code>AVKey.TARGET</code> - the link's target frame, one of the following: <code>_blank,
+     * destination.</li> 
+     * <li><code>AVKey.TARGET</code> - the link's target frame, one of the following: <code>_blank,
      * _self, _parent, _top</code>. See the <a href="http://www.w3.org/TR/html401/types.html#type-frame-target">W3C
-     * documentation</a> on frame target names.</li> <li><code>AVKey.BOUNDS</code> - a <code>java.awt.Rectangle</code>
-     * representing the link's bounding rectangle.</li> <li><code>AVKey.RECTANGLES</code> - an array of one or more
-     * <code>java.awt.Rectangle</code> instances representing the link's separate pickable rectangles.</li> </ul>
-     * <p/>
+     * documentation</a> on frame target names.</li> 
+     * <li><code>AVKey.BOUNDS</code> - a <code>java.awt.Rectangle</code>
+     * representing the link's bounding rectangle.</li> 
+     * <li><code>AVKey.RECTANGLES</code> - an array of one or more
+     * <code>java.awt.Rectangle</code> instances representing the link's separate pickable rectangles.</li> 
+     * </ul>
+     * <p>
      * The link rectangles are in the <code>WebView</code>'s local coordinate system, and are clipped to the
      * <code>WebView's</code> visible area. The <code>WebView</code>'s coordinate system has its origin in the lower
      * left corner with the X-axis pointing right and the Y-axis pointing up. Multi-line links are represented as one
@@ -201,7 +216,7 @@ public interface WebView extends AVList, Disposable
      * Returns a layed out and rendered representation of the WebView's content as a {@link
      * gov.nasa.worldwind.render.WWTexture}. The texture's image source is the WebView, and its dimensions are large
      * enough to capture the WebView's frame size (see {@link #setFrameSize(java.awt.Dimension)}.
-     * <p/>
+     * <p>
      * On machines that support non-power-of-two sized textures, the texture's dimensions are always equal to the
      * WebView's frame size. Otherwise, the texture's dimensions are the smallest power-of-two that captures the
      * WebView's frame size.
@@ -233,12 +248,12 @@ public interface WebView extends AVList, Disposable
      * Sends the specified input event to the WebView. Which events the WebView's responds to and how it responds is
      * implementation-defined. Typical implementations respond to {@link java.awt.event.KeyEvent}, {@link
      * java.awt.event.MouseEvent}, and {@link java.awt.event.MouseWheelEvent}.
-     * <p/>
+     * <p>
      * The screen coordinates for a <code>MouseEvent</code> must be transformed into the WebView's local coordinate
      * system, which has its origin in the lower left corner with the X-axis pointing right and the Y-axis pointing up.
-     * <p/>
+     * <p>
      * This does nothing if the specified event is <code>null</code>.
-     * <p/>
+     * <p>
      * Users of the WebView must call {@link #setActive} before sending input events to the WebView. The WebView can be
      * activated and deactivated any number of times. For example, a controller might call <code>setActive(true)</code>
      * when the mouse enters the WebView texture, and call <code>setActive(false)</code> when the mouse exits the

--- a/src/gov/nasa/worldwind/util/webview/WindowsWebView.java
+++ b/src/gov/nasa/worldwind/util/webview/WindowsWebView.java
@@ -23,8 +23,7 @@ import java.util.logging.Level;
 /**
  * {@link WebView} implementation for Windows. This implementation uses the Window's native web browser control and the
  * MSHTML library to render a web page and create an OpenGL texture from the web browser window.
- * <p/>
- * <a name="limits"><h2>Limits on the number of WebViews that can be created</h2></a> WindowsWebView creates a hidden
+ * <h2><a name="limits">Limits on the number of WebViews that can be created</a></h2> WindowsWebView creates a hidden
  * native window. Creating the native window can fail if the process runs out of Windows user object handles. Other GUI
  * elements in an application also consume these handles, so it is difficult to put a firm limit on how many WebViews
  * can be created. An application that creates only WebViews and no other windows can create about 1500 WebViews before
@@ -347,7 +346,7 @@ public class WindowsWebView extends AbstractWebView
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to apply the active state to the native WebView.
      */
     @Override

--- a/src/gov/nasa/worldwind/util/webview/WindowsWebViewJNI.java
+++ b/src/gov/nasa/worldwind/util/webview/WindowsWebViewJNI.java
@@ -16,23 +16,22 @@ import java.beans.PropertyChangeListener;
 /**
  * JNI bindings for the Windows WebView library. This library provides functions for creating and destroying native
  * WebViews, sending user input to a WebView, and adding listeners to a WebView.
- * <p/>
  * <h3>Message loops</h3>
- * <p/>
+ * <p>
  * WebViews created by this library must be managed by a message loop in native code. This class provides methods for
  * creating and running a native message loop using a Java thread. Each WebView must be associated with one message
  * loop. Each message loop can handle any number of WebViews.
- * <p/>
+ * <p>
  * To create a WebView message loop: <ol> <li> Create a new Java thread to run the message loop.</li> <li> Call {@link
  * #newMessageLoop()} from the message loop thread.</li> <li> Call {@link #runMessageLoop(long)} from the message loop
  * thread. This enters a blocking loop in native code. It will not return until {@link #releaseMessageLoop(long)} is
  * called by another thread.</li> </ol>
- * <p/>
+ * <p>
  * Here is an example of creating and running  a message loop:
- * <p/>
  * <pre>
+ * {@code
  * long webViewMessageLoop = 0;
- * <p/>
+ * 
  * // Create a new thread to run the WebView message loop.
  * webViewUI = new Thread("WebView UI")
  * {
@@ -41,20 +40,20 @@ import java.beans.PropertyChangeListener;
  *          // Create a message loop in native code. This call must return
  *          // before any messages are sent to the WebView.
  *          webViewMessageLoop = WindowsWebViewJNI.newMessageLoop();
- * <p/>
+ * 
  *          // Notify the outer thread that the message loop is ready.
  *          synchronized (webViewUILock)
  *          {
  *              webViewUILock.notify();
  *          }
- * <p/>
+ * 
  *          // Process messages in native code until the message loop
  *          // is terminated.
  *          WindowsWebViewJNI.runMessageLoop(webViewMessageloop);
  *      }
  *  };
  *  webViewUI.start();
- * <p/>
+ * 
  *  // Wait for the newly started thread to create the message loop. We cannot
  *  // safely use the WebView until the message loop has been initialized.
  *  while (webViewMessageLoop == 0)
@@ -67,6 +66,7 @@ import java.beans.PropertyChangeListener;
  *      {
  *      }
  *  }
+ * }
  * </pre>
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwind/util/xml/AbstractXMLEventParser.java
+++ b/src/gov/nasa/worldwind/util/xml/AbstractXMLEventParser.java
@@ -17,16 +17,16 @@ import java.util.*;
 
 /**
  * Base class for XML event parsers. Handles parsing control and creation of new parser instances.
- * <p/>
+ * <p>
  * A parser holds the information parsed from the event stream. That information can be queried via the parser's
  * accessors. A parser typically does not maintain a reference to the event stream it parsed or the parser context used
  * during parsing.
- * <p/>
+ * <p>
  * Parsers are created when events of the associated type are encountered in the input stream. An {@link
  * #allocate(XMLEventParserContext, javax.xml.stream.events.XMLEvent)} method in the parser typically creates a default
  * parser prior to consulting the {@link XMLEventParserContext}, which returns a new parser whose type is determined by
  * consulting a table of event types. The default parser is returned if the table contains no entry for the event type.
- * <p/>
+ * <p>
  * A parser can be associated with a specific namespace. The namespace is used to qualify the parser's association with
  * event types.
  *

--- a/src/gov/nasa/worldwind/util/xml/XMLEventParserContext.java
+++ b/src/gov/nasa/worldwind/util/xml/XMLEventParserContext.java
@@ -74,7 +74,7 @@ public interface XMLEventParserContext extends AVList
 
     /**
      * Determines whether an event is the corresponding end element for a specified start event.
-     * <p/>
+     * <p>
      * Note: Only the event's element name and type are compared. The method returns true if the start and end events
      * are the corresponding event types for an element of the same name.
      *
@@ -256,7 +256,7 @@ public interface XMLEventParserContext extends AVList
      * Specify the object to receive notifications, which are sent when exceptions occur during parsing and when
      * unrecognized element types are encountered. See {@link gov.nasa.worldwind.util.xml.XMLParserNotification} for
      * more information.
-     * <p/>
+     * <p>
      * The parser context may have only one notification listener. That listener may be changed at any time.
      *
      * @param listener the object to receive notification events.

--- a/src/gov/nasa/worldwind/util/xml/XMLEventParserContextFactory.java
+++ b/src/gov/nasa/worldwind/util/xml/XMLEventParserContextFactory.java
@@ -157,7 +157,7 @@ public class XMLEventParserContextFactory
      * Constructs and returns a parser context for a specified mime type and namespace. The list of registered parser
      * contexts is searched from first to last. A parser context is constructed from the first entry matching the
      * specified mime type and namespace. Null is returned if no match is found.
-     * <p/>
+     * <p>
      * Note that the empty namespace, {@link XMLConstants#NULL_NS_URI} does not match any other namespace. In order for
      * a parser context with the empty namespace to be returned, one with the empty namespace must be registered.
      *

--- a/src/gov/nasa/worldwind/view/BasicView.java
+++ b/src/gov/nasa/worldwind/view/BasicView.java
@@ -22,7 +22,7 @@ import com.jogamp.opengl.GL2;
  * derived from {@link BasicView} {@link BasicView} models the view in terms of a geographic position, and a pitch,
  * heading, and roll. It provides a mapping from that geocentric view model to a 3D graphics modelview matrix. BasicView
  * also manages the projection matrix via a {@link Frustum}.
- * <p/>
+ * <p>
  * The view model is based on
  *
  * @author jym

--- a/src/gov/nasa/worldwind/view/BasicViewPropertyLimits.java
+++ b/src/gov/nasa/worldwind/view/BasicViewPropertyLimits.java
@@ -264,6 +264,7 @@ public class BasicViewPropertyLimits implements ViewPropertyLimits
      *
      * @param angle      angle to clamp to the allowed range.
      * @param viewLimits defines the heading limits.
+     * @return the clamped angle.
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitHeading(gov.nasa.worldwind.View, gov.nasa.worldwind.geom.Angle)} instead.
@@ -303,6 +304,7 @@ public class BasicViewPropertyLimits implements ViewPropertyLimits
      *
      * @param angle      angle to clamp to the allowed range.
      * @param viewLimits defines the pitch limits.
+     * @return the clampled angle.
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitPitch(gov.nasa.worldwind.View, gov.nasa.worldwind.geom.Angle)} instead.
@@ -341,6 +343,7 @@ public class BasicViewPropertyLimits implements ViewPropertyLimits
      *
      * @param angle      angle to clamp to the allowed range.
      * @param viewLimits defines the roll limits.
+     * @return the clamped angle.
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitRoll(gov.nasa.worldwind.View, gov.nasa.worldwind.geom.Angle)} instead.
@@ -379,6 +382,7 @@ public class BasicViewPropertyLimits implements ViewPropertyLimits
      *
      * @param elevation  elevation to clamp to the allowed range.
      * @param viewLimits defines the eye elevation limits.
+     * @return the clamped angle.
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitEyePosition(gov.nasa.worldwind.View, gov.nasa.worldwind.geom.Position)} instead.
@@ -411,6 +415,7 @@ public class BasicViewPropertyLimits implements ViewPropertyLimits
      * @param latitude   latitude angle to clamp to the allowed range.
      * @param longitude  longitude angle to clamp to the allowed range.
      * @param viewLimits defines the eye location limits.
+     * @return the clamped location angles
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitEyePosition(gov.nasa.worldwind.View, gov.nasa.worldwind.geom.Position)} instead.

--- a/src/gov/nasa/worldwind/view/firstperson/BasicFlyView.java
+++ b/src/gov/nasa/worldwind/view/firstperson/BasicFlyView.java
@@ -17,7 +17,7 @@ import com.jogamp.opengl.GL;
 /**
  * This is a basic view that implements a yaw-pitch-roll model that can be applied to first-person style view
  * applications (such as flight simulation).
- * <p/>
+ * <p>
  * Note that the pitch angle is defined as normal to the ground plane, not parallel as in most body axis
  * representations.  This is to be consistent with the definition of pitch within WorldWind. Applications will need to
  * correct for pitch values by adding 90 degrees when commanding pitch (i.e. to get a horizontal view, enter 90 degrees

--- a/src/gov/nasa/worldwind/view/orbit/BasicOrbitViewLimits.java
+++ b/src/gov/nasa/worldwind/view/orbit/BasicOrbitViewLimits.java
@@ -184,6 +184,7 @@ public class BasicOrbitViewLimits extends BasicViewPropertyLimits implements Orb
      *
      * @param position   position to clamp to the allowed range.
      * @param viewLimits defines the center location and elevation limits.
+     * @return the clamped position.
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitCenterPosition(gov.nasa.worldwind.View, gov.nasa.worldwind.geom.Position)} instead.
@@ -215,6 +216,7 @@ public class BasicOrbitViewLimits extends BasicViewPropertyLimits implements Orb
      * @param latitude   latitude angle to clamp to the allowed range.
      * @param longitude  longitude angle to clamp to the allowed range.
      * @param viewLimits defines the center location limits.
+     * @return the clamped location.
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitCenterPosition(gov.nasa.worldwind.View, gov.nasa.worldwind.geom.Position)} instead.
@@ -264,6 +266,7 @@ public class BasicOrbitViewLimits extends BasicViewPropertyLimits implements Orb
      *
      * @param value      elevation to clamp to the allowed range.
      * @param viewLimits defines the center elevation limits.
+     * @return the clamped elevation.
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitCenterPosition(gov.nasa.worldwind.View, gov.nasa.worldwind.geom.Position)} instead.
@@ -297,6 +300,7 @@ public class BasicOrbitViewLimits extends BasicViewPropertyLimits implements Orb
      *
      * @param value      distance to clamp to the allowed range.
      * @param viewLimits defines the zoom distance limits.
+     * @return the clamped zoom distance.
      *
      * @throws IllegalArgumentException if any argument is null.
      * @deprecated Use {@link #limitZoom(gov.nasa.worldwind.View, double)} instead.

--- a/src/gov/nasa/worldwind/view/orbit/OrbitView.java
+++ b/src/gov/nasa/worldwind/view/orbit/OrbitView.java
@@ -54,7 +54,7 @@ public interface OrbitView extends View
      * Sets the center position of the OrbitView. The center position is used as the point about which the
      * heading and pitch rotate.  It is defined by the intersection of a ray from the eye position through the
      * center of the viewport with the surface of the globe.
-     * @param center
+     * @param center the center position.
      */
     void setCenterPosition(Position center);
 
@@ -68,7 +68,7 @@ public interface OrbitView extends View
     /**
      * Set the zoom value for the OrbitVeiw. The zoom value is the distance between the eye
      * position and the center position.
-     * @param zoom
+     * @param zoom the zoom value.
      */
     void setZoom(double zoom);
 
@@ -85,7 +85,7 @@ public interface OrbitView extends View
      * Set the limits for this OrbitView.  OrbitView has state values that augment the state values of a {@link View}.
      * Specifically, zoom and center position.  {@link OrbitViewLimits} enables the limiting of those values in addition
      * the the derived {@link gov.nasa.worldwind.view.BasicViewPropertyLimits} state.
-     * @param limits
+     * @param limits the limits to set.
      */
     void setOrbitViewLimits(OrbitViewLimits limits);
 

--- a/src/gov/nasa/worldwind/wms/WMSNamespaceContext.java
+++ b/src/gov/nasa/worldwind/wms/WMSNamespaceContext.java
@@ -24,8 +24,12 @@ public class WMSNamespaceContext extends BasicNamespaceContext
     /**
      * Sole constructor for WMSNamespaceContext. In addition to the namespaces configured by the superclass constructor
      * {@link gov.nasa.worldwind.util.BasicNamespaceContext#BasicNamespaceContext()}, this configures the following
-     * namespaces: <table> <tr><th>Prefix</th><th>URI</th></tr> <tr><td>wms</td><td>http://www.opengis.net/wms</td></tr>
-     * <tr><td><code>DEFAULT_NS_PREFIX ("")</code></td><td>http://www.opengis.net/wms</td></tr> </table>
+     * namespaces: 
+     * <table><caption>Namespaces</caption>
+     * <tr><th>Prefix</th><th>URI</th></tr> 
+     * <tr><td>wms</td><td>http://www.opengis.net/wms</td></tr>
+     * <tr><td><code>DEFAULT_NS_PREFIX ("")</code></td><td>http://www.opengis.net/wms</td></tr>
+     * </table>
      */
     public WMSNamespaceContext()
     {

--- a/src/gov/nasa/worldwindx/applications/antenna/Interpolator2D.java
+++ b/src/gov/nasa/worldwindx/applications/antenna/Interpolator2D.java
@@ -53,7 +53,7 @@ public class Interpolator2D
      * when a value at a first coordinate of 355 is requested, interpolation should likely be performed between 350 and
      * 0. If the wrap flag is true, interpolation is performed. If it is false, null is returned from {@link
      * #getValue(double, double)}.
-     * <p/>
+     * <p>
      * The default wrap S flag is <code>false</code>.
      *
      * @param wrapS the first coordinate's wrap flag.
@@ -83,7 +83,7 @@ public class Interpolator2D
      * Specifies whether this interpolator interpolates between maximum and minimum second coordinates if a second
      * coordinate outside the current range of second coordinates is specified. See {@link #setWrapS(boolean)} for a
      * description of wrapping and the use of wrap flags.
-     * <p/>
+     * <p>
      * The default T wrap flag is <code>false</code>.
      *
      * @param wrapT the second coordinate's wrap flag.

--- a/src/gov/nasa/worldwindx/applications/sar/ElementParser.java
+++ b/src/gov/nasa/worldwindx/applications/sar/ElementParser.java
@@ -41,11 +41,11 @@ public class ElementParser
     /**
      * Starts an element. No parameters may be null.
      *
-     * @param uri
-     * @param lname
-     * @param qname
-     * @param attributes
-     * @throws org.xml.sax.SAXException
+     * @param uri the URI.
+     * @param lname the LName.
+     * @param qname the QName.
+     * @param attributes the attributes
+     * @throws org.xml.sax.SAXException on error
      * @throws IllegalArgumentException if any argument is null
      */
     public void startElement(String uri, String lname, String qname, org.xml.sax.Attributes attributes)
@@ -85,10 +85,10 @@ public class ElementParser
     /**
      * Finishes an element. No parameters may be null.
      *
-     * @param uri
-     * @param lname
-     * @param qname
-     * @throws org.xml.sax.SAXException
+     * @param uri the URI.
+     * @param lname the LName.
+     * @param qname the QName.
+     * @throws org.xml.sax.SAXException on error
      * @throws IllegalArgumentException if any argument is null
      */
     public void endElement(String uri, String lname, String qname) throws org.xml.sax.SAXException
@@ -133,9 +133,9 @@ public class ElementParser
     }
 
     /**
-     * @param data
-     * @param start
-     * @param length
+     * @param data the data.
+     * @param start the start position.
+     * @param length the length to retrieve.
      * @throws IllegalArgumentException if <code>data</code> has length less than 1
      */
     public void characters(char[] data, int start, int length)

--- a/src/gov/nasa/worldwindx/applications/worldwindow/features/DataImportUtil.java
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/features/DataImportUtil.java
@@ -138,7 +138,7 @@ public class DataImportUtil
      * default location for importing data. This attempts to use the first FileStore location marked as an "install"
      * location. If no install location exists, this falls back to the FileStore's default write location, the same
      * location where downloaded data is cached.
-     * <p/>
+     * <p>
      * The returned {@link java.io.File} represents an abstract path, and therefore may not exist. In this case, the
      * caller must create the missing directories composing the abstract path.
      *

--- a/src/gov/nasa/worldwindx/examples/AirspaceBuilder.java
+++ b/src/gov/nasa/worldwindx/examples/AirspaceBuilder.java
@@ -35,30 +35,32 @@ import java.util.zip.*;
  * Illustrates runtime construction of 3D extruded polygons and spheres using WorldWind <code>{@link Airspace}</code>
  * shapes. This uses a <code>{@link PolygonEditor}</code> and a <code>{@link SphereAirspaceEditor}</code> to enable
  * runtime editing of <code>{@link Polygon}</code> airspace and <code>{@link SphereAirspace}</code> shapes.
- * <p/>
  * <h1>Usage Instructions</h1>
- * <p/>
- * <strong>Adding and Removing Shapes</strong> <br/> Add a shape by selecting either <code>Polygon</code> or
- * <code>Sphere</code> in the drop down box then clicking <code>New shape</code>. Delete a shape by left-clicking it
- * then pressing the <code>delete</code> key.
- * <p/>
- * <strong>Moving Shapes</strong/> <br/> Move a shape by left-clicking and dragging it.
- * <p/>
- * <strong>Editing Spheres</strong> <br/> <i>Note: a sphere must be selected before it can be edited. Select a sphere by
- * left-clicking it.</i> </br> Adjust a sphere's height by holding the <code>Shift</code> key then left-click and drag
- * the sphere. Resize a sphere by moving the cursor toward the sphere's edge until a blue control point appears, then
- * left-click and drag the control point.
- * <p/>
- * <strong>Editing Polygons</strong> <br/> <i>Note: a polygon must be selected before it can be edited. Select a polygon
- * by left-clicking it.</i> </br> Add a polygon vertex by holding the <code>Alt</code> key and left-clicking anywhere
- * near the polygon. Remove a polygon control point by holding the <code>Control</code> key and left-clicking the blue
- * sphere at the vertex. Move a polygon vertex by left-clicking and dragging it. Change a polygon's bottom or top height
- * by holding the <code>Shift</code> key then left-click any blue sphere at a vertex and drag it.
- * <p/>
+ * <p>
+ * <strong>Adding and Removing Shapes</strong> <br>
+ * Add a shape by selecting either <code>Polygon</code> or <code>Sphere</code> in the drop down box then clicking
+ * <code>New shape</code>. Delete a shape by left-clicking it then pressing the <code>delete</code> key.
+ * <p>
+ * <strong>Moving Shapes</strong> <br>
+ * Move a shape by left-clicking and dragging it.
+ * <p>
+ * <strong>Editing Spheres</strong> <br>
+ * <i>Note: a sphere must be selected before it can be edited. Select a sphere by left-clicking it.</i> <br>
+ * Adjust a sphere's height by holding the <code>Shift</code> key then left-click and drag the sphere. Resize a sphere
+ * by moving the cursor toward the sphere's edge until a blue control point appears, then left-click and drag the
+ * control point.
+ * <p>
+ * <strong>Editing Polygons</strong> <br>
+ * <i>Note: a polygon must be selected before it can be edited. Select a polygon by left-clicking it.</i> <br>
+ * Add a polygon vertex by holding the <code>Alt</code> key and left-clicking anywhere near the polygon. Remove a
+ * polygon control point by holding the <code>Control</code> key and left-clicking the blue sphere at the vertex. Move a
+ * polygon vertex by left-clicking and dragging it. Change a polygon's bottom or top height by holding the
+ * <code>Shift</code> key then left-click any blue sphere at a vertex and drag it.
  * <h1>Demo Shapes</h1>
- * <p/>
- * Select <code>File -> Load Demo Shapes</code> to display a set of polygon airspace shapes built with this editor. The
- * data for these shapes is located in the WorldWind project under src/gov/nasa/worldwindx/examples/data/AirspaceBuilder-DemoShapes.zip.
+ * <p>
+ * Select {@code File -> Load Demo Shapes} to display a set of polygon airspace shapes built with this editor. The
+ * data for these shapes is located in the WorldWind project under
+ * src/gov/nasa/worldwindx/examples/data/AirspaceBuilder-DemoShapes.zip.
  *
  * @author dcollins
  * @version $Id: AirspaceBuilder.java 2231 2014-08-15 19:03:12Z dcollins $

--- a/src/gov/nasa/worldwindx/examples/Airspaces.java
+++ b/src/gov/nasa/worldwindx/examples/Airspaces.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
  * extruded 3D volumes defined by geographic coordinates and upper- and lower- altitude boundaries. The interior of
  * airspace shapes always conforms to the curvature of the globe, and optionally also conform to the underlying
  * terrain.
- * <p/>
+ * <p>
  * This shows how to use all 11 types of standard airspace shapes: <ul> <li><code>{@link Orbit}</code> - a rectangle
  * with rounded end caps.</li> <li><code>{@link Curtain}</code> - a vertically extruded wall.</li> <li><code>{@link
  * Polygon}</code> - a vertically extruded polygon.</li> <li><code>{@link PolyArc}</code> - a vertically extruded

--- a/src/gov/nasa/worldwindx/examples/AlarmIcons.java
+++ b/src/gov/nasa/worldwindx/examples/AlarmIcons.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
  * Illustrates how to display an icon with an alarm state using a WorldWind <code>{@link WWIcon}</code>. This applies a
  * background image to an icon indicating a warning or an urgent condition, then varies the background image's scale
  * factor over time to make it flash or pulse.
- * <p/>
+ * <p>
  * This applies the background image by calling <code>{@link WWIcon#setBackgroundImage(Object)}</code>, and varies its
  * scale factor by calling <code>{@link WWIcon#setBackgroundScale(double)}</code>.
  *

--- a/src/gov/nasa/worldwindx/examples/Balloons.java
+++ b/src/gov/nasa/worldwindx/examples/Balloons.java
@@ -23,22 +23,29 @@ import java.io.InputStream;
  * to a position on the Globe. For each abstract balloon type, there are two concrete types: AnnotationBalloon which
  * provides support for simple text content with an optional image, and BrowserBalloon which provides support for
  * complex HTML, JavaScript, and Flash content.
- * <p/>
- * <strong>Balloon Content</strong> <br/> A Balloon's content is specified by calling <code>{@link
+ * <p>
+ * <strong>Balloon Content</strong> <br>
+ * A Balloon's content is specified by calling <code>{@link
  * Balloon#setText(String)}</code>, and its visual attributes are specified by calling <code>{@link
  * Balloon#setAttributes(gov.nasa.worldwind.render.BalloonAttributes)}</code> with an instance of <code>{@link
  * BalloonAttributes}</code>.
- * <p/>
- * <strong>ScreenBalloon</strong> <br/> ScreenBalloons display a screen-aligned balloon at a point on the screen. There
- * are two concrete ScreenBalloon types: <ul> <li><code>{@link ScreenAnnotationBalloon}</code> - a screen-attached
- * balloon with support for multi-line text, a background image, simple HTML text markup, and simple text styling
- * attributes.</li> <li><code>{@link ScreenBrowserBalloon}</code> - a screen-attached balloon with support for HTML,
- * JavaScript, and Flash content.</li> </ul>
- * <p/>
- * <strong>GlobeBalloon</strong> <br/> GlobeBalloons display a screen-aligned balloon attached to a position on the
- * Globe. <ul> <li><code>{@link GlobeAnnotationBalloon}</code> - a Globe-attached balloon with support for multi-line
- * text, a background image, simple HTML text markup, and simple text styling attributes.</li> <li><code>{@link
- * GlobeBrowserBalloon}</code> - a Globe-attached balloon with support for HTML, JavaScript, and Flash content.</li>
+ * <p>
+ * <strong>ScreenBalloon</strong> <br>
+ * ScreenBalloons display a screen-aligned balloon at a point on the screen. There are two concrete ScreenBalloon types:
+ * <ul>
+ * <li><code>{@link ScreenAnnotationBalloon}</code> - a screen-attached balloon with support for multi-line text, a
+ * background image, simple HTML text markup, and simple text styling attributes.</li>
+ * <li><code>{@link ScreenBrowserBalloon}</code> - a screen-attached balloon with support for HTML, JavaScript, and
+ * Flash content.</li>
+ * </ul>
+ * <p>
+ * <strong>GlobeBalloon</strong> <br>
+ * GlobeBalloons display a screen-aligned balloon attached to a position on the Globe.
+ * <ul>
+ * <li><code>{@link GlobeAnnotationBalloon}</code> - a Globe-attached balloon with support for multi-line text, a
+ * background image, simple HTML text markup, and simple text styling attributes.</li>
+ * <li><code>{@link GlobeBrowserBalloon}</code> - a Globe-attached balloon with support for HTML, JavaScript, and Flash
+ * content.</li>
  * </ul>
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwindx/examples/ContourBuilderExample.java
+++ b/src/gov/nasa/worldwindx/examples/ContourBuilderExample.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * Shows how to use the {@link gov.nasa.worldwind.util.ContourBuilder} class to compute contour lines in an arbitrary
  * rectangular array of numeric values.
- * <p/>
+ * <p>
  * This example creates a 60x60 rectangular array of floating point values in the range from 0.0 to 1.0, inclusive. The
  * array is displayed on the globe as an AnalyticSurface by mapping each array value to a color, where an array value of
  * 0.0 maps to hue 0, an array value of 1.0 maps to hue 360, and values in between are interpolated between those two

--- a/src/gov/nasa/worldwindx/examples/DeepPicking.java
+++ b/src/gov/nasa/worldwindx/examples/DeepPicking.java
@@ -15,7 +15,7 @@ import gov.nasa.worldwind.render.airspaces.Airspace;
  * Illustrates how to cause all elements under the cursor in a WorldWindow to be reported in <code>{@link
  * SelectEvent}s</code>. This prints all elements under the cursor to the console in response to a <code>HOVER</code>
  * SelectEvent.
- * <p/>
+ * <p>
  * In order to enable deep picking, any batch picking for the desired elements must be disabled and the
  * SceneController's deep picking property must be enabled. See <code>{@link gov.nasa.worldwind.SceneController#setDeepPickEnabled(boolean)}</code>.
  *

--- a/src/gov/nasa/worldwindx/examples/GetBestElevations.java
+++ b/src/gov/nasa/worldwindx/examples/GetBestElevations.java
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * Retrieve the highest-resolution elevations available for the current elevation model, drawing them from the server if
  * necessary. Shift-click on the globe to retrieve the elevation of a location.
- * <p/>
+ * <p>
  * Note: The {@link gov.nasa.worldwind.terrain.HighResolutionTerrain} class may be more appropriate to your needs than
  * this example.
  *
@@ -37,7 +37,7 @@ public class GetBestElevations extends ApplicationTemplate
          * available for the dataset and the area bounding the locations. Since the necessary elevation data might not
          * be in memory at the time of the call, this method iterates until the necessary elevation data is in memory
          * and can be used to determine the locations' elevations.
-         * <p/>
+         * <p>
          * The locations must have a bounding sector, so more than one location is required. If the bounding region is
          * large, a huge amount of data must be retrieved from the server. Be aware that you are overriding the system's
          * resolution selection mechanism by requesting the highest resolution data, which could easily be gigabytes.

--- a/src/gov/nasa/worldwindx/examples/GoToCoordinatePanel.java
+++ b/src/gov/nasa/worldwindx/examples/GoToCoordinatePanel.java
@@ -28,9 +28,9 @@ import java.util.regex.*;
  * <li>Degrees, minutes and seconds with sign prefix or N, S, E, W suffix.</li>
  * </ul>
  * The separator between lat/lon pairs can be ',', ', ' or any number of spaces.
- * </p>
  * <p>
- * Examples:<pre>
+ * Examples:
+ * <pre>
  * 11sku528111
  * 11S KU 528 111
  *
@@ -40,7 +40,6 @@ import java.util.regex.*;
  *
  * 45 30 N 50 30 W
  * </pre>
- * </p>
  *
  * @author Patrick Murris
  * @version $Id: GoToCoordinatePanel.java 1171 2013-02-11 21:45:02Z dcollins $

--- a/src/gov/nasa/worldwindx/examples/KeepingObjectsInView.java
+++ b/src/gov/nasa/worldwindx/examples/KeepingObjectsInView.java
@@ -29,7 +29,7 @@ import java.util.*;
  * KeepingObjectsInView demonstrates keeping a set of scene elements visible by using the utility class {@link
  * gov.nasa.worldwindx.examples.util.ExtentVisibilitySupport}. To run this demonstration, execute this class' main
  * method, then follow the on-screen instructions.
- * <p/>
+ * <p>
  * The key functionality demonstrated by KeepingObjectsVisible is found in the internal classes {@link
  * KeepingObjectsInView.ViewController} and {@link gov.nasa.worldwindx.examples.KeepingObjectsInView.ViewAnimator}.
  *

--- a/src/gov/nasa/worldwindx/examples/LineBuilder.java
+++ b/src/gov/nasa/worldwindx/examples/LineBuilder.java
@@ -28,19 +28,19 @@ import java.util.*;
  * will echo while the mouse is dragged. Continue selecting new positions this way until the polyline contains all
  * desired positions. </li> <li> Disarm the <code>LineBuilder</code> object by calling its {@link #setArmed(boolean)}
  * method with an argument of false. </li> </ul>
- * <p/>
+ * <p>
  * While the line builder is armed, pressing and immediately releasing mouse button one while also pressing the control
  * key (Ctl) removes the last position from the polyline. </p>
- * <p/>
+ * <p>
  * Mouse events the line builder acts on while armed are marked as consumed. These events are mouse pressed, released,
  * clicked and dragged. These events are not acted on while the line builder is not armed. The builder can be
  * continuously armed and rearmed to allow intervening maneuvering of the globe while building a polyline. A user can
  * add positions, pause entry, maneuver the view, then continue entering positions. </p>
- * <p/>
+ * <p>
  * Arming and disarming the line builder does not change the contents or attributes of the line builder's layer. </p>
- * <p/>
+ * <p>
  * The polyline and a layer containing it may be specified when a <code>LineBuilder</code> is constructed. </p>
- * <p/>
+ * <p>
  * This class contains a <code>main</code> method implementing an example program illustrating use of
  * <code>LineBuilder</code>. </p>
  *

--- a/src/gov/nasa/worldwindx/examples/MultiResPath.java
+++ b/src/gov/nasa/worldwindx/examples/MultiResPath.java
@@ -17,7 +17,7 @@ import java.util.*;
 /**
  * Illustrates use of the {@link MultiResolutionPath} shape, which adapts its complexity as the path's distance frome
  * the eye point changes.
- * <p/>
+ * <p>
  * Also illustrates the use of the "show positions" feature of {@link Path}.
  *
  * @author tag

--- a/src/gov/nasa/worldwindx/examples/PathPositionColors.java
+++ b/src/gov/nasa/worldwindx/examples/PathPositionColors.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 /**
  * Illustrates usage of the per-position color feature of {@link Path}. Path's per-position colors may be assigned in
  * any manner the application chooses. This example illustrates only one way of assigning color to each path position.
- * <p/>
+ * <p>
  * Also illustrates the use of the "show positions" feature of {@link Path}.
  *
  * @author dcollins

--- a/src/gov/nasa/worldwindx/examples/PlacemarkDecluttering.java
+++ b/src/gov/nasa/worldwindx/examples/PlacemarkDecluttering.java
@@ -21,7 +21,7 @@ import java.awt.*;
  * Illustrates how to use the {@link gov.nasa.worldwind.util.PlacemarkClutterFilter} to declutter PointPlacemark labels.
  * To enable this decluttering a filter has to be specified to the scene controller and each PointPlacemark that
  * participates in decluttering must be enabled for decluttering.
- * <p/>
+ * <p>
  * This example also enables label picking for all PointPlacemarks to illustrate that labels can be picked both when
  * they're not decluttered and when they are.
  *

--- a/src/gov/nasa/worldwindx/examples/ScankortDenmark.java
+++ b/src/gov/nasa/worldwindx/examples/ScankortDenmark.java
@@ -15,7 +15,7 @@ import gov.nasa.worldwind.terrain.*;
 /**
  * This example demonstrates high resolution imagery (0.2 meters per pixel) and elevation data (1.6 meters per pixel)
  * served by the WorldWind WMS, and visualized by the WorldWind Java client.
- * <p/>
+ * <p>
  * The data is from Denmark.  Details for loading the imagery can be found in: config/Earth/ScankortDenmarkImageLayer.xml
  * while information for loading the elevation data is in: config/Earth/ScankortDenmarkDSMElevationModel.xml.
  *

--- a/src/gov/nasa/worldwindx/examples/ShapeClipping.java
+++ b/src/gov/nasa/worldwindx/examples/ShapeClipping.java
@@ -24,7 +24,7 @@ import java.awt.event.*;
  * Shows how to use the {@link gov.nasa.worldwind.util.combine.Combinable} interface and the {@link
  * gov.nasa.worldwind.util.combine.ShapeCombiner} class to compute the intersection of a WorldWind surface shapes with
  * Earth's land and water.
- * <p/>
+ * <p>
  * This example provides an editable surface circle indicating a region to clip against either land or water. The land
  * and water are represented by an ESRI shapefile containing polygons of Earth's continents, including major islands.
  * Clipping against land is accomplished by computing the intersection of the surface circle and the shapefile polygons.

--- a/src/gov/nasa/worldwindx/examples/ShapeCombining.java
+++ b/src/gov/nasa/worldwindx/examples/ShapeCombining.java
@@ -17,7 +17,7 @@ import gov.nasa.worldwind.util.combine.ShapeCombiner;
  * Shows how to use the {@link gov.nasa.worldwind.util.combine.Combinable} interface and the {@link
  * gov.nasa.worldwind.util.combine.ShapeCombiner} class to combine WorldWind surface shapes into a complex set of
  * contours by using boolean operations.
- * <p/>
+ * <p>
  * This example creates two static SurfaceCircle instances that partially overlap and displays them in a layer named
  * "Original". A ShapeCombiner is used to combine the two surface circles into a potentially complex set of contours
  * using boolean operations. Three examples of such operations are given: union, intersection and difference. The result

--- a/src/gov/nasa/worldwindx/examples/SplitPaneUsage.java
+++ b/src/gov/nasa/worldwindx/examples/SplitPaneUsage.java
@@ -21,7 +21,7 @@ import java.awt.*;
  * around a Swing bug the WorldWindow must be placed within a JPanel and that JPanel's minimum preferred size must be
  * set to zero (both width and height). See the code that does this in the first few lines of the AppPanel constructor
  * below.
- * <p/>
+ * <p>
  * This example also illustrates another bug in Swing that does not have a known workaround: the WorldWindow does not
  * resize when a vertical split-pane's one-touch-expand widget is clicked if that split-pane contains a horizontal
  * split-plane that contains the WorldWindow. If the one-touch widget is clicked on the bottom pane of this example,

--- a/src/gov/nasa/worldwindx/examples/SurfaceImageViewer.java
+++ b/src/gov/nasa/worldwindx/examples/SurfaceImageViewer.java
@@ -18,18 +18,18 @@ import java.io.*;
 
 /**
  * Open and view arbitrary surface images and elevations that have an accompanying world file.
- * <p/>
+ * <p>
  * After clicking the open button and selecting the desired image or elevations file, the program status will change to
  * Loading while WorldWind installs the selected data.  Wait until the status changes to Ready. The data will have
  * finished installing and will be ready for viewing.
- * <p/>
+ * <p>
  * Image and elevation files that you wish to load must be accompanied by a world file, or they will fail to load. The
  * world file can be identified as the file with a file extension consisting of three letters.  The first two of these
  * will be the first and last letters of the image or elevation file type, e.g. tf for a tiff file, or jg for a jpeg
  * file.  The last letter will be a double.
- * <p/>
+ * <p>
  * For example, a world file accompanying a jpeg file would have the extension .jgw :
- * <p/>
+ * <p>
  * image.jpg           // image file
  * image.jgw           // accompanying world file
  *

--- a/src/gov/nasa/worldwindx/examples/SurfaceShapes.java
+++ b/src/gov/nasa/worldwindx/examples/SurfaceShapes.java
@@ -9,7 +9,6 @@ package gov.nasa.worldwindx.examples;
  * Illustrates how to configure and display WorldWind <code>{@link gov.nasa.worldwind.render.SurfaceShape}s</code>.
  * Surface shapes are used to visualize flat standard shapes types that follow the terrain. This illustrates how to use
  * all 7 standard surface shape types:
- * <p/>
  * <ul> <li><code>{@link gov.nasa.worldwind.render.SurfacePolygon}</code></li> <li><code>{@link
  * gov.nasa.worldwind.render.SurfaceEllipse}</code></li> <li><code>{@link gov.nasa.worldwind.render.SurfaceCircle}</code></li>
  * <li><code>{@link gov.nasa.worldwind.render.SurfaceQuad}</code></li> <li><code>{@link

--- a/src/gov/nasa/worldwindx/examples/TerrainIntersections.java
+++ b/src/gov/nasa/worldwindx/examples/TerrainIntersections.java
@@ -24,17 +24,17 @@ import java.util.concurrent.*;
 /**
  * Shows how to compute terrain intersections using the highest resolution terrain data available from a globe's
  * elevation model.
- * <p/>
+ * <p>
  * To generate and show intersections, Shift + LeftClick anywhere on the globe. The program forms a grid of locations
  * around the selected location. The grid points are shown in yellow. It then determines whether a line between the
  * selected location and each grid point intersects the terrain. If it does, the intersection nearest the selected
  * location is shown in cyan and a line is drawn from the selected location to the intersection. If there is no
  * intersection, a line is drawn from the selected location to the grid position.
- * <p/>
+ * <p>
  * If the highest resolution terrain is not available for the area around the selected location, it is retrieved from
  * the elevation model's source, which is most likely a remote server. Since the high-res data must be retrieved and
  * then loaded from the local disk cache, it will take some time to compute and show the intersections.
- * <p/>
+ * <p>
  * This example uses a {@link gov.nasa.worldwind.terrain.Terrain} object to perform the terrain retrieval, generation
  * and intersection calculations.s
  *

--- a/src/gov/nasa/worldwindx/examples/TerrainProfiler.java
+++ b/src/gov/nasa/worldwindx/examples/TerrainProfiler.java
@@ -19,7 +19,7 @@ import java.awt.event.*;
  * This application shows the {@link gov.nasa.worldwind.layers.TerrainProfileLayer} in action with its various controls.
  * It allows you to view a real-time section profile graph for any place on the planet, at any scale - continent,
  * country or mountain range - just by moving the mouse.
- * <p/>
+ * <p>
  * It proves particularly useful to explore the ocean floors where the bathymetry data reveals important geologic
  * features.
  *

--- a/src/gov/nasa/worldwindx/examples/VPFLayerDemo.java
+++ b/src/gov/nasa/worldwindx/examples/VPFLayerDemo.java
@@ -20,7 +20,7 @@ import java.io.File;
  * Illustrates how to import data from a Vector Product Format (VPF) database into WorldWind. This uses <code>{@link
  * VPFLayer}</code> to display an imported VPF database, and uses <code>{@link VPFCoveragePanel}</code> to enable the
  * user to choose which shapes from the VPF database to display.
- * <p/>
+ * <p>
  * To display VPF shapes with the appropriate color, style, and icon, applications must include the JAR file
  * <code>vpf-symbols.jar</code> in the Java class-path. If this JAR file is not in the Java class-path, VPFLayer outputs
  * the following message in the WorldWind log: <code>WARNING: GeoSym style support is disabled</code>. In this case,

--- a/src/gov/nasa/worldwindx/examples/ViewIteration.java
+++ b/src/gov/nasa/worldwindx/examples/ViewIteration.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 
 /**
  * Example of how to animate the view from one position to another.
- * <p/>
+ * <p>
  * Use the buttons on the left side of the frame to animate the view: <ul> <li> Zero: Move the view to look at 0 degrees
  * latitude, 0 degrees longitude.</li> <li> Heading: Animate the view from 0 degrees heading to 90 degrees heading.</li>
  * <li> Follow: Animate the view to along a path of geographic positions.</li> <li> Forward: Animate the view to look at

--- a/src/gov/nasa/worldwindx/examples/WebBrowserBalloons.java
+++ b/src/gov/nasa/worldwindx/examples/WebBrowserBalloons.java
@@ -21,11 +21,13 @@ import java.io.InputStream;
  * form of a screen-aligned balloon. There are two browser balloon types: <code>{@link ScreenBrowserBalloon}</code>
  * which displays a balloon at a point on the screen, and <code>{@link GlobeBrowserBalloon}</code> which displays a
  * balloon attached to a position on the Globe.
- * <p/>
- * <strong>Browser Balloon Content</strong> <br/> A balloon's HTML content is specified by calling <code>{@link
+ * <p>
+ * <strong>Browser Balloon Content</strong> <br>
+ * A balloon's HTML content is specified by calling <code>{@link
  * Balloon#setText(String)}</code> with a string containing either plain text or HTML + JavaScript. The balloon's visual
- * attributes are specified by calling <code>{@link Balloon#setAttributes(gov.nasa.worldwind.render.BalloonAttributes)}</code>
- * with an instance of <code>{@link BalloonAttributes}</code>.
+ * attributes are specified by calling
+ * <code>{@link Balloon#setAttributes(gov.nasa.worldwind.render.BalloonAttributes)}</code> with an instance of
+ * <code>{@link BalloonAttributes}</code>.
  *
  * @author dcollins
  * @version $Id: WebBrowserBalloons.java 2109 2014-06-30 16:52:38Z tgaskins $

--- a/src/gov/nasa/worldwindx/examples/analytics/AnalyticSurface.java
+++ b/src/gov/nasa/worldwindx/examples/analytics/AnalyticSurface.java
@@ -32,19 +32,20 @@ import java.util.List;
  * values, where width and height are the AnalyticSurface's grid dimensions. If the caller does not specify any
  * GridPointAttributes, or the caller specified iterable contains too few values, the unassigned grid points are given
  * default attributes: the default scalar value is 0, and the default color is {@link java.awt.Color#BLACK}.
- * <p/>
  * <h2>Surface Altitude</h2>
- * <p/>
+ * <p>
  * AnalyticSurface's altitude can vary at each grid point. The altitude of each grid point depends on four properties:
  * the altitude mode, the surface altitude, the vertical scale, and the scalar value from GridPointAttributes. The
  * following table outlines how the altitude at each grid point is computed for each altitude mode:
- * <p/>
- * <table border="1"> <tr><th>Altitude Mode</th><th>Grid Point Altitude</th></tr> <tr><td>WorldWind.ABSOLUTE
- * (default)</td><td>surface altitude + (vertical scale * scalar value from GridPointAttributes)</td></tr>
+ * <table border="1"><caption>Altitude Computations</caption>
+ * <tr><th>Altitude Mode</th><th>Grid Point Altitude</th></tr>
+ * <tr><td>WorldWind.ABSOLUTE (default)</td><td>surface altitude + (vertical scale * scalar value from
+ * GridPointAttributes)</td></tr>
  * <tr><td>WorldWind.RELATIVE_TO_GROUND</td><td>terrain height at grid point + surface altitude + (vertical scale *
  * scalar value from GridPointAttributes)</td></tr> <tr><td>WorldWind.CLAMP_TO_GROUND</td><td>terrain height at grid
- * point</td></tr> </table>
- * <p/>
+ * point</td></tr>
+ * </table>
+ * <p>
  * Note that when the altitude mode is WorldWind.CLAMP_TO_GROUND the surface altitude, vertical scale, and the scalar
  * value from GridPointAttributes are ignored. In this altitude mode only the Sector, dimensions, and color from
  * GridPointAttributes are used.
@@ -500,7 +501,7 @@ public class AnalyticSurface implements Renderable, PreRenderable
     /**
      * {@inheritDoc}
      *
-     * @param dc
+     * @param dc the draw context.
      */
     public void preRender(DrawContext dc)
     {

--- a/src/gov/nasa/worldwindx/examples/analytics/AnalyticSurfaceDemo.java
+++ b/src/gov/nasa/worldwindx/examples/analytics/AnalyticSurfaceDemo.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
  * Illustrates how to configure and display a 3D geographic grid of scalar data using the WorldWind <code>{@link
  * AnalyticSurface}</code>. Analytic surface defines a grid over a geographic <code>{@link Sector}</code> at a specified
  * altitude, and enables the caller to specify the color and height at each grid point.
- * <p/>
+ * <p>
  * This illustrates three key AnalyticSurface configurations: <ul> <li>Displaying a static data set where each grid
  * point uses color and height to indicate the data's magnitude.</li> <li>Displaying data that varies by color over time
  * on the terrain surface.</li> <li>Displaying data that varies by color and height over time at a specified

--- a/src/gov/nasa/worldwindx/examples/analytics/ExportableAnalyticSurface.java
+++ b/src/gov/nasa/worldwindx/examples/analytics/ExportableAnalyticSurface.java
@@ -122,7 +122,7 @@ public class ExportableAnalyticSurface extends AnalyticSurface implements Export
      * the exportImageWidth and exportImageHeight fields may be set to indicate the size of the exported ground overlay
      * image. These values are both 1024 by default. The surface's opacity attributes are ignored, but any opacity
      * values specified in the surface's color values are captured in the ground overlay image.
-     * <p/>
+     * <p>
      * If color values have not been specified for the surface then the interior if the output image is blank. The image
      * outline is exported only if the surface's drawOutline file is true.
      *

--- a/src/gov/nasa/worldwindx/examples/dataimport/DataInstallUtil.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/DataInstallUtil.java
@@ -138,7 +138,7 @@ public class DataInstallUtil
      * default location for installing data. This attempts to use the first FileStore location marked as an "install"
      * location. If no install location exists, this falls back to the FileStore's default write location, the same
      * location where downloaded data is cached.
-     * <p/>
+     * <p>
      * The returned {@link java.io.File} represents an abstract path, and therefore may not exist. In this case, the
      * caller must create the missing directories composing the abstract path.
      *

--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallElevations.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallElevations.java
@@ -23,7 +23,7 @@ import java.io.File;
 
 /**
  * Illustrates how to install elevation data into a WorldWind <code>{@link gov.nasa.worldwind.cache.FileStore}</code>.
- * <p/>
+ * <p>
  * Elevation data is installed into a FileStore by executing the following steps: <ol> <li>Choose the FileStore location
  * to place the installed elevations. This example uses the FileStore's install location. </li> <li>Compute a unique
  * cache name for the elevations. In this example, the cache name is "Examples/ElevationsName", where "ElevationsName"

--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallImagery.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallImagery.java
@@ -22,7 +22,7 @@ import java.io.File;
 
 /**
  * Illustrates how to install imagery into a WorldWind <code>{@link FileStore}</code>.
- * <p/>
+ * <p>
  * Image data is installed into a FileStore by executing the following steps: <ol> <li>Choose the FileStore location to
  * place the installed imagery. This example uses the default install location.</li> <li>Compute a unique cache name for
  * the imagery. In this example the cache name is "Examples/ImageName", where "ImageName" is the image's display name,

--- a/src/gov/nasa/worldwindx/examples/dataimport/InstallImageryAndElevationsDemo.java
+++ b/src/gov/nasa/worldwindx/examples/dataimport/InstallImageryAndElevationsDemo.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * visualized in WorldWind either as a <code>{@link gov.nasa.worldwind.layers.TiledImageLayer}</code> or an
  * <code>{@link gov.nasa.worldwind.globes.ElevationModel}</code>. The application also illustrates how to visualize data
  * that has been installed during a previous session.
- * <p/>
+ * <p>
  * For the simplest possible examples of installing imagery and elevation data, see the examples <code>{@link
  * InstallImagery}</code> and <code>{@link InstallElevations}</code>.
  *
@@ -557,7 +557,7 @@ public class InstallImageryAndElevationsDemo extends ApplicationTemplate
 
     /**
      * Suggests a name for a dataset based on pathnames of the passed files.
-     * <p/>
+     * <p>
      * Attempts to extract all common words that files' path can share, removes all non-alpha-numeric chars
      *
      * @param files Array of raster files
@@ -644,7 +644,7 @@ public class InstallImageryAndElevationsDemo extends ApplicationTemplate
      *
      * @return instance of the DataStoreProducer
      *
-     * @throws IllegalArgumentException, if types of rasters do not match, or array of raster files is null or empty
+     * @throws IllegalArgumentException if types of rasters do not match, or array of raster files is null or empty
      */
     protected static DataStoreProducer createDataStoreProducerFromFiles(File[] files) throws IllegalArgumentException
     {

--- a/src/gov/nasa/worldwindx/examples/kml/KMLApplicationController.java
+++ b/src/gov/nasa/worldwindx/examples/kml/KMLApplicationController.java
@@ -21,7 +21,7 @@ import java.beans.*;
  * A controller that maps KML events to changes in a WorldWind application. This controller animates the view to a KML
  * feature when the feature is clicked in the feature tree, and animates the view to KML network links when they are
  * refreshed.
- * <p/>
+ * <p>
  * This controller may optionally be associated with a {@link BalloonController}. If a BalloonController is set, this
  * controller will open the description balloon for a KML feature when the feature is clicked in the feature tree.
  *
@@ -140,7 +140,7 @@ public class KMLApplicationController implements SelectListener, PropertyChangeL
      * Upon receiving a <code>{@link gov.nasa.worldwind.avlist.AVKey#RETRIEVAL_STATE_SUCCESSFUL}</code> event from a
      * <code>KMLNetworkLink</code>, this attempts to fly to a <code>KMLAbstractView</code> associated with the link's
      * KML resource.
-     * <p/>
+     * <p>
      * If the <code>KMLNetworkLink</code>'s <code>flyToView</code> property is <code>0</code> or <code>false</code>,
      * this ignores the event. Otherwise, this attempts to get a <code>KMLAbstractView</code> from features in the
      * link's KML resource as follows: <ol> <li><code>NetworkLinkControl</code> child of link's KML resource.</li>
@@ -171,7 +171,7 @@ public class KMLApplicationController implements SelectListener, PropertyChangeL
      * Called from <code>propertyChange</code> when a <code>KMLNetworkLink</code> sends a <code>{@link
      * gov.nasa.worldwind.avlist.AVKey#RETRIEVAL_STATE_SUCCESSFUL}</code> property change event. This attempts to fly to
      * a view associated with the link's KML resource.
-     * <p/>
+     * <p>
      * This does nothing if the <code>networkLink</code> is <code>null</code>.
      *
      * @param networkLink the <code>KMLNetworkLink</code> that has been refreshed.

--- a/src/gov/nasa/worldwindx/examples/kml/KMLViewController.java
+++ b/src/gov/nasa/worldwindx/examples/kml/KMLViewController.java
@@ -22,7 +22,7 @@ import java.util.*;
  * a {@code LookAt} or {@code Camera} view, or to animate to a default view a KML feature that does not define a view.
  * Subclasses of this base class implement animator logic for particular types of {@link View}, for example {@link
  * OrbitView}.
- * <p/>
+ * <p>
  * An application that provides a custom View implementation can extend this base class to provide a KML controller for
  * the custom view.
  *

--- a/src/gov/nasa/worldwindx/examples/kml/KMLViewer.java
+++ b/src/gov/nasa/worldwindx/examples/kml/KMLViewer.java
@@ -109,7 +109,7 @@ public class KMLViewer extends ApplicationTemplate
          * Adds the specified <code>kmlRoot</code> to this app frame's <code>WorldWindow</code> as a new
          * <code>Layer</code>, and adds a new <code>KMLLayerTreeNode</code> for the <code>kmlRoot</code> to this app
          * frame's on-screen layer tree.
-         * <p/>
+         * <p>
          * This expects the <code>kmlRoot</code>'s <code>AVKey.DISPLAY_NAME</code> field to contain a display name
          * suitable for use as a layer name.
          *
@@ -187,7 +187,7 @@ public class KMLViewer extends ApplicationTemplate
          * then adds the new <code>KMLRoot</code> to this worker thread's <code>AppFrame</code>. The
          * <code>KMLRoot</code>'s <code>AVKey.DISPLAY_NAME</code> field contains a display name created from either the
          * KML source or the KML root feature name.
-         * <p/>
+         * <p>
          * If loading the KML source fails, this prints the exception and its stack trace to the standard error stream,
          * but otherwise does nothing.
          */

--- a/src/gov/nasa/worldwindx/examples/lineofsight/LinesOfSight.java
+++ b/src/gov/nasa/worldwindx/examples/lineofsight/LinesOfSight.java
@@ -31,12 +31,14 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Computes and displays line-of-sight intersections for terrain and renderables. Uses a {@link Terrain} object in order
  * to determine accurate intersections relative to the highest-resolution elevation data associated with a specified
  * globe.
- * <p/>
+ * <p>
  * This class uses a {@link gov.nasa.worldwindx.examples.lineofsight.TerrainLineIntersector} and a {@link
  * gov.nasa.worldwindx.examples.lineofsight.ShapeLineIntersector} to compute the intersections.
- * <p/>
- * <em>Usage:</em> <br/> Shift-click: Calculate lines of sight for a position. <br/> Ctrl-click: Cancel the running
- * computation. <br/> Alt-click: Re-run the most recent line of sight calculation.
+ * <p>
+ * <em>Usage:</em> <br>
+ * Shift-click: Calculate lines of sight for a position. <br>
+ * Ctrl-click: Cancel the running computation. <br>
+ * Alt-click: Re-run the most recent line of sight calculation.
  *
  * @author tag
  * @version $Id: LinesOfSight.java 2109 2014-06-30 16:52:38Z tgaskins $

--- a/src/gov/nasa/worldwindx/examples/lineofsight/PointGrid.java
+++ b/src/gov/nasa/worldwindx/examples/lineofsight/PointGrid.java
@@ -434,7 +434,7 @@ public class PointGrid extends WWObjectImpl implements OrderedRenderable, Highli
      * If the scene controller is rendering ordered renderables, this method draws this placemark's image as an ordered
      * renderable. Otherwise the method determines whether this instance should be added to the ordered renderable
      * list.
-     * <p/>
+     * <p>
      * The Cartesian and screen points of the placemark are computed during the first call per frame and re-used in
      * subsequent calls of that frame.
      *

--- a/src/gov/nasa/worldwindx/examples/multiwindow/CardLayoutUsage.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/CardLayoutUsage.java
@@ -21,12 +21,12 @@ import java.awt.event.*;
 
 /**
  * This class illustrates how to use multiple WorldWind windows with a {@link CardLayout} layer manager.
- * <p/>
+ * <p>
  * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
  * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and will be shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
- * <p/>
+ * <p>
  * Most WorldWind {@link Globe} and {@link Layer} objects can be shared among WorldWindows. Those that cannot be shared
  * have an operational dependency on the WorldWindow they're associated with. An example is the {@link
  * ViewControlsLayer} layer for on-screen navigation. Because this layer responds to input events within a specific

--- a/src/gov/nasa/worldwindx/examples/multiwindow/FlatAndRoundGlobes.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/FlatAndRoundGlobes.java
@@ -26,12 +26,12 @@ import java.util.ArrayList;
 
 /**
  * This class illustrates how to display round and flat globes side by side.
- * <p/>
+ * <p>
  * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
  * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and will be shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
- * <p/>
+ * <p>
  * Most WorldWind {@link Globe} and {@link Layer} objects can be shared among WorldWindows. Those that cannot be shared
  * have an operational dependency on the WorldWindow they're associated with. An example is the {@link
  * ViewControlsLayer} layer for on-screen navigation. Because this layer responds to input events within a specific

--- a/src/gov/nasa/worldwindx/examples/multiwindow/MultiFrame.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/MultiFrame.java
@@ -19,12 +19,12 @@ import java.awt.*;
 /**
  * This example shows how to create two WorldWindows, each in its own JFrame. The WorldWindows share a globe and some
  * layers.
- * <p/>
+ * <p>
  * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
  * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and are shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
- * <p/>
+ * <p>
  * Most WorldWind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be
  * shared among WorldWindows. Those that cannot be shared have an operational dependency on the WorldWindow they're
  * associated with. An example is the {@link gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen

--- a/src/gov/nasa/worldwindx/examples/multiwindow/SharedShapes.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/SharedShapes.java
@@ -30,12 +30,12 @@ import java.util.Arrays;
  * WorldWind windows share imagery layers and the layers representing each type of shape. Though this example uses a
  * different globe for each window, it is possible for the two windows to share the same {@link Globe} as is done in the
  * {@link MultiFrame} example.
- * <p/>
+ * <p>
  * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
  * resources among those windows. Most WorldWind classes are designed to be shared across WorldWindow objects and are
  * shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a previously
  * created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
- * <p/>
+ * <p>
  * Most WorldWind Globe and {@link gov.nasa.worldwind.layers.Layer} objects can be shared among WorldWindows. Those
  * that cannot be shared have an operational dependency on the WorldWindow they're associated with. An example is the
  * {@link gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen navigation. Because this layer responds to

--- a/src/gov/nasa/worldwindx/examples/multiwindow/TabbedPaneUsage.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/TabbedPaneUsage.java
@@ -19,12 +19,12 @@ import java.awt.*;
 
 /**
  * This class illustrates how to use multiple WorldWind windows with a {@link JTabbedPane}.
- * <p/>
+ * <p>
  * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
  * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and will be shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
- * <p/>
+ * <p>
  * Most WorldWind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be shared among WorldWindows. Those that cannot be shared
  * have an operational dependency on the WorldWindow they're associated with. An example is the {@link
  * gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen navigation. Because this layer responds to input events within a specific

--- a/src/gov/nasa/worldwindx/examples/multiwindow/ViewViewVolume.java
+++ b/src/gov/nasa/worldwindx/examples/multiwindow/ViewViewVolume.java
@@ -17,12 +17,12 @@ import java.awt.*;
 /**
  * This class illustrates how to display a globe, and in a separate window display another globe with a visualization of
  * the view volume in the main globe window.
- * <p/>
+ * <p>
  * Applications using multiple WorldWind windows simultaneously should instruct WorldWind to share OpenGL and other
  * resources among those windows. Most WorldWind classes are designed to be shared across {@link WorldWindow} objects
  * and will be shared automatically. But OpenGL resources are not automatically shared. To share them, a reference to a
  * previously created WorldWindow must be specified as a constructor argument for subsequently created WorldWindows.
- * <p/>
+ * <p>
  * Most WorldWind {@link gov.nasa.worldwind.globes.Globe} and {@link gov.nasa.worldwind.layers.Layer} objects can be
  * shared among WorldWindows. Those that cannot be shared have an operational dependency on the WorldWindow they're
  * associated with. An example is the {@link gov.nasa.worldwind.layers.ViewControlsLayer} layer for on-screen

--- a/src/gov/nasa/worldwindx/examples/shapebuilder/AbstractShapeEditor.java
+++ b/src/gov/nasa/worldwindx/examples/shapebuilder/AbstractShapeEditor.java
@@ -22,7 +22,7 @@ import java.awt.event.*;
  * related labels), references to the current WorldWindow and mouse location, flags indicating whether the editor is
  * currently armed and whether annotations should be shown, as well as fields indicating the current action being
  * performed, the current editMode, and the current altitudeMode.
- * <p/>
+ * <p>
  * In addition, the class contains several helper functions related to displaying annotations, which all editors should
  * be able to do.
  *

--- a/src/gov/nasa/worldwindx/examples/shapebuilder/RigidShapeBuilder.java
+++ b/src/gov/nasa/worldwindx/examples/shapebuilder/RigidShapeBuilder.java
@@ -39,11 +39,11 @@ import java.util.*;
  * desired shape from a dropdown menu, create an instance of it with the click of a button, and specify an "edit mode"
  * for modifying the shape: move, scale, rotate, skew, or texture.  Numerous shapes may be created and placed on the
  * globe together, but only one may be selected and edited at any given time.
- * <p/>
+ * <p>
  * Keyboard shortcuts allow the user to toggle easily between the various edit modes.  The shortcuts are as follows:
- * <p/>
+ * <p>
  * Ctrl-Z:  move Ctrl-X:  scale Ctrl-C:  rotate Ctrl-V:  skew Ctrl-B:  texture
- * <p/>
+ * <p>
  * Edited shapes are Restorable and may be saved to or loaded from a file using options in the File menu.
  *
  * @author ccrick

--- a/src/gov/nasa/worldwindx/examples/symbology/Symbology.java
+++ b/src/gov/nasa/worldwindx/examples/symbology/Symbology.java
@@ -22,10 +22,10 @@ import java.util.List;
 
 /**
  * Demonstrates the simplest possible usage of WorldWind {@link TacticalSymbol} and {@link
- * gov.nasa.worldwind.symbology.TacticalGraphic} to display symbols from the MIL-STD-2525 symbology set. See the <a
- * title="Symbology Usage Guide" href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology
- * Usage Guide</a> for more information on symbology support in WorldWind.
- * <p/>
+ * gov.nasa.worldwind.symbology.TacticalGraphic} to display symbols from the MIL-STD-2525 symbology set. See the
+ * <a href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology Usage Guide</a> for more
+ * information on symbology support in WorldWind.
+ * <p>
  * For more detailed examples of how to use TacticalSymbol and TacticalGraphic in an application, see the {@link
  * TacticalSymbols} example and the {@link TacticalGraphics} example.
  *

--- a/src/gov/nasa/worldwindx/examples/symbology/TacticalGraphics.java
+++ b/src/gov/nasa/worldwindx/examples/symbology/TacticalGraphics.java
@@ -24,10 +24,10 @@ import java.util.*;
 import java.util.List;
 
 /**
- * Demonstrates how to create and display WorldWind tactical graphics. See the <a title="Symbology Usage Guide"
- * href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology Usage Guide</a> for more
+ * Demonstrates how to create and display WorldWind tactical graphics. See the
+ * <a href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology Usage Guide</a> for more
  * information on symbology support in WorldWind.
- * <p/>
+ * <p>
  * See the {@link TacticalSymbols} for a detailed example of using WorldWind tactical symbols in an application.
  *
  * @author pabercrombie

--- a/src/gov/nasa/worldwindx/examples/symbology/TacticalSymbols.java
+++ b/src/gov/nasa/worldwindx/examples/symbology/TacticalSymbols.java
@@ -23,10 +23,10 @@ import java.awt.*;
 import java.awt.event.*;
 
 /**
- * Demonstrates how to create and display WorldWind tactical symbols. See the <a title="Symbology Usage Guide"
+ * Demonstrates how to create and display WorldWind tactical symbols. See the <a
  * href="https://goworldwind.org/developers-guide/symbology/" target="_blank">Symbology Usage Guide</a> for more
  * information on symbology support in WorldWind.
- * <p/>
+ * <p>
  * See the {@link TacticalGraphics} for a detailed example of using WorldWind tactical graphics in an application.
  *
  * @author dcollins

--- a/src/gov/nasa/worldwindx/examples/tutorial/Cube.java
+++ b/src/gov/nasa/worldwindx/examples/tutorial/Cube.java
@@ -106,6 +106,7 @@ public class Cube extends ApplicationTemplate implements Renderable
      * Determines whether the cube intersects the view frustum.
      *
      * @param dc the current draw context.
+     * @param orderedCube the cube to evaluate.
      *
      * @return true if this cube intersects the frustum, otherwise false.
      */
@@ -121,6 +122,7 @@ public class Cube extends ApplicationTemplate implements Renderable
      * Compute per-frame attributes, and add the ordered renderable to the ordered renderable list.
      *
      * @param dc Current draw context.
+     * @return the ordered cube
      */
     protected OrderedCube makeOrderedRenderable(DrawContext dc)
     {
@@ -169,6 +171,7 @@ public class Cube extends ApplicationTemplate implements Renderable
      * mode.
      *
      * @param dc Current draw context.
+     * @param pickCandidates the pick candidate results if in picking mode
      */
     protected void drawOrderedRenderable(DrawContext dc, PickSupport pickCandidates)
     {

--- a/src/gov/nasa/worldwindx/examples/util/BalloonController.java
+++ b/src/gov/nasa/worldwindx/examples/util/BalloonController.java
@@ -30,43 +30,36 @@ import java.util.List;
 import java.util.Timer;
 
 /**
- * Controller to display a {@link Balloon} and handle balloon events. The controller does the following: <ul>
- * <li>Display a balloon when an object is selected</li> <li>Handle URL selection events in balloons</li> <li>Resize
- * BrowserBalloons</li> <li>Handle close, back, and forward events in BrowserBalloon</li> </ul>
- * <p/>
+ * Controller to display a {@link Balloon} and handle balloon events. The controller does the following:
+ * <ul>
+ * <li>Display a balloon when an object is selected</li>
+ * <li>Handle URL selection events in balloons</li>
+ * <li>Resize BrowserBalloons</li>
+ * <li>Handle close, back, and forward events in BrowserBalloon</li>
+ * </ul>
  * <h2>Displaying a balloon for a selected object</h2>
- * <p/>
  * When a object is clicked, the controller looks for a Balloon attached to the object. The controller includes special
  * logic for handling balloons attached to KML features.
- * <p/>
  * <h3>KML Features</h3>
- * <p/>
  * The KMLAbstractFeature is attached to the top PickedObject under AVKey.CONTEXT. The controller looks for the balloon
  * in the KMLAbstractFeature under key AVKey.BALLOON.
- * <p/>
  * <h3>Other objects</h3>
- * <p/>
  * If the top object is an instance of AVList, the controller looks for a Balloon under AVKey.BALLOON.
- * <p/>
  * <h2>URL events</h2>
- * <p/>
  * The controller looks for a value under AVKey.URL attached to either the top PickedObject. If the URL refers to a KML
  * or KMZ document, the document is loaded into a new layer. If the link includes a reference to a KML feature,
  * controller will animate the view to that feature and/or open the feature balloon.
- * <p/>
+ * <p>
  * If the link should open in a new window (determined by an AVKey.TARGET of "_blank"), the controller will launch the
  * system web browser and navigate to the link. Otherwise it will allow the BrowserBalloon to navigate to the link.
- * <p/>
+ * <p>
  * Consuming a SelectEvent in the BalloonController will prevent the balloon from taking action on that event. For
  * example, a BrowserBalloon will navigate in place when a link is clicked, but it will not if the balloon controller
  * consumes the left press and left click select events. This allows the balloon controller to override the default
  * action for certain URLs.
- * <p/>
- * <h2>BrowserBalloon control events</h2>
- * <p/>
- * {@link gov.nasa.worldwind.render.AbstractBrowserBalloon} identifies its controls by attaching a value to the
- * PickedObject's AVList under AVKey.ACTION. The controller reads this value and performs the appropriate action. The
- * possible actions are AVKey.RESIZE, AVKey.BACK, AVKey.FORWARD, and AVKey.CLOSE.
+ * <h2>BrowserBalloon control events</h2> {@link gov.nasa.worldwind.render.AbstractBrowserBalloon} identifies its
+ * controls by attaching a value to the PickedObject's AVList under AVKey.ACTION. The controller reads this value and
+ * performs the appropriate action. The possible actions are AVKey.RESIZE, AVKey.BACK, AVKey.FORWARD, and AVKey.CLOSE.
  *
  * @author pabercrombie
  * @version $Id: BalloonController.java 1531 2013-08-04 16:19:13Z pabercrombie $
@@ -422,19 +415,19 @@ public class BalloonController extends MouseAdapter implements SelectListener
     /**
      * Called when a URL in a balloon is activated. This method handles links to KML documents, features in KML
      * documents, and links that target a new browser window.
-     * <p/>
+     * <p>
      * The possible cases are:
-     * <p/>
+     * <p>
      * <b>KML/KMZ document</b> - Load the document in a new layer.<br> <b>Feature in KML/KMZ document</b> - Load the
      * document, navigate to the feature and/or open feature balloon.<br> <b>Feature in currently open KML/KMZ
      * document</b> - Navigate to the feature and/or open feature balloon. <br> <b>HTML document, target current
      * window</b> - No action, let the BrowserBalloon navigate to the URL. <br> <b>HTML document, target new window</b>
      * - Launch the system web browser and navigate to the URL.
-     * <p/>
+     * <p>
      * If the URL matches one of the cases defined above, the SelectEvent will be marked as consumed. Marking the event
      * as consumed prevents BrowserBalloon from handling the event. However, the controller will only take action on the
      * event if the event is a link activation trigger.
-     * <p/>
+     * <p>
      * For example, if a left click event (a link activation event) occurs on a link to a KML document, the event will
      * be marked as consumed and the document will be opened. If a left press event (not a link activation event) occurs
      * with the same URL, the event will be consumed but the document will not be opened (if the press is followed by a
@@ -747,7 +740,7 @@ public class BalloonController extends MouseAdapter implements SelectListener
      * Get the balloon attached to a PickedObject. If the PickedObject represents a KML feature, then the balloon will
      * be retrieved from the feature.  Otherwise, the balloon will be retrieved from the user object's field
      * AVKey.BALLOON.
-     * <p/>
+     * <p>
      * If a KML feature is picked, and the feature does not have a balloon, a new balloon may be created and attached to
      * the feature. {@link #canShowBalloon(gov.nasa.worldwind.ogc.kml.KMLAbstractFeature) canShowBalloon} determines if
      * a balloon will be created for the feature.
@@ -1412,7 +1405,7 @@ public class BalloonController extends MouseAdapter implements SelectListener
     /**
      * Adds the specified <code>document</code> to this controller's <code>WorldWindow</code> as a new
      * <code>Layer</code>.
-     * <p/>
+     * <p>
      * This expects the <code>kmlRoot</code>'s <code>AVKey.DISPLAY_NAME</code> field to contain a display name suitable
      * for use as a layer name.
      *
@@ -1436,7 +1429,7 @@ public class BalloonController extends MouseAdapter implements SelectListener
      * Dispatch Thread (EDT) to either {@link BalloonController#onDocumentLoaded(String,
      * gov.nasa.worldwind.ogc.kml.KMLRoot, String) onDocumentLoaded} or {@link BalloonController#onDocumentFailed(String,
      * Exception) onDocumentFailed}.
-     * <p/>
+     * <p>
      * This task is designed to be repeated periodically. The task will cancel itself when the document becomes
      * available, or the timeout is exceeded.
      */

--- a/src/gov/nasa/worldwindx/examples/util/DirectedPath.java
+++ b/src/gov/nasa/worldwindx/examples/util/DirectedPath.java
@@ -51,7 +51,7 @@ public class DirectedPath extends Path
 
     /**
      * Creates a path with specified positions.
-     * <p/>
+     * <p>
      * Note: If fewer than two positions is specified, no path is drawn.
      *
      * @param positions the path positions. This reference is retained by this shape; the positions are not copied. If
@@ -67,7 +67,7 @@ public class DirectedPath extends Path
 
     /**
      * Creates a path with positions specified via a generic list.
-     * <p/>
+     * <p>
      * Note: If fewer than two positions is specified, the path is not drawn.
      *
      * @param positions the path positions. This reference is retained by this shape; the positions are not copied. If
@@ -205,7 +205,7 @@ public class DirectedPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to also compute the geometry of the direction arrows.
      */
     @Override
@@ -217,7 +217,7 @@ public class DirectedPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to return a {@link gov.nasa.worldwindx.examples.util.DirectedSurfacePolyline}.
      */
     @Override
@@ -231,7 +231,7 @@ public class DirectedPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to update the arrow properties of {@link gov.nasa.worldwindx.examples.util.DirectedSurfacePolyline}.
      */
     @Override
@@ -311,6 +311,8 @@ public class DirectedPath extends Path
      * Compute the geometry of a direction arrow between two points.
      *
      * @param dc       current draw context
+     * @param poleA    the pole A
+     * @param poleB    the pole B
      * @param polePtA  the first pole position. This is one of the application defined path positions.
      * @param polePtB  second pole position
      * @param buffer   buffer in which to place computed points
@@ -428,7 +430,7 @@ public class DirectedPath extends Path
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to also draw direction arrows.
      *
      * @param dc Current draw context.
@@ -444,7 +446,7 @@ public class DirectedPath extends Path
     /**
      * Draws this DirectedPath's direction arrows. Called from {@link #doDrawOutline(gov.nasa.worldwind.render.DrawContext)}
      * before drawing the Path's actual outline.
-     * <p/>
+     * <p>
      * If this Path is entirely located on the terrain, this applies an offset to the arrow's depth values to to ensure
      * they shows over the terrain. This does not apply a depth offset in any other case to avoid incorrectly drawing
      * the arrows over objects they should be behind, including the terrain. In addition to applying a depth offset,

--- a/src/gov/nasa/worldwindx/examples/util/DirectedSurfacePolyline.java
+++ b/src/gov/nasa/worldwindx/examples/util/DirectedSurfacePolyline.java
@@ -73,7 +73,7 @@ public class DirectedSurfacePolyline extends SurfacePolyline
 
     /**
      * Constructs a new directed surface polyline with the default attributes and the specified iterable of locations.
-     * <p/>
+     * <p>
      * Note: If fewer than two locations is specified, no polyline is drawn.
      *
      * @param iterable the polyline locations.
@@ -89,7 +89,7 @@ public class DirectedSurfacePolyline extends SurfacePolyline
      * Constructs a new directed surface polyline with the specified normal (as opposed to highlight) attributes and the
      * specified iterable of locations. Modifying the attribute reference after calling this constructor causes this
      * shape's appearance to change accordingly.
-     * <p/>
+     * <p>
      * Note: If fewer than two locations is specified, no polyline is drawn.
      *
      * @param normalAttrs the normal attributes. May be null, in which case default attributes are used.
@@ -209,7 +209,7 @@ public class DirectedSurfacePolyline extends SurfacePolyline
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Overridden to also draw direction arrows.
      *
      * @param dc  the current draw context.

--- a/src/gov/nasa/worldwindx/examples/util/ExtentVisibilitySupport.java
+++ b/src/gov/nasa/worldwindx/examples/util/ExtentVisibilitySupport.java
@@ -24,11 +24,11 @@ import java.util.ArrayList;
  * The static convenience method {@link #extentsFromExtentHolders(Iterable, gov.nasa.worldwind.globes.Globe, double)}
  * makes it easy to for callers to convert an Iterable of Extents references to an Iterable of {@link
  * gov.nasa.worldwind.geom.ExtentHolder} references.
- * <p/>
+ * <p>
  * The method {@link #areExtentsContained(gov.nasa.worldwind.View)} provides a mechanism for callers to test whether or
  * not the currently configured scene is entirely contained within a certain {@link gov.nasa.worldwind.View}. This
  * method tests containment on both the model coordinate extents and screen coordinate extents.
- * <p/>
+ * <p>
  * The method {@link #computeViewLookAtContainingExtents(gov.nasa.worldwind.globes.Globe, double,
  * gov.nasa.worldwind.View)} returns a viewing coordinate system which contains the currently configured scene, while
  * preserving the current view's orientation to the globe (heading and pitch). This has the effect of computing the pan
@@ -296,7 +296,7 @@ public class ExtentVisibilitySupport
      * elements. The returned look-at vectors define a new viewing coordinate system as follows: The vector at index 0
      * defines the eye point, the vector at index 1 defines the reference center point, and the value at index 2 defines
      * the up vector.
-     * <p/>
+     * <p>
      * The specified eye point, reference center point, and up vector define the input view coordinate system, and the
      * returned view coordinates preserve the input view coordinates' orientation relative to the specified Globe. The
      * field-of-view, viewport and clip distances define the input view projection parameters, and are used to compute
@@ -428,7 +428,7 @@ public class ExtentVisibilitySupport
      * elements. The returned look-at vectors define a new viewing coordinate system as follows: The vector at index 0
      * defines the eye point, the vector at index 1 defines the reference center point, and the value at index 2 defines
      * the up vector.
-     * <p/>
+     * <p>
      * The specified View defines both the input view coordinate system, and the input view projection parameters. The
      * returned view coordinates preserve the input view's orientation relative to the specified Globe, and are optimal
      * for the View's projection parameters.

--- a/src/gov/nasa/worldwindx/examples/util/HotSpotController.java
+++ b/src/gov/nasa/worldwindx/examples/util/HotSpotController.java
@@ -20,7 +20,7 @@ import java.awt.event.*;
  * gov.nasa.worldwind.util.HotSpot}. The active HotSpot is updated on {@link gov.nasa.worldwind.event.SelectEvent#ROLLOVER}
  * select events, but not during a drag operation. This ensures that the active HotSpot remains active while it's being
  * dragged, regardless of what's under the cursor.
- * <p/>
+ * <p>
  * The active HotSpot is updated during non-drag rollover select events as follows: <ul> <li>The select event's top
  * picked object, if the top picked object implements {@link gov.nasa.worldwind.util.HotSpot}.</li> <li>The value for
  * {@code SelectEvent.getTopPickedObject().getValue(AVKey.HOT_SPOT)},if the value for key {@link
@@ -61,7 +61,7 @@ public class HotSpotController implements SelectListener, MouseMotionListener
     /**
      * Updates the active {@link gov.nasa.worldwind.util.HotSpot} if necessary, and forwards the select event to the
      * active HotSpot. This does nothing if the select event is {@code null}.
-     * <p/>
+     * <p>
      * This forwards the select event to {@link #doSelected(gov.nasa.worldwind.event.SelectEvent)}, and catches and logs
      * any exceptions thrown by {@code doSelected}.
      *
@@ -202,7 +202,8 @@ public class HotSpotController implements SelectListener, MouseMotionListener
      * listener, mouse motion listener, and mouse wheel listener on the WorldWindow's {@link
      * gov.nasa.worldwind.event.InputHandler}. This removes the previously active HotSpot as a listener on the World
      * Window's InputHandler. This does nothing if the active HotSpot and the specified HotSpot are the same object.
-     * </p> Additionally, this updates the WorldWindow's {@link java.awt.Cursor} to the value returned by {@code
+     * <p>
+     * Additionally, this updates the WorldWindow's {@link java.awt.Cursor} to the value returned by {@code
      * hotSpot.getCursor()}, or {@code null} if the specified hotSpot is {@code null}.
      *
      * @param hotSpot The HotSpot that becomes the active HotSpot. {@code null} to indicate that there is no active

--- a/src/gov/nasa/worldwindx/examples/util/LabeledPath.java
+++ b/src/gov/nasa/worldwindx/examples/util/LabeledPath.java
@@ -16,7 +16,7 @@ import java.awt.*;
  * LabeledPath draws a {@link gov.nasa.worldwind.render.Annotation} on a specified path. The path itself is not drawn.
  * Instead, the annotation is drawn at the location that maximizes the annotation's visible area in the viewport. The
  * annotation is not drawn if the location list is {@code null}, or if no location in the list is visible.
- * <p/>
+ * <p>
  * The caller must specify the screen annotation used to draw the path's label by calling {@link
  * #setAnnotation(gov.nasa.worldwind.render.ScreenAnnotation)}. The path sets the specified annotation's screen point to
  * control the label's location, but otherwise does not modify the annotation.
@@ -128,7 +128,7 @@ public class LabeledPath implements Renderable
     /**
      * Specifies the labeled path's altitude mode, one of {@link gov.nasa.worldwind.WorldWind#ABSOLUTE}, {@link
      * gov.nasa.worldwind.WorldWind#RELATIVE_TO_GROUND} or {@link gov.nasa.worldwind.WorldWind#CLAMP_TO_GROUND}.
-     * <p/>
+     * <p>
      * Note: If the altitude mode is unrecognized, {@link gov.nasa.worldwind.WorldWind#ABSOLUTE} is used.
      *
      * @param altitudeMode the altitude mode. The default value is {@link gov.nasa.worldwind.WorldWind#ABSOLUTE}.

--- a/src/gov/nasa/worldwindx/examples/util/LayerManagerLayer.java
+++ b/src/gov/nasa/worldwindx/examples/util/LayerManagerLayer.java
@@ -397,7 +397,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
      * Determines whether the layer list frame is minimized. When minimized, the layer list only contains itself as the
      * only item, and thus shrinks toward it's corner position.
      *
-     * @return <ode>true</code> if the layer list frame is minimized.
+     * @return <code>true</code> if the layer list frame is minimized.
      */
     public boolean isMinimized()
     {
@@ -408,7 +408,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
      * Set the layer list frame to be minimized. When minimized, the layer list only contains itself as the only item,
      * and thus shrinks toward it's corner position.
      *
-     * @param minimized <ode>true</code> if the layer list frame sould be minimized.
+     * @param minimized <code>true</code> if the layer list frame should be minimized.
      */
     public void setMinimized(boolean minimized)
     {
@@ -418,7 +418,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
 
     /**
      * Determines whether the layer list can be moved or dragged with the mouse cursor.
-     * <p/>
+     * <p>
      * If enabled, dragging the frame will result in a change to it's location offset - {@link
      * #setLocationOffset(Vec4)}. If the list is also set to snap to corners - {@link #setSnapToCorners(boolean)}, the
      * frame position may change so as to be attached to the nearest corner - see {@link #setPosition(String)}.
@@ -432,7 +432,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
 
     /**
      * Sets whether the layer list can be moved or dragged with the mouse cursor.
-     * <p/>
+     * <p>
      * If enabled, dragging the frame will result in a change to it's location offset - {@link
      * #setLocationOffset(Vec4)}. If the list is also set to snap to corners - {@link #setSnapToCorners(boolean)}, the
      * frame position may change so as to be attached to the nearest corner - see {@link #setPosition(String)}.
@@ -468,7 +468,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
 
     /**
      * Determines whether the layer list snaps to the viewport sides and corners while being dragged.
-     * <p/>
+     * <p>
      * Dragging the layer list frame will result in a change to it's location offset - {@link #setLocationOffset(Vec4)}.
      * If the list is also set to snap to corners - {@link #setSnapToCorners(boolean)}, the frame position may change so
      * as to be attached to the nearest corner - see {@link #setPosition(String)}.
@@ -482,7 +482,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
 
     /**
      * Sets whether the layer list snaps to the viewport sides and corners while being dragged.
-     * <p/>
+     * <p>
      * Dragging the layer list frame will result in a change to it's location offset - {@link #setLocationOffset(Vec4)}.
      * If the list is also set to snap to corners the frame position may change so as to be attached to the nearest
      * corner - see {@link #setPosition(String)}.
@@ -772,7 +772,7 @@ public class LayerManagerLayer extends RenderableLayer implements SelectListener
     /**
      * Change the annotation appearance according to the given highlighted state.
      *
-     * @param highlighted <ode>true</code> if the annotation should appear highlighted.
+     * @param highlighted <code>true</code> if the annotation should appear highlighted.
      */
     protected void highlight(boolean highlighted)
     {

--- a/src/gov/nasa/worldwindx/examples/util/OpenStreetMapShapefileLoader.java
+++ b/src/gov/nasa/worldwindx/examples/util/OpenStreetMapShapefileLoader.java
@@ -51,12 +51,15 @@ public class OpenStreetMapShapefileLoader
      * source type may be one of the following: <ul> <li>{@link java.io.InputStream}</li> <li>{@link java.net.URL}</li>
      * <li>absolute {@link java.net.URI}</li> <li>{@link java.io.File}</li> <li>{@link String} containing a valid URL
      * description or a file or resource name available on the classpath.</li> </ul>
-     * <p/>
+     * <p>
      * The returned Layer renders each Shapefile record as a surface circle with an associated screen label. The label
      * text is taken from the Shapefile record attribute key "name". This determines each surface circle's appearance
-     * from the Shapefile record attribute key "type" as follows: <table> <tr><th>Type</th><th>Color</th></tr>
+     * from the Shapefile record attribute key "type" as follows: 
+     * <table><caption>Types</caption>
+     * <tr><th>Type</th><th>Color</th></tr>
      * <tr><td>hamlet</td><td>Black</td></tr> <tr><td>village</td><td>Green</td></tr>
-     * <tr><td>town</td><td>Cyan</td></tr> <tr><td>city</td><td>Yellow</td></tr> </table>
+     * <tr><td>town</td><td>Cyan</td></tr> <tr><td>city</td><td>Yellow</td></tr> 
+     * </table>
      *
      * @param source the source of the OpenStreetMap Shapefile.
      *
@@ -91,12 +94,15 @@ public class OpenStreetMapShapefileLoader
 
     /**
      * Creates a {@link gov.nasa.worldwind.layers.Layer} from an OpenStreetMap Shapefile of placemarks.
-     * <p/>
+     * <p>
      * The returned Layer renders each Shapefile record as a surface circle with an associated screen label. The label
      * text is taken from the Shapefile record attribute key "name". This determines each surface circle's appearance
-     * from the Shapefile record attribute key "type" as follows: <table> <tr><th>Type</th><th>Color</th></tr>
+     * from the Shapefile record attribute key "type" as follows: 
+     * <table><caption>Types</caption>
+     * <tr><th>Type</th><th>Color</th></tr>
      * <tr><td>hamlet</td><td>Black</td></tr> <tr><td>village</td><td>Green</td></tr>
-     * <tr><td>town</td><td>Cyan</td></tr> <tr><td>city</td><td>Yellow</td></tr> </table>
+     * <tr><td>town</td><td>Cyan</td></tr> <tr><td>city</td><td>Yellow</td></tr>
+     * </table>
      *
      * @param shp the Shapefile to create a layer for.
      *

--- a/src/gov/nasa/worldwindx/examples/util/PowerOfTwoPaddedImage.java
+++ b/src/gov/nasa/worldwindx/examples/util/PowerOfTwoPaddedImage.java
@@ -18,7 +18,7 @@ import java.io.InputStream;
  * image are completely transparent. This is a useful property when converting images to OpenGL textures.
  * Non-power-of-two textures are handled inconsistently by graphics hardware. Not all hardware supports them, and many
  * that do lack full support for the the texturing functionality avialable for power-of-two textures.
- * <p/>
+ * <p>
  * PowerOfTwoPaddedImage provides accessors to the converted power-of-two image, the power-of-two image's width and
  * height, and the original image's width and height.
  *

--- a/src/gov/nasa/worldwindx/examples/util/ScreenSelector.java
+++ b/src/gov/nasa/worldwindx/examples/util/ScreenSelector.java
@@ -23,9 +23,8 @@ import java.util.List;
  * and tracks the list of objects intersecting the screen rectangle. The screen rectangle is displayed on a layer
  * created by ScreenSelector, and is used as the WorldWindow's pick rectangle to perform object selection. Objects
  * intersecting the screen rectangle can be accessed by calling {@link #getSelectedObjects()}.
- * <p/>
  * <h3>Using ScreenSelector</h3>
- * <p/>
+ * <p>
  * To use ScreenSelector in an application, create a new instance of ScreenSelector and specify the application's
  * WorldWindow as the sole parameter. When the user wants to define a screen selection, call {@link #enable} and the
  * ScreenSelector then translates mouse events to changes in the selection rectangle. The selection rectangle is
@@ -33,19 +32,18 @@ import java.util.List;
  * ScreenSelector consumes mouse events it responds in order to suppress navigation events while the user is performing
  * a selection. When the user selection is complete, call {@link #disable} and the ScreenSelector stops responding to
  * mouse events.
- * <p/>
+ * <p>
  * While the ScreenSelector is enabled it keeps track of the objects intersecting the selection rectangle, which can be
  * accessed by calling getSelectedObjects. When the list of selected objects changes, SceneSelector sends
  * SELECTION_STARTED, SELECTION_CHANGED, and SELECTION_ENDED messages to its message listeners. These three messages
  * correspond to the user starting a selection, changing what's in the selection, and completing the selection. To
  * receive a notification when the list of selected objects changes, register a MessageListener with the SceneSelector
  * by calling {@link #addMessageListener(gov.nasa.worldwind.event.MessageListener)}.
- * <p/>
+ * <p>
  * Note that enabling or disabling the ScreenSelector does not change its list of selected objects. The list of selected
  * objects only changes in response to user input when the ScreenSelector is enabled.
- * <p/>
  * <h3>User Input</h3>
- * <p/>
+ * <p>
  * When ScreenSelector is enabled, pressing the first mouse button causes ScreenSelector to set its selection to a
  * rectangle at the cursor with zero width and height, then clear the list of selected objects. Subsequently dragging
  * the mouse causes ScreenSelector to update its selection rectangle to include the starting point and the current
@@ -53,22 +51,21 @@ import java.util.List;
  * causes ScreenSelector to stop displaying the selection rectangle, but does not change the list of selected objects.
  * Keeping the list of selected object available after the selection is complete enables applications to access the
  * user's final selection by calling getSelectedObjects.
- * <p/>
+ * <p>
  * To customize ScreenSelector's response to mouse events, create a subclass of ScreenSelector and override the methods
  * mousePressed, mouseReleased, and mouseDragged. To customize ScreenSelector's response to screen rectangle select
  * events, override the method selected.
- * <p/>
+ * <p>
  * ScreenSelector translates its raw mouse events to the methods selectionStarted, selectionEnded, and selectionChanged.
  * To customize how ScreenSelector responds to these semantic events without changing the user input model, create a
  * subclass of ScreenSelector and override any of these methods.
- * <p/>
  * <h3>Screen Rectangle Appearance</h3>
- * <p/>
+ * <p>
  * To customize the appearance of the rectangle displayed by ScreenRectangle, call {@link
  * #setInteriorColor(java.awt.Color)} and {@link #setBorderColor(java.awt.Color)} to specify the rectangle's interior
  * and border colors, respectively. Setting either value to <code>null</code> causes ScreenRectangle to use the default
  * values: 25% opaque white interior, 100% opaque white border.
- * <p/>
+ * <p>
  * To further customize the displayed rectangle, create a subclass of ScreenSelector, override the method
  * createSelectionRectangle, and return a subclass of the internal class ScreenSelector.SelectionRectangle.
  *

--- a/src/gov/nasa/worldwindx/examples/util/ShapefileLoader.java
+++ b/src/gov/nasa/worldwindx/examples/util/ShapefileLoader.java
@@ -15,17 +15,25 @@ import gov.nasa.worldwind.util.*;
 
 /**
  * Converts Shapefile geometry into WorldWind renderable objects. Shapefile geometries are mapped to WorldWind objects
- * as follows: <table> <tr><th>Shapefile Geometry</th><th>WorldWind Object</th></tr> <tr><td>Point</td><td>{@link
- * gov.nasa.worldwind.render.WWIcon}</td></tr> <tr><td>MultiPoint</td><td>List of {@link
- * gov.nasa.worldwind.render.WWIcon}</td></tr> <tr><td>Polyline</td><td>{@link gov.nasa.worldwind.render.SurfacePolylines}</td></tr>
- * <tr><td>Polygon</td><td>{@link gov.nasa.worldwind.render.SurfacePolygons}</td></tr> </table>
- * <p/>
+ * as follows:
+ * <table><caption>Shapefile Geometries</caption>
+ * <tr><th>Shapefile Geometry</th><th>WorldWind Object</th></tr>
+ * <tr><td>Point</td><td>{@link gov.nasa.worldwind.render.WWIcon}</td></tr>
+ * <tr><td>MultiPoint</td><td>List of {@link gov.nasa.worldwind.render.WWIcon}</td></tr>
+ * <tr><td>Polyline</td><td>{@link gov.nasa.worldwind.render.SurfacePolylines}</td></tr>
+ * <tr><td>Polygon</td><td>{@link gov.nasa.worldwind.render.SurfacePolygons}</td></tr>
+ * </table>
+ * <p>
  * Shapefiles do not contain a standard definition for color and other visual attributes. Though some Shapefiles contain
  * color information in each record's key-value attributes, ShapefileLoader does not attempt to interpret that
  * information. Instead, the WorldWind renderable objects created by ShapefileLoader are assigned a random color.
  * Callers can replace or extend this behavior by defining a subclass of ShapefileLoader and overriding the following
- * methods: <ul> <li>{@link #nextPointAttributes()}</li> <li>{@link #nextPolylineAttributes()}</li> <li>{@link
- * #nextPolygonAttributes()}</li></ul>.
+ * methods:
+ * <ul>
+ * <li>{@link #nextPointAttributes()}</li>
+ * <li>{@link #nextPolylineAttributes()}</li>
+ * <li>{@link #nextPolygonAttributes()}</li>
+ * </ul>.
  *
  * @author dcollins
  * @version $Id: ShapefileLoader.java 2326 2014-09-17 22:35:45Z dcollins $

--- a/src/gov/nasa/worldwindx/examples/util/StatusLayer.java
+++ b/src/gov/nasa/worldwindx/examples/util/StatusLayer.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Renders statusbar information as a layer.
- * <p/>
+ * <p>
  * Used ScalebarLayer and StatusBar as template
  */
 //TODO


### PR DESCRIPTION
### Description of the Change
Changed the javadoc text to produce an error and warning free build of the community edition WorldWindJava API documentation. Also changed the API documentation branding to reflect the community edition.

Online API branding:
- Browser window/tab title: **WorldWindJava API**
- Document title on JavaDoc overview: **NASA WorldWind Java-Community Edition**
- Headers on JavaDoc pages: **NASA WorldWind-CE** 
- Previews values were "NASA WorldWind" for all the above.

### Why Should This Be In Core?
Part of an error free build.

### Benefits
- Reduces the noise in the build output. 
- May be required for Maven or Gradle builds.

### Potential Drawbacks
None

### Applicable Issues
Closes #16 
