### PR TITLE
Gradle build-script improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ jdk:
   - openjdk8
   - openjdk11
   - openjdk12
-  - oraclejdk8
   - oraclejdk11
   - openjdk-ea
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,13 @@ before_install:
 install: 
   # Using clean as dummy target; could install dependencies here if needed.
   - ./gradlew clean
-  
-# Use xvfb to run tests that require a GUI and give it some time to start
+
+# Use xvfb to run tests that require a GUI.
+services:
+  - xvfb
+
 before_script:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
 
 # Build the project
 script:

--- a/build.gradle
+++ b/build.gradle
@@ -36,14 +36,14 @@ repositories {
 }
 
 dependencies {
-    compile "org.jogamp.jogl:jogl-all-main:${project.joglVersion}"
-    compile "org.jogamp.gluegen:gluegen-rt-main:${project.joglVersion}"
+    compile "org.jogamp.jogl:jogl-all-main:$project.joglVersion"
+    compile "org.jogamp.gluegen:gluegen-rt-main:$project.joglVersion"
 
-    implementation "org.gdal:gdal:${project.gdalVersion}"
+    implementation "org.gdal:gdal:$project.gdalVersion"
 
-    compile "org.codehaus.jackson:jackson-core-asl:${project.jacksonVersion}"
+    compile "org.codehaus.jackson:jackson-core-asl:$project.jacksonVersion"
 
-    testImplementation "junit:junit:${project.junitVersion}"
+    testImplementation "junit:junit:$project.junitVersion"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
@@ -68,12 +68,12 @@ task extensionsJar(type: Jar) {
         exclude 'images/**'
         exclude 'gov/nasa/worldwind/**'
     }
-}
-extensionsJar.doLast {
-    copy {
-        from "$buildDir/libs/${extensionsJar.archiveName}"
-        into "${project.projectDir}"
-        rename "${extensionsJar.archiveName}", "${extensionsJar.baseName}.${extensionsJar.extension}"
+    doLast {
+        copy {
+            from "$buildDir/libs/$extensionsJar.archiveName"
+            into project.projectDir
+            rename "$extensionsJar.archiveName", "$extensionsJar.baseName.$extensionsJar.extension"
+        }
     }
 }
 
@@ -89,7 +89,7 @@ def pomConfig = {
         license {
             name 'NASA Open Source Agreement v1.3'
             url 'https://ti.arc.nasa.gov/opensource/nosa/'
-            distribution "repo"
+            distribution 'repo'
         }
     }
     developers {
@@ -100,7 +100,7 @@ def pomConfig = {
         }
     }
     scm {
-       url "https://github.com/WorldWindEarth/WorldWindJava"
+       url 'https://github.com/WorldWindEarth/WorldWindJava'
     }
 }
 
