### PR TITLE
Latitude normalization fix for angles > 180-deg.

### DIFF
--- a/src/gov/nasa/worldwind/geom/Angle.java
+++ b/src/gov/nasa/worldwind/geom/Angle.java
@@ -677,11 +677,14 @@ public class Angle implements Comparable<Angle>
         double a = degrees % 360;
         return a > 180 ? a - 360 : a < -180 ? 360 + a : a;
     }
-
+    
     public static double normalizedDegreesLatitude(double degrees)
     {
         double lat = degrees % 180;
-        return lat > 90 ? 180 - lat : lat < -90 ? -180 - lat : lat;
+        double normalizedLat = lat > 90 ? 180 - lat : lat < -90 ? -180 - lat : lat;
+        // Determine whether the latitude is in the northern or southern hemisphere.
+        int numEquatorCrosses = (int) (degrees / 180);
+        return (numEquatorCrosses % 2 == 0) ? normalizedLat : -normalizedLat;
     }
 
     public static double normalizedDegreesLongitude(double degrees)

--- a/test/gov/nasa/worldwind/geom/AngleTest.java
+++ b/test/gov/nasa/worldwind/geom/AngleTest.java
@@ -267,4 +267,56 @@ public class AngleTest
 
         assertEquals("conflicting string format, positive sign and direction", expectedValue, actualValue, 0.0);
     }
+    
+    @Test
+    public void testNormalizedDegreesLatitude_AngleBelow90()
+    {
+        double angle = 67.0;
+        double normalizedAngle = Angle.normalizedDegreesLatitude(angle); // Expected angle should be 67-degrees.
+        assertEquals("test with angle less than 90 degrees", angle, normalizedAngle, 0.0);
+    }
+    
+    @Test
+    public void testNormalizedDegreesLatitude_AngleAbove90()
+    {
+        double angle = 95.0;
+        double normalizedAngle = Angle.normalizedDegreesLatitude(angle);
+        double expectedValue = 180.0 - angle; // Expected angle should be 85-degrees.
+        assertEquals("test with angle above 90 degrees", expectedValue, normalizedAngle, 0.0);
+    }
+    
+    @Test
+    public void testNormalizedDegreesLatitude_AngleAbove180()
+    {
+        double angle = 184.0;
+        double normalizedAngle = Angle.normalizedDegreesLatitude(angle);
+        double expectedValue = -1.0 * (angle % 180.0); // Expected angle should be -4-degrees.
+        assertEquals("test with angle above 180 degrees", expectedValue, normalizedAngle, 0.0);
+    }
+    
+    @Test
+    public void testNormalizedDegreesLatitude_AngleAboveNeg90()
+    {
+        double angle = -73.0;
+        double normalizedAngle = Angle.normalizedDegreesLatitude(angle); // Expected angle should be -73-degrees.
+        assertEquals("test with angle above -90 degrees", angle, normalizedAngle, 0.0);
+    }
+    
+    @Test
+    public void testNormalizedDegreesLatitude_AngleBelowNeg90()
+    {
+        double angle = -130.0;
+        double normalizedAngle = Angle.normalizedDegreesLatitude(angle);
+        double expectedValue = -180.0 - angle; // Expeccted angle should be -50-degrees.
+        assertEquals("test with angle below -90 degrees", expectedValue, normalizedAngle, 0.0);
+    }
+    
+    @Test
+    public void testNormalizedDegreesLatitude_AngleBelowNeg180()
+    {
+        double angle = -190.0;
+        double normalizedAngle = Angle.normalizedDegreesLatitude(angle);
+        double expectedValue = -1.0 * (angle % 180.0); // Expected angle should be 10-degrees.
+        assertEquals("test with angle below -180-degrees", expectedValue, normalizedAngle, 0.0);
+    }
 }


### PR DESCRIPTION
### Description of the Change
Made a bugfix to the `Angle` class' normalizedDegreesLatitude() method. The the latitude normalization didn't take the equator-crosses into account when determining the resulting angle's sign. This fix was
spotted by @Sufaev and was taken from the Android version of WorldWind. A couple of unit tests were also added to the `AngleTest` class to ensure that the edge-cases are correctly accounted for.

### Why Should This Be In Core?
This fixes a bug in a core class, namely `Angle` that is used throughout WorldWind. This is a bug that is already fixed in the Android version of WorldWind and we should fix it here as well.

### Benefits
Correct angle normalization calculations.

### Potential Drawbacks
Client code that relied on the incorrect results from this method will probably need to be fixed now as well.

### Applicable Issues
Issue #46