### PR TITLE
MacOS surface-scale fix

### DIFF
--- a/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
@@ -57,7 +57,7 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 {
     /** The drawable to which {@link WorldWindow} methods are delegated. */
     protected final WorldWindowGLDrawable wwd; // WorldWindow interface delegates to wwd
-
+    
     /** Constructs a new <code>WorldWindowGLCanvas</code> on the default graphics device. */
     public WorldWindowGLCanvas()
     {
@@ -65,6 +65,8 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 
         try
         {
+            float[] surfaceScale = {1.0f, 1.0f};
+            setSurfaceScale(surfaceScale);
             this.wwd = ((WorldWindowGLDrawable) WorldWind.createConfigurationComponent(AVKey.WORLD_WINDOW_CLASS_NAME));
             this.wwd.initDrawable(this);
             this.wwd.addPropertyChangeListener(this);
@@ -100,6 +102,8 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 
         try
         {
+            float[] surfaceScale = {1.0f, 1.0f};
+            setSurfaceScale(surfaceScale);
             this.wwd = ((WorldWindowGLDrawable) WorldWind.createConfigurationComponent(AVKey.WORLD_WINDOW_CLASS_NAME));
             this.wwd.initDrawable(this);
             this.wwd.addPropertyChangeListener(this);
@@ -140,6 +144,8 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 
         try
         {
+            float[] surfaceScale = {1.0f, 1.0f};
+            setSurfaceScale(surfaceScale);
             this.wwd = ((WorldWindowGLDrawable) WorldWind.createConfigurationComponent(AVKey.WORLD_WINDOW_CLASS_NAME));
             this.wwd.initDrawable(this);
             this.wwd.addPropertyChangeListener(this);
@@ -185,6 +191,8 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 
         try
         {
+            float[] surfaceScale = {1.0f, 1.0f};
+            setSurfaceScale(surfaceScale);
             this.wwd = ((WorldWindowGLDrawable) WorldWind.createConfigurationComponent(AVKey.WORLD_WINDOW_CLASS_NAME));
             this.wwd.initDrawable(this);
             if (shareWith != null)

--- a/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
+++ b/src/gov/nasa/worldwind/awt/WorldWindowGLCanvas.java
@@ -65,8 +65,7 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 
         try
         {
-            float[] surfaceScale = {1.0f, 1.0f};
-            setSurfaceScale(surfaceScale);
+            initializeSurfaceScale();
             this.wwd = ((WorldWindowGLDrawable) WorldWind.createConfigurationComponent(AVKey.WORLD_WINDOW_CLASS_NAME));
             this.wwd.initDrawable(this);
             this.wwd.addPropertyChangeListener(this);
@@ -102,8 +101,7 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 
         try
         {
-            float[] surfaceScale = {1.0f, 1.0f};
-            setSurfaceScale(surfaceScale);
+            initializeSurfaceScale();
             this.wwd = ((WorldWindowGLDrawable) WorldWind.createConfigurationComponent(AVKey.WORLD_WINDOW_CLASS_NAME));
             this.wwd.initDrawable(this);
             this.wwd.addPropertyChangeListener(this);
@@ -144,8 +142,7 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 
         try
         {
-            float[] surfaceScale = {1.0f, 1.0f};
-            setSurfaceScale(surfaceScale);
+            initializeSurfaceScale();
             this.wwd = ((WorldWindowGLDrawable) WorldWind.createConfigurationComponent(AVKey.WORLD_WINDOW_CLASS_NAME));
             this.wwd.initDrawable(this);
             this.wwd.addPropertyChangeListener(this);
@@ -191,8 +188,7 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
 
         try
         {
-            float[] surfaceScale = {1.0f, 1.0f};
-            setSurfaceScale(surfaceScale);
+            initializeSurfaceScale();
             this.wwd = ((WorldWindowGLDrawable) WorldWind.createConfigurationComponent(AVKey.WORLD_WINDOW_CLASS_NAME));
             this.wwd.initDrawable(this);
             if (shareWith != null)
@@ -210,6 +206,12 @@ public class WorldWindowGLCanvas extends GLCanvas implements WorldWindow, Proper
             Logging.logger().severe(message);
             throw new WWRuntimeException(message, e);
         }
+    }
+    
+    private void initializeSurfaceScale()
+    {
+        float[] surfaceScale = {1.0f, 1.0f};
+        setSurfaceScale(surfaceScale);
     }
 
     public void propertyChange(PropertyChangeEvent evt)


### PR DESCRIPTION
### Description of the Change
According to @pcmehlitz, if we update to the latest version of JOGL and we do not explicitly set the surface-scale factor to 1.0 in the different constructors of WorldWindowGLCanvas, we will end up with a
surface-scale factor of 2.0 on MacOS machines with high-DPI displays. To quote his original commit-message:

"there is one more serious issue that manifests at least on OX X machines with high DPI (e.g. Macbook Pros with retina display). If we do not explicitly request pixel scale factors of 1.0 in the worldwind.awt.WorldWindowGLCanvas, we end up with factors of 2.0 after the GLCanvas is realized, which then causes all AWTInputHandler mouse callbacks to receive MouseEvents with wrong coordinates (0.5 of what they should be), which in turn causes operations that compute world coordinates from screen coordinates to fail (e.g. click-to-re-center)."

See: https://github.com/pcmehlitz/WorldWindJava/commit/3c8322d18a8db33cd219af35c2d0d98222706a8e

Unfortunately I do not own a Mac, so I can't test this on my side. Can we get this tested by someone else to confirm that it works.

### Why Should This Be In Core?
Critical bug-fix for MacOS users.

### Benefits
Improving the stability of the code-base.

### Potential Drawbacks
None

### Applicable Issues
None