### PR TITLE
Fixed null-Globe bug in FlyToOrbitViewAnimator.

### DIFF
--- a/src/gov/nasa/worldwind/view/orbit/FlyToOrbitViewAnimator.java
+++ b/src/gov/nasa/worldwind/view/orbit/FlyToOrbitViewAnimator.java
@@ -51,7 +51,7 @@ public class FlyToOrbitViewAnimator extends CompoundAnimator
         Angle beginPitch, Angle endPitch,
         double beginZoom, double endZoom, long timeToMove, int altitudeMode)
     {
-        OnSurfacePositionAnimator centerAnimator = new OnSurfacePositionAnimator(orbitView.getGlobe(),
+        OnSurfacePositionAnimator centerAnimator = new OnSurfacePositionAnimator(orbitView,
             new ScheduledInterpolator(timeToMove),
             beginCenterPos, endCenterPos,
             OrbitViewPropertyAccessor.createCenterPositionAccessor(
@@ -84,17 +84,17 @@ public class FlyToOrbitViewAnimator extends CompoundAnimator
 
     protected static class OnSurfacePositionAnimator extends PositionAnimator
     {
-        Globe globe;
+        OrbitView orbitView;
         int altitudeMode;
         boolean useMidZoom = true;
 
-        public OnSurfacePositionAnimator(Globe globe, Interpolator interpolator,
+        public OnSurfacePositionAnimator(OrbitView orbitView, Interpolator interpolator,
             Position begin,
             Position end,
             PropertyAccessor.PositionAccessor propertyAccessor, int altitudeMode)
         {
             super(interpolator, begin, end, propertyAccessor);
-            this.globe = globe;
+            this.orbitView = orbitView;
             this.altitudeMode = altitudeMode;
         }
 
@@ -117,17 +117,21 @@ public class FlyToOrbitViewAnimator extends CompoundAnimator
             // correct altitude.
             double endElevation = 0.0;
             boolean overrideEndElevation = false;
-
-            if (this.altitudeMode == WorldWind.CLAMP_TO_GROUND)
+            
+            Globe globe = this.orbitView.getGlobe();
+            if (globe != null)
             {
-                overrideEndElevation = true;
-                endElevation = this.globe.getElevation(getEnd().getLatitude(), getEnd().getLongitude());
-            }
-            else if (this.altitudeMode == WorldWind.RELATIVE_TO_GROUND)
-            {
-                overrideEndElevation = true;
-                endElevation = this.globe.getElevation(getEnd().getLatitude(), getEnd().getLongitude())
-                    + getEnd().getAltitude();
+                if (this.altitudeMode == WorldWind.CLAMP_TO_GROUND)
+                {
+                    overrideEndElevation = true;
+                    endElevation = globe.getElevation(getEnd().getLatitude(), getEnd().getLongitude());
+                }
+                else if (this.altitudeMode == WorldWind.RELATIVE_TO_GROUND)
+                {
+                    overrideEndElevation = true;
+                    endElevation = globe.getElevation(getEnd().getLatitude(), getEnd().getLongitude())
+                        + getEnd().getAltitude();
+                }
             }
 
             if (overrideEndElevation)

--- a/src/gov/nasa/worldwind/view/orbit/FlyToOrbitViewAnimator.java
+++ b/src/gov/nasa/worldwind/view/orbit/FlyToOrbitViewAnimator.java
@@ -119,19 +119,17 @@ public class FlyToOrbitViewAnimator extends CompoundAnimator
             boolean overrideEndElevation = false;
             
             Globe globe = this.orbitView.getGlobe();
-            if (globe != null)
+            
+            if (this.altitudeMode == WorldWind.CLAMP_TO_GROUND)
             {
-                if (this.altitudeMode == WorldWind.CLAMP_TO_GROUND)
-                {
-                    overrideEndElevation = true;
-                    endElevation = globe.getElevation(getEnd().getLatitude(), getEnd().getLongitude());
-                }
-                else if (this.altitudeMode == WorldWind.RELATIVE_TO_GROUND)
-                {
-                    overrideEndElevation = true;
-                    endElevation = globe.getElevation(getEnd().getLatitude(), getEnd().getLongitude())
-                        + getEnd().getAltitude();
-                }
+                overrideEndElevation = true;
+                endElevation = globe.getElevation(getEnd().getLatitude(), getEnd().getLongitude());
+            }
+            else if (this.altitudeMode == WorldWind.RELATIVE_TO_GROUND)
+            {
+                overrideEndElevation = true;
+                endElevation = globe.getElevation(getEnd().getLatitude(), getEnd().getLongitude())
+                    + getEnd().getAltitude();
             }
 
             if (overrideEndElevation)


### PR DESCRIPTION
### Description of the Change
The `Globe` that is provided to the `OnSurfacePositionAnimator's` constructor could, in some situations, be null. This is especially true during startup when the `View.goTo()` method is called and the `View.getGlobe()` method returns null. As noted in the Javadocs, `View.getGlobe()` returns null if called before the first invocation of `View.apply()`. So then, instead of getting the `Globe`, and passing it on, the `OrbitView` itself is now passed along as constructor argument where the `OnSurfacePositionAnimator` can get the `Globe`, check if it is null or not and based on this determine whether it wants to try and get the `endElevation` at that point in time. If this fix is not done, the `OnSurfacePositionAnimator` could get stuck with a null `Globe` and will cause the entire application to break with `NullPointerExceptions` being printed out continually.

### Why Should This Be In Core?
If this bugfix is not in, you can potentially end up with a broken Globe at startup.

### Benefits
Stability improvements.

### Potential Drawbacks
None

### Applicable Issues
Issue #55