### PR TITLE
Address Mapbox Tiling

### DIFF
--- a/src/config/worldwind.layers.xml
+++ b/src/config/worldwind.layers.xml
@@ -42,4 +42,7 @@
     <Layer className="gov.nasa.worldwind.layers.WorldMapLayer"/>
     <Layer className="gov.nasa.worldwind.layers.ScalebarLayer"/>
     <Layer className="gov.nasa.worldwind.layers.CompassLayer"/>
+    <Layer className="gov.nasa.worldwind.layers.Earth.MapboxLayer" actuate="onRequest">
+        <Property name="AccessToken" value="access token here"/>
+    </Layer>
 </LayerList>

--- a/src/gov/nasa/worldwind/layers/Earth/MapboxLayer.java
+++ b/src/gov/nasa/worldwind/layers/Earth/MapboxLayer.java
@@ -1,0 +1,45 @@
+package gov.nasa.worldwind.layers.Earth;
+
+import gov.nasa.worldwind.layers.mercator.BasicMercatorTiledImageLayer;
+import gov.nasa.worldwind.layers.mercator.MercatorTileUrlBuilder;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class MapboxLayer extends BasicMercatorTiledImageLayer {
+
+    public MapboxLayer()
+    {
+        super("mb", "Earth/Mapbox", 19, 256, false, ".png", new URLBuilder());
+        MapboxLayer.this.setDetailHint(-1.8);
+    }
+
+    private static class URLBuilder extends MercatorTileUrlBuilder
+    {
+        private String accessToken;
+
+        @Override
+        protected URL getMercatorURL(int x, int y, int z) throws MalformedURLException
+        {
+            String urlPostfix = (this.accessToken != null) ? "?access_token=" + this.accessToken : "";
+            return new URL("https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/256/" + z + "/" + x + "/" + y + urlPostfix);
+        }
+    }
+
+    public void setAccessToken(String apiKey)
+    {
+        URLBuilder urlBuilder = (URLBuilder)getURLBuilder();
+        urlBuilder.accessToken = apiKey;
+    }
+
+    public String getAccessToken()
+    {
+        URLBuilder urlBuilder = (URLBuilder)getURLBuilder();
+        return urlBuilder.accessToken;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Mapbox";
+    }
+}

--- a/src/gov/nasa/worldwind/layers/Earth/MapboxLayer.java
+++ b/src/gov/nasa/worldwind/layers/Earth/MapboxLayer.java
@@ -10,7 +10,7 @@ public class MapboxLayer extends BasicMercatorTiledImageLayer {
     public MapboxLayer()
     {
         super("mb", "Earth/Mapbox", 19, 256, false, ".png", new URLBuilder());
-        MapboxLayer.this.setDetailHint(-1.8);
+        MapboxLayer.this.setDetailHint(0.3);
     }
 
     private static class URLBuilder extends MercatorTileUrlBuilder

--- a/src/gov/nasa/worldwind/layers/TiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/TiledImageLayer.java
@@ -483,41 +483,12 @@ public abstract class TiledImageLayer extends AbstractLayer
     {
         return this.detailHintOrigin + this.getDetailHint();
     }
-
+    
     protected boolean needToSplit(DrawContext dc, Sector sector, Level level)
     {
-        // Compute the height in meters of a texel from the specified level. Take care to convert from the radians to
-        // meters by multiplying by the globe's radius, not the length of a Cartesian point. Using the length of a
-        // Cartesian point is incorrect when the globe is flat.
-        double texelSizeRadians = level.getTexelSize();
-        double texelSizeMeters = dc.getGlobe().getRadius() * texelSizeRadians;
-
-        // Compute the level of detail scale and the field of view scale. These scales are multiplied by the eye
-        // distance to derive a scaled distance that is then compared to the texel size. The level of detail scale is
-        // specified as a power of 10. For example, a detail factor of 3 means split when the cell size becomes more
-        // than one thousandth of the eye distance. The field of view scale is specified as a ratio between the current
-        // field of view and a the default field of view. In a perspective projection, decreasing the field of view by
-        // 50% has the same effect on object size as decreasing the distance between the eye and the object by 50%.
-        // The detail hint is reduced for tiles above 75 degrees north and below 75 degrees south.
-        double s = this.getDetailFactor();
-        if (sector.getMinLatitude().degrees >= 75 || sector.getMaxLatitude().degrees <= -75)
-            s *= 0.9;
-        double detailScale = Math.pow(10, -s);
-        double fieldOfViewScale = dc.getView().getFieldOfView().tanHalfAngle() / Angle.fromDegrees(45).tanHalfAngle();
-        fieldOfViewScale = WWMath.clamp(fieldOfViewScale, 0, 1);
-
-        // Compute the distance between the eye point and the sector in meters, and compute a fraction of that distance
-        // by multiplying the actual distance by the level of detail scale and the field of view scale.
-        double eyeDistanceMeters = sector.distanceTo(dc, dc.getView().getEyePoint());
-        double scaledEyeDistanceMeters = eyeDistanceMeters * detailScale * fieldOfViewScale;
-
-        // Split when the texel size in meters becomes greater than the specified fraction of the eye distance, also in
-        // meters. Another way to say it is, use the current tile if its texel size is less than the specified fraction
-        // of the eye distance.
-        //
-        // NOTE: It's tempting to instead compare a screen pixel size to the texel size, but that calculation is
-        // window-size dependent and results in selecting an excessive number of tiles when the window is large.
-        return texelSizeMeters > scaledEyeDistanceMeters;
+        double texelSize = level.getTexelSize() * dc.getGlobe().getRadius();
+        double pixelSize = dc.getView().computePixelSizeAtDistance(sector.distanceTo(dc, dc.getView().getEyePoint()));
+        return texelSize > pixelSize * this.getDetailFactor();
     }
 
     public Double getMinEffectiveAltitude(Double radius)

--- a/src/gov/nasa/worldwind/layers/mercator/BasicMercatorTiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/mercator/BasicMercatorTiledImageLayer.java
@@ -97,15 +97,7 @@ public class BasicMercatorTiledImageLayer extends BasicTiledImageLayer
         MercatorTileUrlBuilder urlBuilder = (MercatorTileUrlBuilder)value;
         return urlBuilder;
     }
