### PR TITLE
Publish artifacts to Maven central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,13 @@ script:
 
 # Deploy develop branch javadocs to gh_pages, and create and deploy CHANGELOG.md on tags
 deploy:
+  # Publish SNAPSHOT artifacts to oss.jfrog.org
+  - provider: script
+    script: ./gradlew artifactoryPublish -Psnapshot -Pbuild.number=$TRAVIS_BUILD_NUMBER --stacktrace
+    skip_cleanup: true
+    on:
+      branch: develop
+      jdk: oraclejdk8
   # Publish API documentation to GitHub Pages
   - provider: pages
     github_token: $GITHUB_API_KEY
@@ -58,6 +65,13 @@ deploy:
     skip_cleanup: true
     on:
       branch: develop
+      jdk: oraclejdk8
+  # Publish release artifacts to Bintray/JCenter
+  - provider: script
+    script: ./gradlew bintrayUpload -Prelease --stacktrace
+    skip_cleanup: true
+    on:
+      tags: true
       jdk: oraclejdk8
   # Create CHANGELOG.md in the current directory
   - provider: script

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,19 @@
+buildscript {
+    dependencies {
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:latest.release'
+    }
+}
+
+plugins {
+    id 'com.jfrog.bintray' version '1.8.1'
+}
+
 apply plugin: 'java'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
 
 group = 'earth.worldwind'
