### PR TITLE
Wcs error handling

### DIFF
--- a/src/gov/nasa/worldwind/data/BasicRasterServer.java
+++ b/src/gov/nasa/worldwind/data/BasicRasterServer.java
@@ -140,6 +140,8 @@ public class BasicRasterServer extends WWObjectImpl implements RasterServer
             String message = Logging.getMessage("generic.DataSetLimitedAvailability", this.getDataSetName() );
             Logging.logger().severe(message);
         }
+        
+        config.dispose();
     }
 
     protected String getDataSetName()

--- a/src/gov/nasa/worldwind/data/RasterServerConfiguration.java
+++ b/src/gov/nasa/worldwind/data/RasterServerConfiguration.java
@@ -143,6 +143,16 @@ public class RasterServerConfiguration extends AbstractXMLEventParser
 
         this.initialize();
     }
+    
+    public void dispose() {
+    	try {
+			eventReader.close();
+		} catch (XMLStreamException e) {
+			e.printStackTrace();
+		}
+    	WWXML.closeEventReader(eventReader, "RasterServerConfiguration");
+    	freeResources();
+    }
 
     protected void initialize()
     {

--- a/src/gov/nasa/worldwind/data/RasterServerConfiguration.java
+++ b/src/gov/nasa/worldwind/data/RasterServerConfiguration.java
@@ -144,14 +144,18 @@ public class RasterServerConfiguration extends AbstractXMLEventParser
         this.initialize();
     }
     
-    public void dispose() {
-    	try {
-			eventReader.close();
-		} catch (XMLStreamException e) {
-			e.printStackTrace();
-		}
-    	WWXML.closeEventReader(eventReader, "RasterServerConfiguration");
-    	freeResources();
+    public void dispose()
+    {
+        try
+        {
+            eventReader.close();
+        }
+        catch (XMLStreamException e)
+        {
+            e.printStackTrace();
+        }
+        WWXML.closeEventReader(eventReader, "RasterServerConfiguration");
+        freeResources();
     }
 
     protected void initialize()

--- a/src/gov/nasa/worldwind/terrain/BasicElevationModel.java
+++ b/src/gov/nasa/worldwind/terrain/BasicElevationModel.java
@@ -385,6 +385,8 @@ public class BasicElevationModel extends AbstractElevationModel implements BulkR
         Angle minLongitude = ElevationTile.computeColumnLongitude(key.getColumn(), dLon, lonOrigin);
 
         Sector tileSector = new Sector(minLatitude, minLatitude.add(dLat), minLongitude, minLongitude.add(dLon));
+        // Clip tile sector by the layer's coverage extent
+        tileSector = levels.getSector().intersection(tileSector);
 
         return new ElevationTile(tileSector, level, key.getRow(), key.getColumn());
     }

--- a/src/gov/nasa/worldwind/util/DataConfigurationUtils.java
+++ b/src/gov/nasa/worldwind/util/DataConfigurationUtils.java
@@ -766,8 +766,9 @@ public class DataConfigurationUtils
                 WMSLayerCapabilities layerCaps = caps.getLayerByName(name);
                 if (layerCaps == null)
                 {
-                    Logging.logger().warning(Logging.getMessage("WMS.LayerNameMissing", name));
-                    continue;
+                    String msg = Logging.getMessage("WMS.LayerNameMissing", name);
+                    Logging.logger().warning(msg);
+                    throw new WWRuntimeException(msg);
                 }
 
                 if (layerCaps.hasCoordinateSystem("EPSG:4326"))
@@ -912,6 +913,13 @@ public class DataConfigurationUtils
         if (coverage == null)
         {
             String message = Logging.getMessage("nullValue.WCSDescribeCoverage");
+            Logging.logger().severe(message);
+            throw new IllegalArgumentException(message);
+        }
+
+        if (coverage.getCoverageOfferings().size() == 0)
+        {
+        	String message = Logging.getMessage("AbsentResourceList.WCSDescribeCoverage");
             Logging.logger().severe(message);
             throw new IllegalArgumentException(message);
         }
