### PR TITLE
Updated .travis.yml to force the use of Ant over Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ addons:
     packages:
       - ant-optional
 
+# Custom install script to force using ant instead of gradle if travis detects a build.gradle file.
+install: 
+  # Using clean as dummy target; could install dependencies here if needed.
+  - ant clean
+  
 # Use xvfb to run tests that require a GUI and give it some time to start
 before_script:
   - "export DISPLAY=:99.0"


### PR DESCRIPTION
### Description of the Change
The default WorldWindJava build process uses Apache Ant. This change to the Travis configuration ensures that `ant` is used even if Gradle or Maven build configuration files are detected by Travis-CI.

### Why Should This Be In Core?
This change ensures the prescribed build process is followed.

### Benefits
Without this change, Gradle or Maven could be used by Travis instead of `ant` .

### Potential Drawbacks
None.

### Applicable Issues
PR #30 
Issue #11 