-version = '2.2.0'
+version = '2.2.0' + (project.hasProperty('snapshot') ? '-SNAPSHOT' : '')
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
@@ -30,6 +42,134 @@ dependencies {
     testImplementation "junit:junit:${project.junitVersion}"
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    group = 'build'
+    description = 'Assembles a jar archive containing the sources.'
+    classifier = 'sources'
+    from (sourceSets.main.allSource) {
+        include '**/*.java'
+        exclude 'config/**'
+        exclude 'images/**'
+        exclude 'gov/nasa/worldwindx/**'
+    }
+}
+
+task extensionsJar(type: Jar) {
+    group = 'build'
+    description = 'Assembles a jar archive containing the extension classes.'
+    baseName = 'worldwindx'
+    from (sourceSets.main.output) {
+        exclude 'com/**'
+        exclude 'config/**'
+        exclude 'images/**'
+        exclude 'gov/nasa/worldwind/**'
+    }
+}
+extensionsJar.doLast {
+    copy {
+        from "$buildDir/libs/${extensionsJar.archiveName}"
+        into "${project.projectDir}"
+        rename "${extensionsJar.archiveName}", "${extensionsJar.baseName}.${extensionsJar.extension}"
+    }
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    group = 'build'
+    description = 'Assembles a jar archive containing the javadocs.'
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+def pomConfig = {
+    licenses {
+        license {
+            name 'NASA Open Source Agreement v1.3'
+            url 'https://ti.arc.nasa.gov/opensource/nosa/'
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id 'emxsys'
+            name 'Bruce Schubert'
+            email 'bruce@emxsys.com'
+        }
+    }
+    scm {
+       url "https://github.com/WorldWindEarth/WorldWindJava"
+    }
+}
+
+publishing {
+    publications {
+        bintray(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            groupId project.group
+            artifactId project.name
+            version project.version
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description',
+                    'A community supported fork of the NASA WorldWind Java SDK (WWJ)' +
+                    'is for building cross-platform 3D geospatial desktop applications in Java.'
+                )
+                root.appendNode('name', project.name)
+                root.appendNode('url', 'https://github.com/WorldWindEarth/WorldWindJava')
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['bintray']
+    pkg {
+        repo = System.getenv('BINTRAY_REPOSITORY')
+        name = System.getenv('BINTRAY_PACKAGE')
+        userOrg = System.getenv('BINTRAY_ORGANIZATION')
+        desc = 'A community supported fork of the NASA WorldWind Java SDK (WWJ) ' +
+            'is for building cross-platform 3D geospatial desktop applications in Java.'
+        websiteUrl = 'https://worldwind.earth'
+        issueTrackerUrl = 'https://github.com/WorldWindEarth/WorldWindJava/issues'
+        vcsUrl = 'https://github.com/WorldWindEarth/WorldWindJava'
+        licenses = ['NASA-1.3']
+        labels = ['nasa', 'worldwind', 'worldwindjava', 'gis', 'geospatial',
+            'globe', '3d', 'jogl', 'maps', 'imagery', 'terrain',
+            'visualization', 'wms', 'wmts', 'shapes', 'shapefile', 'kml',
+            'opengl', 'sdk-java', 'community-edition'
+        ]
+        githubRepo = 'WorldWindEarth/WorldWindJava'
+        version {
+            name = project.version
+            desc = 'WorldWind v' + project.version
+            vcsTag = System.getenv('TRAVIS_TAG')
+            released = new Date()
+        }
+    }
+}
+
+artifactory {
+    contextUrl = 'https://oss.jfrog.org/artifactory'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = System.getenv('BINTRAY_USER')
+            password = System.getenv('BINTRAY_API_KEY')
+        }
+        defaults {
+            publications('bintray')
+            publishArtifacts = true
+        }
+    }
+    if (project.hasProperty('build.number')) {
+        clientConfig.info.setBuildNumber(project.getProperty('build.number'))
+    }
+}
+
 sourceSets {
     main {
         java {
@@ -49,52 +189,25 @@ sourceSets {
 }
 
 compileJava {
-    options.debug = !project.hasProperty("releaseBuild")
-}
-
-// Compile worldwind jar.
-jar {
-    dependsOn classes
-    version = null
-    from sourceSets.main.output
-    exclude 'gov/nasa/worldwindx/**'
-}
-// Copy worldwind jar to project-directory.
-jar.doLast {
-    copy {
-        from "$buildDir/libs/${jar.archiveName}"
-        into "${project.projectDir}"
-    }
-}
-
-// Compile worldwindx jar.
-task extensionsJar(type: Jar) {
-    group = 'build'
-    description = 'Assembles a jar archive containing the extension classes.'
-    baseName = 'worldwindx'
-    version = null
-    from (sourceSets.main.output) {
-        exclude 'com/**'
-        exclude 'config/**'
-        exclude 'images/**'
-        exclude 'gov/nasa/worldwind/**'
-    }
-}
-// Copy worldwindx jar to project-directory.
-extensionsJar.doLast {
-    copy {
-        from "$buildDir/libs/${extensionsJar.archiveName}"
-        into "${project.projectDir}"
-    }
-}
-
-artifacts {
-    archives extensionsJar
+    options.debug = !project.hasProperty('release')
 }
 
 test {
     dependsOn jar
     classpath += project.files("$buildDir/libs/${jar.archiveName}", configurations.runtime)
+}
+
+jar {
+    dependsOn classes
+    from sourceSets.main.output
+    exclude 'gov/nasa/worldwindx/**'
+}
+jar.doLast {
+    copy {
+        from "$buildDir/libs/${jar.archiveName}"
+        into "${project.projectDir}"
+        rename "${jar.archiveName}", "${jar.baseName}.${jar.extension}"
+    }
 }
 
 javadoc {
@@ -111,4 +224,10 @@ javadoc {
     }
     exclude 'com/**'
     exclude 'gov/nasa/worldwind/formats/**'
+}
+
+artifacts {
+    archives sourcesJar
+    archives extensionsJar
+    archives javadocJar
 }


### PR DESCRIPTION
### Description of the Change
Modified the `build.gradle` and `travis.yml` files to allow us to publish snapshots to artifactory and releases to bintray depending on whether the Travis build has been done on the `develop` branch or a release-tag. The changes are similar to the way in which artifacts are published for WorldWindAndroid with a couple of differences here and there that are specific to this project.

### Why Should This Be In Core?
We want to get to a point where WorldWind can be pulled in as a dependency via Maven. At the moment other non-official jars have been published that might be outdated. By adding these changes we ensure that our latest Travis builds get published so that they can be used by other 3rd-party projects.

### Benefits
By allowing our `develop` branch to be built on a regular basis and published as a snapshot version would allow for easier testing of unstable features. We also ensure that our latest stable branch can be pulled in easily via Maven and that 3rd-party projects are using the correct version.

### Potential Drawbacks
None

### Applicable Issues
Issue #36