@@ -1148,6 +1156,8 @@ public class DataConfigurationUtils
 
             String layerName = lNames[i];
             WMSLayerCapabilities layer = caps.getLayerByName(layerName);
+            if (layer == null) continue;		// layer not found
+
             String layerTitle = layer.getTitle();
             sb.append(layerTitle != null ? layerTitle : layerName);
 

--- a/src/gov/nasa/worldwind/util/DataConfigurationUtils.java
+++ b/src/gov/nasa/worldwind/util/DataConfigurationUtils.java
@@ -919,7 +919,7 @@ public class DataConfigurationUtils
 
         if (coverage.getCoverageOfferings().size() == 0)
         {
-        	String message = Logging.getMessage("AbsentResourceList.WCSDescribeCoverage");
+            String message = Logging.getMessage("AbsentResourceList.WCSDescribeCoverage");
             Logging.logger().severe(message);
             throw new IllegalArgumentException(message);
         }
@@ -1156,7 +1156,10 @@ public class DataConfigurationUtils
 
             String layerName = lNames[i];
             WMSLayerCapabilities layer = caps.getLayerByName(layerName);
-            if (layer == null) continue;		// layer not found
+            if (layer == null)
+            {
+                continue; // layer not found
+            }
 
             String layerTitle = layer.getTitle();
             sb.append(layerTitle != null ? layerTitle : layerName);

--- a/src/gov/nasa/worldwind/util/MessageStrings.properties
+++ b/src/gov/nasa/worldwind/util/MessageStrings.properties
@@ -743,6 +743,7 @@ AbsentResourceList.MaxTriesLessThanOne=The specified maximum number of tries is 
 AbsentResourceList.CheckIntervalLessThanZero=The specified check interval is less than 0
 AbsentResourceList.RetryIntervalLessThanZero=The specified retry interval is less than 0
 AbsentResourceList.MaximumListSizeLessThanOne=The requested maximum list size is less than 1
+AbsentResourceList.WCSDescribeCoverage=No coverage offering from WCS
 
 AVAAccessibleImpl.AttributeValueForKeyIsNotAString=Attribute value for key is not a String. Key {0}
 