-
-    @Override
-    protected boolean needToSplit(DrawContext dc, Sector sector, Level level)
-    {
-        double texelSize = level.getTexelSize() * dc.getGlobe().getRadius();
-        double pixelSize = dc.getView().computePixelSizeAtDistance(sector.distanceTo(dc, dc.getView().getEyePoint()));
-        return texelSize > pixelSize * this.getDetailFactor();
-    }
-
+    
     @Override
     protected DownloadPostProcessor createDownloadPostProcessor(TextureTile tile)
     {
@@ -143,13 +135,19 @@ public class BasicMercatorTiledImageLayer extends BasicTiledImageLayer
             if (image != null)
             {
                 int type = image.getType();
-                if (type == BufferedImage.TYPE_CUSTOM)
-                {
-                    type = BufferedImage.TYPE_INT_RGB;
-                }
-                else if (type == BufferedImage.TYPE_BYTE_INDEXED)
-                {
-                    type = BufferedImage.TYPE_INT_ARGB;
+                switch (type) {
+                    case BufferedImage.TYPE_CUSTOM:
+                        type = BufferedImage.TYPE_INT_RGB;
+                        break;
+                    case BufferedImage.TYPE_BYTE_INDEXED:
+                        type = BufferedImage.TYPE_INT_ARGB;
+                        break;
+                    case BufferedImage.TYPE_BYTE_BINARY:
+                        type = BufferedImage.TYPE_INT_RGB;
+                        break;
+                    default:
+                        // leave value returned from image.getType()
+                        break;
                 }
 
                 BufferedImage trans = new BufferedImage(image.getWidth(), image.getHeight(), type);

--- a/src/gov/nasa/worldwind/layers/mercator/BasicMercatorTiledImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/mercator/BasicMercatorTiledImageLayer.java
@@ -135,21 +135,11 @@ public class BasicMercatorTiledImageLayer extends BasicTiledImageLayer
             if (image != null)
             {
                 int type = image.getType();
-                switch (type) {
-                    case BufferedImage.TYPE_CUSTOM:
-                        type = BufferedImage.TYPE_INT_RGB;
-                        break;
-                    case BufferedImage.TYPE_BYTE_INDEXED:
-                        type = BufferedImage.TYPE_INT_ARGB;
-                        break;
-                    case BufferedImage.TYPE_BYTE_BINARY:
-                        type = BufferedImage.TYPE_INT_RGB;
-                        break;
-                    default:
-                        // leave value returned from image.getType()
-                        break;
+                if (type != BufferedImage.TYPE_INT_RGB)
+                {
+                    type = BufferedImage.TYPE_INT_ARGB;
                 }
-
+                
                 BufferedImage trans = new BufferedImage(image.getWidth(), image.getHeight(), type);
                 double miny = ((MercatorSector) tile.getSector()).getMinLatPercent();
                 double maxy = ((MercatorSector) tile.getSector()).getMaxLatPercent();


### PR DESCRIPTION
When loading maps from Mapbox (and potentially other Mercator layer sources) a problem existed with tiles containing little or no detail (such as over water) appearing blank or empty.  

### Description of the Change
Discovered that these tile images report various image types which which need to be handled as "BufferedImage.TYPE_INT_ARGB" for the layer to display as intended.

Modified handling of image type in BasicMercatorTiledImageLayer class as follows:
Old Code
```
                int type = image.getType();
                if (type == BufferedImage.TYPE_CUSTOM)
                {
                    type = BufferedImage.TYPE_INT_RGB;
                }
                else if (type == BufferedImage.TYPE_BYTE_INDEXED)
                {
                    type = BufferedImage.TYPE_INT_ARGB;
                }
```
New Code
 ```
                int type = image.getType();
                if (type != BufferedImage.TYPE_INT_RGB)
                {
                    type = BufferedImage.TYPE_INT_ARGB;
                }
```

### Why Should This Be In Core?
Allows users to include Mapbox layers in WorldWind and potentially any Mercator layer.

### Benefits
-- See "Why Should This Be In Core"--

### Potential Drawbacks
No real drawback.  However, this issue was challenging to track down since using the "wrong" image type did not produce any error or warning messages.  If other image types produce display problems in the future it may be difficult to track down the reason as well.  Unfortunately I don't know of any good way to provide a warning message in these situations.

### Applicable Issues
#53



**EDIT**
Leaving details about "level of detail calculation" here (below) for future reference.  However, the pull request has been modified so that the changes to the "needToSplit" function in the TiledImageLayer class have been reverted to the WWJ v2.1.0 version.  Also removed the override of this function from the BasicMercatorTiledImageLayerClass.

**Level of Detail Calculation** 
### Issue Description
@Sufaev pointed out that the "needToSplit" calculation in the TiledImageLayer class 
> is based on camera distance to surface and horizontal field of view, but it does not provide stable pixel density of tiles comparing to monitor pixel density (as it usually appears on 2d maps).

### Description of the Change
Moved "needToSplit" function from BasicMercatorTiledImageLayer class to TiledImageLayer class (replacing the same function in the TiledImageLayer class).
Old Code in TiledImageLayer class
```
    protected boolean needToSplit(DrawContext dc, Sector sector, Level level)
    {
        // Compute the height in meters of a texel from the specified level. Take care to convert from the radians to
        // meters by multiplying by the globe's radius, not the length of a Cartesian point. Using the length of a
        // Cartesian point is incorrect when the globe is flat.
        double texelSizeRadians = level.getTexelSize();
        double texelSizeMeters = dc.getGlobe().getRadius() * texelSizeRadians;

        // Compute the level of detail scale and the field of view scale. These scales are multiplied by the eye
        // distance to derive a scaled distance that is then compared to the texel size. The level of detail scale is
        // specified as a power of 10. For example, a detail factor of 3 means split when the cell size becomes more
        // than one thousandth of the eye distance. The field of view scale is specified as a ratio between the current
        // field of view and a the default field of view. In a perspective projection, decreasing the field of view by
        // 50% has the same effect on object size as decreasing the distance between the eye and the object by 50%.
        // The detail hint is reduced for tiles above 75 degrees north and below 75 degrees south.
        double s = this.getDetailFactor();
        if (sector.getMinLatitude().degrees >= 75 || sector.getMaxLatitude().degrees <= -75)
            s *= 0.9;
        double detailScale = Math.pow(10, -s);
        double fieldOfViewScale = dc.getView().getFieldOfView().tanHalfAngle() / Angle.fromDegrees(45).tanHalfAngle();
        fieldOfViewScale = WWMath.clamp(fieldOfViewScale, 0, 1);

        // Compute the distance between the eye point and the sector in meters, and compute a fraction of that distance
        // by multiplying the actual distance by the level of detail scale and the field of view scale.
        double eyeDistanceMeters = sector.distanceTo(dc, dc.getView().getEyePoint());
        double scaledEyeDistanceMeters = eyeDistanceMeters * detailScale * fieldOfViewScale;

        // Split when the texel size in meters becomes greater than the specified fraction of the eye distance, also in
        // meters. Another way to say it is, use the current tile if its texel size is less than the specified fraction
        // of the eye distance.
        //
        // NOTE: It's tempting to instead compare a screen pixel size to the texel size, but that calculation is
        // window-size dependent and results in selecting an excessive number of tiles when the window is large.
        return texelSizeMeters > scaledEyeDistanceMeters;
    }
```
New Code in TiledImageLayer class
```
protected boolean needToSplit(DrawContext dc, Sector sector, Level level)
    {
        double texelSize = level.getTexelSize() * dc.getGlobe().getRadius();
        double pixelSize = dc.getView().computePixelSizeAtDistance(sector.distanceTo(dc, dc.getView().getEyePoint()));
        return texelSize > pixelSize * this.getDetailFactor();
    }
```

### Potential Drawbacks
The "expected" behavior may be subjective.  There is also a note in the existing "needToSplit" function in the TiledImageLayer class that reads:
`NOTE: It's tempting to instead compare a screen pixel size to the texel size, but that calculation is window-size dependent and results in selecting an excessive number of tiles when the window is large.`

The "level of detail calculation" discussion can continue as a separate issue and tied to #60 

**EDIT 2**
Modified title removing reference to "level of detail calculations".  Also updated description of the issue and modified the new "needToSplit" code in the "Description of the Change" section to reflect the final version of the code in the pull request.