@@ -149,7 +149,7 @@ bintray {
         githubRepo = 'WorldWindEarth/WorldWindJava'
         version {
             name = project.version
-            desc = 'WorldWind v' + project.version
+            desc = "WorldWind v$project.version"
             vcsTag = System.getenv('TRAVIS_TAG')
             released = new Date()
         }
@@ -198,25 +198,25 @@ compileJava {
 
 test {
     dependsOn jar
-    classpath += project.files("$buildDir/libs/${jar.archiveName}", configurations.runtime)
+    classpath += project.files("$buildDir/libs/$jar.archiveName", configurations.runtime)
 }
 
 jar {
     dependsOn classes
     from sourceSets.main.output
     exclude 'gov/nasa/worldwindx/**'
-}
-jar.doLast {
-    copy {
-        from "$buildDir/libs/${jar.archiveName}"
-        into "${project.projectDir}"
-        rename "${jar.archiveName}", "${jar.baseName}.${jar.extension}"
+    doLast {
+        copy {
+            from "$buildDir/libs/$jar.archiveName"
+            into project.projectDir
+            rename "$jar.archiveName", "$jar.baseName.$jar.extension"
+        }
     }
 }
 
 javadoc {
     options {
-        overview = "${project.projectDir}/src/overview.html"
+        overview = "$project.projectDir/src/overview.html"
         windowTitle = 'WorldWindJava API'
         title = 'NASA WorldWind Java-Community Edition'
         header = 'NASA WorldWind-CE'

--- a/build.gradle
+++ b/build.gradle
@@ -318,3 +318,11 @@ task milStd2525Zip(type: Zip, dependsOn: processMilStd2525SVGs) {
     archiveName 'milstd2525-symbols.zip'
     destinationDir milStd2525OutDir
 }
+
+task runLayerManager(type: JavaExec, dependsOn: classes) {
+    group = 'run'
+    description = 'Runs the LayerManager example app.'
+    classpath sourceSets.main.runtimeClasspath
+    main = 'gov.nasa.worldwindx.examples.layermanager.LayerManagerApp'
+    systemProperty 'java.util.logging.config.file', "$project.projectDir/logging.properties"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ targetCompatibility = '1.8'
 
 ant {
     property(file: 'build.properties')
+    property(file: "gdal.${org.gradle.internal.os.OperatingSystem.current().isWindows() ? 'win' : 'unix'}.properties")
 }
 
 ext {
@@ -38,8 +39,12 @@ repositories {
 dependencies {
     compile "org.jogamp.jogl:jogl-all-main:$project.joglVersion"
     compile "org.jogamp.gluegen:gluegen-rt-main:$project.joglVersion"
-
-    implementation "org.gdal:gdal:$project.gdalVersion"
+    
+    if (project.hasProperty('systemGDAL')) {
+        compile files("${ant.properties['gdal.jar.dir']}/gdal.jar")
+    } else {
+        implementation "org.gdal:gdal:$project.gdalVersion"
+    }
 
     compile "org.codehaus.jackson:jackson-core-asl:$project.jacksonVersion"
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-    implementation "org.jogamp.jogl:jogl-all-main:${project.joglVersion}"
-    implementation "org.jogamp.gluegen:gluegen-rt-main:${project.joglVersion}"
+    compile "org.jogamp.jogl:jogl-all-main:${project.joglVersion}"
+    compile "org.jogamp.gluegen:gluegen-rt-main:${project.joglVersion}"
 
-    compile "org.gdal:gdal:${project.gdalVersion}"
+    implementation "org.gdal:gdal:${project.gdalVersion}"
 
-    implementation "org.codehaus.jackson:jackson-core-asl:${project.jacksonVersion}"
+    compile "org.codehaus.jackson:jackson-core-asl:${project.jacksonVersion}"
 
     testImplementation "junit:junit:${project.junitVersion}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ version = '2.2.0' + (project.hasProperty('snapshot') ? '-SNAPSHOT' : '')
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
+ant {
+    property(file: 'build.properties')
+}
+
 ext {
     joglVersion = '2.3.2'
     gdalVersion = '2.4.0'
@@ -230,4 +234,87 @@ artifacts {
     archives sourcesJar
     archives extensionsJar
     archives javadocJar
+}
+
+task processMilStd2525SVGs(dependsOn: jar) {
+    group = 'build'
+    description = 'Processes the MIL-STD-2525 SVG source files.'
+    
+    // Set outputs of this task to be PNG directory.
+    def milStd2525PngDir = file(ant.properties['milstd2525.png.dir'])
+    outputs.dir(milStd2525PngDir)
+
+    doLast {
+        def milStd2525SrcDir = file(ant.properties['milstd2525.src.dir'])
+        
+        // If PNG directory doesn't exist, create it.
+        if (!milStd2525PngDir.exists()) {
+            milStd2525PngDir.mkdirs()
+        }
+        
+        def width = ant.properties['milstd2525.png.width']
+        def height = ant.properties['milstd2525.png.height']
+        
+        // Rasterize the MIL-STD-2525 SVG sources. Exclude empty directories in order
+        // to suppress erroneous error messages from the Apache Batik Rasterizer.
+        milStd2525SrcDir.traverse([type: groovy.io.FileType.DIRECTORIES, excludeNameFilter: ~/fills|frames|icons/]) { srcDir ->
+            def dstDir = milStd2525PngDir.path + (srcDir.path - milStd2525SrcDir.path)
+            exec {
+                commandLine 'java',\
+                    '-jar',\
+                    "$project.projectDir/lib-external/batik/batik-rasterizer.jar",\
+                    '-m',\
+                    'image/png',\
+                    '-maxw',\
+                    width,\
+                    '-h',\
+                    height,\
+                    '-d',\
+                    dstDir,\
+                    srcDir
+            }
+        }
+        
+        // The Forward Edge of Battle (FEBA, 2.X.2.4.2.1) image has a custom height of 16 pixels.
+        milStd2525SrcDir.traverse([type: groovy.io.FileType.FILES, nameFilter: ~/g-g.dlf--------\.svg/]) { srcFile ->
+            def dstFile = ((milStd2525PngDir.path + (srcFile.path - milStd2525SrcDir.path)) - '.svg') + '.png'
+            exec {
+                commandLine 'java',\
+                    '-jar',\
+                    "$project.projectDir/lib-external/batik/batik-rasterizer.jar",\
+                    '-m',\
+                    'image/png',\
+                    '-maxw',\
+                    width,\
+                    '-h',\
+                    '16',\
+                    '-d',\
+                    dstFile,\
+                    srcFile
+            }
+        }
+        
+        // Trim the MIL-STD-2525 modifier images to remove transparent borders.
+        def modifiersDir = file("$milStd2525PngDir.path/modifiers")
+        modifiersDir.traverse([type: groovy.io.FileType.FILES]) { srcFile ->
+            exec {
+                commandLine 'java',\
+                    '-cp',\
+                    "$buildDir/libs/$jar.archiveName",\
+                    'gov.nasa.worldwind.util.ImageTrimmer',\
+                    srcFile
+            }
+        }
+    }
+}
+
+task milStd2525Zip(type: Zip, dependsOn: processMilStd2525SVGs) {
+    group = 'build'
+    description = 'Assembles the MIL-STD-2525 symbology package.'
+    def milStd2525OutDir = file(ant.properties['milstd2525.out.dir'])
+    def milStd2525PngDir = file(ant.properties['milstd2525.png.dir'])
+    from milStd2525PngDir
+    include '**/*'
+    archiveName 'milstd2525-symbols.zip'
+    destinationDir milStd2525OutDir
 }

--- a/build.xml
+++ b/build.xml
@@ -505,15 +505,11 @@
     </target>
     
     <target name="runLayerManager" depends="build" description="Runs the LayerManager example app.">
-     <echoproperties/>
-       <java fork="true" 
-            classname="gov.nasa.worldwindx.examples.layermanager.LayerManagerApp" 
-            classpath="${gdal.jar.dir}/gdal.jar;gluegen-rt-natives-linux-amd64.jar;gluegen-rt-natives-linux-i586.jar;gluegen-rt-natives-macosx-universal.jar;gluegen-rt-natives-windows-amd64.jar;gluegen-rt-natives-windows-i586.jar;gluegen-rt.jar;jackson-core-asl.jar;jogl-all-natives-linux-amd64.jar;jogl-all-natives-linux-i586.jar;jogl-all-natives-macosx-universal.jar;jogl-all-natives-windows-amd64.jar;jogl-all-natives-windows-i586.jar;jogl-all.jar;junit-4.5.jar;vpf-symbols.jar;worldwind.jar;worldwindx.jar"
-            >
-            <env key="GDAL_DATA" path="${gdal.data.dir}"/>
-            <env key="GDAL_DRIVER_PATH" path="${gdal.plugins.dir}"/>
+        <echoproperties/>
+        <java fork="true"
+              classname="gov.nasa.worldwindx.examples.layermanager.LayerManagerApp" 
+              classpath="gluegen-rt-natives-linux-amd64.jar;gluegen-rt-natives-linux-i586.jar;gluegen-rt-natives-macosx-universal.jar;gluegen-rt-natives-windows-amd64.jar;gluegen-rt-natives-windows-i586.jar;gluegen-rt.jar;jackson-core-asl.jar;jogl-all-natives-linux-amd64.jar;jogl-all-natives-linux-i586.jar;jogl-all-natives-macosx-universal.jar;jogl-all-natives-windows-amd64.jar;jogl-all-natives-windows-i586.jar;jogl-all.jar;junit-4.5.jar;vpf-symbols.jar;worldwind.jar;worldwindx.jar">
             <sysproperty key="java.util.logging.config.file" value="${basedir}/logging.properties"/>
-       </java>
+        </java>
     </target>
-    
 </project>

--- a/gdal.unix.properties
+++ b/gdal.unix.properties
@@ -3,4 +3,3 @@ gdal.jar.dir=/usr/share/java
 gdal.jni.dir=/usr/lib/jni
 gdal.data.dir=/usr/share/gdal/2.2
 gdal.plugins.dir=/usr/lib/gdalplugins
-


### PR DESCRIPTION
### Description of the Change
Additional changes and fixes to the `build.gradle` file. In particular we can now build the MilStd2525 symbology zip file as well as launch the layer-manager example via the `runLayerManager` task. The dependency declarations have been fixed by swapping the "compile" clauses with "implementation" and vice versa (this was incorrectly declared initially). We also now have the ability to build against the system GDAL jar if required.

### Why Should This Be In Core?
The `build.gradle` file is now more complete and covers most of the functionality of the ant build script. We just lack the webstart clauses.

### Benefits
More complete gradle build script.

### Potential Drawbacks
None

### Applicable Issues
None