--- a/src/gov/nasa/worldwind/util/WWXML.java
+++ b/src/gov/nasa/worldwind/util/WWXML.java
@@ -39,6 +39,8 @@ public class WWXML
 {
     public static final String XLINK_URI = "http://www.w3.org/1999/xlink";
 
+    private static Map<XMLEventReader, InputStream> inputSources = new HashMap<XMLEventReader, InputStream>();
+    
     /**
      * Create a DOM builder.
      *
@@ -170,9 +172,12 @@ public class WWXML
             throw new IllegalArgumentException(message);
         }
 
-        InputStream inputStream = WWIO.openFileOrResourceStream(filePath, c);
-
-        return inputStream != null ? openDocumentStream(inputStream) : null;
+        try (InputStream inputStream = WWIO.openFileOrResourceStream(filePath, c)) {
+        	return inputStream != null ? openDocumentStream(inputStream) : null;
+        } catch (IOException e) {
+        	e.printStackTrace();
+        	return null;
+        }
     }
 
     /**
@@ -273,10 +278,7 @@ public class WWXML
             throw new IllegalArgumentException(message);
         }
 
-        try
-        {
-            java.io.FileOutputStream outputStream = new java.io.FileOutputStream(filePath);
-
+        try (java.io.FileOutputStream outputStream = new java.io.FileOutputStream(filePath)) {
             saveDocumentToStream(doc, outputStream);
         }
         catch (IOException e)
@@ -356,7 +358,9 @@ public class WWXML
 
         try
         {
-            return inputFactory.createXMLEventReader(inputStream);
+        	XMLEventReader reader = inputFactory.createXMLEventReader(inputStream);
+            inputSources.put(reader, inputStream);
+            return reader;
         }
         catch (XMLStreamException e)
         {
@@ -440,7 +444,9 @@ public class WWXML
         try
         {
             InputStream inputStream = url.openStream();
-            return openEventReaderStream(inputStream, isNamespaceAware);
+            XMLEventReader reader = openEventReaderStream(inputStream, isNamespaceAware);
+            inputSources.put(reader, inputStream);
+            return reader;
         }
         catch (IOException e)
         {
@@ -531,6 +537,15 @@ public class WWXML
         try
         {
             eventReader.close();
+            InputStream is = inputSources.get(eventReader);
+            if (is != null) {
+            	try {
+					is.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+            	inputSources.remove(eventReader);
+            }
         }
         catch (XMLStreamException e)
         {

--- a/src/gov/nasa/worldwind/util/WWXML.java
+++ b/src/gov/nasa/worldwind/util/WWXML.java
@@ -178,7 +178,8 @@ public class WWXML
         }
         catch (IOException e)
         {
-            e.printStackTrace();
+            String message = Logging.getMessage("generic.ExceptionClosingStream", filePath);
+            Logging.logger().severe(message);
             return null;
         }
     }
@@ -552,7 +553,9 @@ public class WWXML
                 }
                 catch (IOException e)
                 {
-                    e.printStackTrace();
+                    String message = Logging.getMessage("generic.ExceptionClosingStream",
+                        name != null ? name : "Unknown");
+                    Logging.logger().severe(message);
                 }
                 inputSources.remove(eventReader);
             }

--- a/src/gov/nasa/worldwind/util/WWXML.java
+++ b/src/gov/nasa/worldwind/util/WWXML.java
@@ -172,11 +172,14 @@ public class WWXML
             throw new IllegalArgumentException(message);
         }
 
-        try (InputStream inputStream = WWIO.openFileOrResourceStream(filePath, c)) {
-        	return inputStream != null ? openDocumentStream(inputStream) : null;
-        } catch (IOException e) {
-        	e.printStackTrace();
-        	return null;
+        try (InputStream inputStream = WWIO.openFileOrResourceStream(filePath, c))
+        {
+            return inputStream != null ? openDocumentStream(inputStream) : null;
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+            return null;
         }
     }
 
@@ -278,7 +281,8 @@ public class WWXML
             throw new IllegalArgumentException(message);
         }
 
-        try (java.io.FileOutputStream outputStream = new java.io.FileOutputStream(filePath)) {
+        try (java.io.FileOutputStream outputStream = new java.io.FileOutputStream(filePath))
+        {
             saveDocumentToStream(doc, outputStream);
         }
         catch (IOException e)
@@ -358,7 +362,7 @@ public class WWXML
 
         try
         {
-        	XMLEventReader reader = inputFactory.createXMLEventReader(inputStream);
+            XMLEventReader reader = inputFactory.createXMLEventReader(inputStream);
             inputSources.put(reader, inputStream);
             return reader;
         }
@@ -532,19 +536,25 @@ public class WWXML
     public static void closeEventReader(XMLEventReader eventReader, String name)
     {
         if (eventReader == null)
+        {
             return;
+        }
 
         try
         {
             eventReader.close();
             InputStream is = inputSources.get(eventReader);
-            if (is != null) {
-            	try {
-					is.close();
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-            	inputSources.remove(eventReader);
+            if (is != null)
+            {
+                try
+                {
+                    is.close();
+                }
+                catch (IOException e)
+                {
+                    e.printStackTrace();
+                }
+                inputSources.remove(eventReader);
             }
         }
         catch (XMLStreamException e)

--- a/src/gov/nasa/worldwindx/examples/layermanager/ElevationModelManagerPanel.java
+++ b/src/gov/nasa/worldwindx/examples/layermanager/ElevationModelManagerPanel.java
@@ -127,7 +127,8 @@ public class ElevationModelManagerPanel extends JPanel
 
         if (!(wwd.getModel().getGlobe().getElevationModel() instanceof CompoundElevationModel))
         {
-            return this.modelPanels.get(0).getElevationModel() == wwd.getModel().getGlobe().getElevationModel();
+           if (this.modelPanels.size() == 0) return false;
+           return this.modelPanels.get(0).getElevationModel() == wwd.getModel().getGlobe().getElevationModel();
         }
 
         CompoundElevationModel cem = (CompoundElevationModel) wwd.getModel().getGlobe().getElevationModel();

--- a/src/gov/nasa/worldwindx/examples/layermanager/ElevationModelManagerPanel.java
+++ b/src/gov/nasa/worldwindx/examples/layermanager/ElevationModelManagerPanel.java
@@ -55,7 +55,9 @@ public class ElevationModelManagerPanel extends JPanel
             public void propertyChange(PropertyChangeEvent propertyChangeEvent)
             {
                 if (propertyChangeEvent.getPropertyName().equals(AVKey.ELEVATION_MODEL))
+                {
                     if (!SwingUtilities.isEventDispatchThread())
+                    {
                         SwingUtilities.invokeLater(new Runnable()
                         {
                             public void run()
@@ -69,8 +71,12 @@ public class ElevationModelManagerPanel extends JPanel
                                 });
                             }
                         });
+                    }
                     else
+                    {
                         update(wwd);
+                    }
+                }
             }
         });
     }
@@ -89,7 +95,9 @@ public class ElevationModelManagerPanel extends JPanel
         // Populate this manager with an entry for each elevation model in the WorldWindow.
 
         if (this.isUpToDate(wwd))
+        {
             return;
+        }
 
         // First remove all the existing entries.
         this.modelPanels.clear();
@@ -111,7 +119,9 @@ public class ElevationModelManagerPanel extends JPanel
             for (ElevationModel elevationModel : cem.getElevationModels())
             {
                 if (elevationModel.getValue(AVKey.IGNORE) != null)
+                {
                     continue;
+                }
 
                 ElevationModelPanel elevationModelPanel = new ElevationModelPanel(wwd, this, elevationModel);
                 this.modelPanels.add(elevationModelPanel);
@@ -127,19 +137,26 @@ public class ElevationModelManagerPanel extends JPanel
 
         if (!(wwd.getModel().getGlobe().getElevationModel() instanceof CompoundElevationModel))
         {
-           if (this.modelPanels.size() == 0) return false;
+           if (this.modelPanels.size() == 0)
+           {
+               return false;
+           }
            return this.modelPanels.get(0).getElevationModel() == wwd.getModel().getGlobe().getElevationModel();
         }
 
         CompoundElevationModel cem = (CompoundElevationModel) wwd.getModel().getGlobe().getElevationModel();
 
         if (this.modelPanels.size() != cem.getElevationModels().size())
+        {
             return false;
+        }
 
         for (int i = 0; i < cem.getElevationModels().size(); i++)
         {
             if (cem.getElevationModels().get(i) != this.modelPanels.get(i).getElevationModel())
+            {
                 return false;
+            }
         }
 
         return true;

--- a/src/gov/nasa/worldwindx/examples/util/WCSCoveragePanel.java
+++ b/src/gov/nasa/worldwindx/examples/util/WCSCoveragePanel.java
@@ -100,7 +100,9 @@ public class WCSCoveragePanel extends JPanel
         {
             e.printStackTrace();
             Container c = WCSCoveragePanel.this.getParent();
-            c.remove(WCSCoveragePanel.this);
+            if (c != null)
+            	c.remove(WCSCoveragePanel.this);
+            
             JOptionPane.showMessageDialog((Component) wwd, "Unable to connect to server " + serverURI.toString(),
                 "Server Error", JOptionPane.ERROR_MESSAGE);
             return;
@@ -192,8 +194,10 @@ public class WCSCoveragePanel extends JPanel
             // If the coverage is selected, add it to the WorldWindow's current model, else remove it from the model.
             if (((JCheckBox) actionEvent.getSource()).isSelected())
             {
-                if (this.component == null)
+                if (this.component == null) {
                     this.component = createComponent(coverageInfo.caps, coverageInfo);
+                    if (this.component == null) return;
+                }
 
                 updateComponent(this.component, true);
             }
@@ -224,8 +228,18 @@ public class WCSCoveragePanel extends JPanel
     protected void updateComponent(Object component, boolean enable)
     {
         ElevationModel model = (ElevationModel) component;
-        CompoundElevationModel compoundModel =
-            (CompoundElevationModel) this.wwd.getModel().getGlobe().getElevationModel();
+        CompoundElevationModel compoundModel;
+
+        // Guarantee that we have a compound elevation model, so additional elevation models can be added.
+        ElevationModel em = this.wwd.getModel().getGlobe().getElevationModel();
+
+        if (!(em instanceof CompoundElevationModel)) {
+        	compoundModel = new CompoundElevationModel();
+        	compoundModel.addElevationModel(em);
+        	this.wwd.getModel().getGlobe().setElevationModel(compoundModel);
+        } else {
+        	compoundModel = (CompoundElevationModel) em;
+        }
 
         if (enable)
         {

--- a/src/gov/nasa/worldwindx/examples/util/WCSCoveragePanel.java
+++ b/src/gov/nasa/worldwindx/examples/util/WCSCoveragePanel.java
@@ -101,7 +101,9 @@ public class WCSCoveragePanel extends JPanel
             e.printStackTrace();
             Container c = WCSCoveragePanel.this.getParent();
             if (c != null)
-            	c.remove(WCSCoveragePanel.this);
+            {
+                c.remove(WCSCoveragePanel.this);
+            }
             
             JOptionPane.showMessageDialog((Component) wwd, "Unable to connect to server " + serverURI.toString(),
                 "Server Error", JOptionPane.ERROR_MESSAGE);
@@ -110,7 +112,9 @@ public class WCSCoveragePanel extends JPanel
 
         final java.util.List<WCS100CoverageOfferingBrief> coverages = caps.getContentMetadata().getCoverageOfferings();
         if (coverages == null)
+        {
             return;
+        }
 
         try
         {
@@ -194,9 +198,13 @@ public class WCSCoveragePanel extends JPanel
             // If the coverage is selected, add it to the WorldWindow's current model, else remove it from the model.
             if (((JCheckBox) actionEvent.getSource()).isSelected())
             {
-                if (this.component == null) {
+                if (this.component == null)
+                {
                     this.component = createComponent(coverageInfo.caps, coverageInfo);
-                    if (this.component == null) return;
+                    if (this.component == null)
+                    {
+                        return;
+                    }
                 }
 
                 updateComponent(this.component, true);
@@ -204,7 +212,9 @@ public class WCSCoveragePanel extends JPanel
             else
             {
                 if (this.component != null)
+                {
                     updateComponent(this.component, false);
+                }
             }
 
             // Tell the WorldWindow to update.
@@ -233,18 +243,23 @@ public class WCSCoveragePanel extends JPanel
         // Guarantee that we have a compound elevation model, so additional elevation models can be added.
         ElevationModel em = this.wwd.getModel().getGlobe().getElevationModel();
 
-        if (!(em instanceof CompoundElevationModel)) {
-        	compoundModel = new CompoundElevationModel();
-        	compoundModel.addElevationModel(em);
-        	this.wwd.getModel().getGlobe().setElevationModel(compoundModel);
-        } else {
-        	compoundModel = (CompoundElevationModel) em;
+        if (!(em instanceof CompoundElevationModel))
+        {
+            compoundModel = new CompoundElevationModel();
+            compoundModel.addElevationModel(em);
+            this.wwd.getModel().getGlobe().setElevationModel(compoundModel);
+        }
+        else
+        {
+            compoundModel = (CompoundElevationModel) em;
         }
 
         if (enable)
         {
             if (!compoundModel.getElevationModels().contains(model))
+            {
                 compoundModel.addElevationModel(model);
+            }
         }
         else
         {


### PR DESCRIPTION
Description of the Change
    • bug fix: request to WCS is clipped to Sector size of data available on the server. Mapserver will return an error if the request is for a region outside of the extent of the layer. See forum 158241. 
    • add error handling for WCS operations 
    • avoid memory/resource leaks 

Why Should This Be In Core?
Avoid errors when using Mapserver WCS to serve elevation data. Provide more useful error reporting when using a WCS server. Avoid memory/resource leaks.

Benefits

Potential Drawbacks
I was a bit concerned of the effect clipping the tile size to what's in the server would have on other code in the system. As far as I could tell, the ElevationModel correctly handles missing data, and if a request is made for data outside the clipped tile, the next ElevationModel in the list will be checked.