### PR TITLE
Added multiple JDKs to the Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@
 # Set up to run the Java build script per the Travis CI documentation
 language: java
 
-# Configure the build to use Oracle JDK 8
+# Configure the build to use Oracle JDK 8 and OpenJDK8
 jdk:
+  - openjdk8
   - oraclejdk8
 
 # Install the Ant JUnit package, which is missing from the Travis CI environment. See the Travis documentation: https://docs.travis-ci.com/user/installing-dependencies/#Adding-APT-Packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ jdk:
   - oraclejdk11
   - openjdk-ea
   
-#   
+# Don't fail the build on the early access JDK, or wait for it to finish before marking it done.
 matrix:
+  fast_finish: tree
   allow_failures:
     - jdk: openjdk-ea  
 
@@ -43,12 +44,14 @@ deploy:
     skip_cleanup: true
     on:
       branch: develop
+      jdk: oraclejdk8
   # Create CHANGELOG.md in the current directory
   - provider: script
     script: ./travis/changelog.sh >> CHANGELOG.md
     skip_cleanup: true
     on:
       tags: true
+      jdk: oraclejdk8
   # Create a GitHub release and publish CHANGELOG.md to the release assets
   - provider: releases
     api_key: $GITHUB_API_KEY
@@ -56,3 +59,4 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
+      jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@
 # Set up to run the Java build script per the Travis CI documentation
 language: java
 
-# Configure the build to use Oracle JDK 8 and OpenJDK8
+# Configure the build to use Oracle JDKs and Open JDKs
 jdk:
   - openjdk8
+  - openjdk11
   - oraclejdk8
-  - oraclejdk9
   - oraclejdk11
 
 # Install the Ant JUnit package, which is missing from the Travis CI environment. See the Travis documentation: https://docs.travis-ci.com/user/installing-dependencies/#Adding-APT-Packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jdk:
   
 # Don't fail the build on the early access JDK, or wait for it to finish before marking it done.
 matrix:
-  fast_finish: tree
+  fast_finish: true
   allow_failures:
     - jdk: openjdk-ea  
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ language: java
 jdk:
   - openjdk8
   - oraclejdk8
+  - oraclejdk9
+  - oraclejdk11
 
 # Install the Ant JUnit package, which is missing from the Travis CI environment. See the Travis documentation: https://docs.travis-ci.com/user/installing-dependencies/#Adding-APT-Packages
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@
 # Set up to run the Java build script per the Travis CI documentation
 language: java
 
-# Configure the build to using the minimum and the latest Oracle JDKs and Open JDKs
+# Configure the build to using the minimum and the latest stable Oracle JDKs and Open JDKs
+# Consider adding openjdk-ea and/or oraclejdk-ea to test early access JDKs
 jdk:
   - openjdk8
   - openjdk11
-  - openjdk-ea
   - oraclejdk8
   - oraclejdk11
-  - oraclejdk-ea
 
 # Install the Ant JUnit package, which is missing from the Travis CI environment. See the Travis documentation: https://docs.travis-ci.com/user/installing-dependencies/#Adding-APT-Packages
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@
 # Set up to run the Java build script per the Travis CI documentation
 language: java
 
-# Configure the build to use Oracle JDKs and Open JDKs
+# Configure the build to using the minimum and the latest Oracle JDKs and Open JDKs
 jdk:
   - openjdk8
   - openjdk11
+  - openjdk-ea
   - oraclejdk8
   - oraclejdk11
+  - oraclejdk-ea
 
 # Install the Ant JUnit package, which is missing from the Travis CI environment. See the Travis documentation: https://docs.travis-ci.com/user/installing-dependencies/#Adding-APT-Packages
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ jdk:
   - openjdk11
   - oraclejdk8
   - oraclejdk11
+  - openjdk-ea
+  
+#   
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea  
 
 # Install the Ant JUnit package, which is missing from the Travis CI environment. See the Travis documentation: https://docs.travis-ci.com/user/installing-dependencies/#Adding-APT-Packages
 addons:


### PR DESCRIPTION
### Description of the Change
The `.travis.yml` build script was changed to test the build with multiple JDKs.  The minimum JDK, the latest stable JDK, and an early access JDK are used.  JDKs from both Oracle and OpenJDK are used.  These include:  

- `openjdk8`
- `openjdk11`
- `oraclejdk8`
- `oraclejdk11`
- `openjdk-ea`

Failues in the early access JDK will not fail the build.

The deployment actions to GitHub Pages and GitHub Releases are constrained to `oraclejdk8`

### Why Should This Be In Core?
Core component of the continuous integration process

### Benefits
Early warning of problems in the build.

### Potential Drawbacks
- Increases the time for the Travis-CI build to finish
- Consumes additional Travis resources

### Applicable Issues
Closes #27 
