### PR TITLE
Restore possibility to tilt 2D globe

### DIFF
--- a/src/config/worldwind.xml
+++ b/src/config/worldwind.xml
@@ -88,6 +88,7 @@
     <Property name="gov.nasa.worldwind.avkey.RectangularTessellatorMaxLevel" value="30"/>
     <Property name="gov.nasa.worldwind.StereoFocusAngle" value="1.6"/>
     <Property name="gov.nasa.worldwind.avkey.ForceRedrawOnMousePressed" value="f"/>
+    <Property name="gov.nasa.worldwind.avkey.Allow2DPitch" value="f"/>
     <!-- Here's one way to specify proxy settings -->
     <!--<Property name="gov.nasa.worldwind.avkey.UrlProxyHost" value="100.215.10.20"/>-->
     <!--<Property name="gov.nasa.worldwind.avkey.UrlProxyPort" value="8080"/>-->

--- a/src/gov/nasa/worldwind/avlist/AVKey.java
+++ b/src/gov/nasa/worldwind/avlist/AVKey.java
@@ -26,6 +26,7 @@ public interface AVKey // TODO: Eliminate unused constants, if any
     final String ACTION = "gov.nasa.worldwind.avkey.Action";
     final String AIRSPACE_GEOMETRY_CACHE_SIZE = "gov.nasa.worldwind.avkey.AirspaceGeometryCacheSize";
     final String ALLOW = "gov.nasa.worldwind.avkey.Allow";
+    final String ALLOW_2D_PITCH = "gov.nasa.worldwind.avkey.Allow2DPitch";
     final String AUTH_TOKEN = "gov.nasa.worldwind.avkey.AuthToken";
 
     final String AVAILABLE_IMAGE_FORMATS = "gov.nasa.worldwind.avkey.AvailableImageFormats";

--- a/src/gov/nasa/worldwind/view/BasicViewPropertyLimits.java
+++ b/src/gov/nasa/worldwind/view/BasicViewPropertyLimits.java
@@ -5,7 +5,8 @@
  */
 package gov.nasa.worldwind.view;
 
-import gov.nasa.worldwind.View;
+import gov.nasa.worldwind.*;
+import gov.nasa.worldwind.avlist.AVKey;
 import gov.nasa.worldwind.geom.*;
 import gov.nasa.worldwind.globes.*;
 import gov.nasa.worldwind.util.*;
@@ -220,6 +221,11 @@ public class BasicViewPropertyLimits implements ViewPropertyLimits
             throw new IllegalArgumentException(message);
         }
 
+        if (this.is2DGlobe(view.getGlobe()) && !this.allow2DPitch())
+        {
+            return Angle.ZERO; // keep the view looking straight down on 2D globes
+        }
+
         return Angle.clamp(angle, this.minPitch, this.maxPitch);
     }
 
@@ -247,6 +253,11 @@ public class BasicViewPropertyLimits implements ViewPropertyLimits
     protected boolean is2DGlobe(Globe globe)
     {
         return globe instanceof Globe2D;
+    }
+    
+    protected boolean allow2DPitch()
+    {
+        return Configuration.getBooleanValue(AVKey.ALLOW_2D_PITCH, Boolean.FALSE);
     }
 
     protected boolean isNonContinous2DGlobe(Globe globe)

--- a/src/gov/nasa/worldwind/view/BasicViewPropertyLimits.java
+++ b/src/gov/nasa/worldwind/view/BasicViewPropertyLimits.java
@@ -220,11 +220,6 @@ public class BasicViewPropertyLimits implements ViewPropertyLimits
             throw new IllegalArgumentException(message);
         }
 
-        if (this.is2DGlobe(view.getGlobe()))
-        {
-            return Angle.ZERO; // keep the view looking straight down on 2D globes
-        }
-
         return Angle.clamp(angle, this.minPitch, this.maxPitch);
     }
 


### PR DESCRIPTION
### Description of the Change

Restore the possibility to tilt the view when in "Flat" 2D mode, effectively creating a 2.5D view.

### Why Should This Be In Core?

WorldWind v. 2.0.0 and earlier always allowed to pitch the view in 2D mode, which is a useful "core" functionality. For unknown reason, WorldWind v. 2.1.0 removed this possibility. 

### Benefits

The pitch buttons as well a mouse gestures (Shift-drag) are functional in all view modes.

### Potential Drawbacks

This alter the default behavior compared to WorldView v. 2.1.0, which removed the possibility of any tilting by hard-coding it in BasicViewPropertyLimits#limitPitch(View, Angle). However, this behavior can easily be recreated by customizing the ViewPropertyLimits with setPitchLimits(Angle.ZERO, Angle.ZERO).

### Applicable Issues

Tilting Globe no longer possible #51
