### PR TITLE
Eclipse

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -19,31 +19,6 @@
 	<classpathentry kind="lib" path="jogl-all-natives-windows-i586.jar"/>
 	<classpathentry kind="lib" path="jogl-all.jar"/>
 	<classpathentry kind="lib" path="junit-4.5.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/batik-rasterizer.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-anim.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-awt-util.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-bridge.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-codec.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-css.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-dom.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-ext.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-extension.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-gui-util.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-gvt.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-parser.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-script.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-svg-dom.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-svggen.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-swing.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-transcoder.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-util.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/batik-xml.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/js.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/pdf-transcoder.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/xalan-2.6.0.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/xerces_2_5_0.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/xml-apis-ext.jar"/>
-	<classpathentry kind="lib" path="lib-external/batik/lib/xml-apis.jar"/>
 	<classpathentry kind="lib" path="vpf-symbols.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ gradlew
 gradlew.bat
 .gradle
 .nb-gradle
+/bin/

--- a/GDAL_README.txt
+++ b/GDAL_README.txt
@@ -119,7 +119,7 @@ Deploying applications
     https://trac.osgeo.org/osgeolive/ticket/2068).  The workaround
     is to 
 
-       setenv LD_LIBRARY_PATH=/usr/lib/jni:/usr/lib/grass74/lib
+       export LD_LIBRARY_PATH=/usr/lib/jni:/usr/lib/grass74/lib
 
     Pre-built binaries for the MrSID and ERDAS ECW formats are not
     available on Ubuntu.  Instructions for building the plugins is

--- a/GDAL_README.txt
+++ b/GDAL_README.txt
@@ -27,6 +27,13 @@ Building
               ...
           }
     
+    If using Eclipse, in the project properties, select 'Java Build Path', 
+    and in the 'Libraries' tab, remove any existing 'gdal.jar' entry,
+    and use 'Add External Jar' to point to your installed GDAL jar
+    location.  Under that new entry, edit the 'Native Library Location' 
+    to point to the location of the native libraries.  This will add
+    the argument '-Djava.library.path=<native library location>' to
+    the JVM args when applications are run.  
 
 Deploying applications
 ------------------------------------------------------------


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Update of project files used by Eclipse.  Classpath and .gitignore adjusted for Eclipse.  

### Why Should This Be In Core?
Eliminate message "Warning: Could not get charToByteConverterClass!" when running WorldWind examples in Eclipse.  

### Benefits
Avoid unnecessary distraction of developers.

### Potential Drawbacks

### Applicable Issues