### PR TITLE
Add arrow head for direction of movement only

### DIFF
--- a/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525TacticalSymbol.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/MilStd2525TacticalSymbol.java
@@ -519,20 +519,24 @@ public class MilStd2525TacticalSymbol extends AbstractTacticalSymbol
             // The length of the direction of movement line is equal to the height of the symbol frame. See
             // MIL-STD-2525C section 5.3.4.1.c, page 33.
             double length = this.iconRect.getHeight();
+            Boolean directionOnly = true;
             Object d = this.getModifier(SymbologyConstants.SPEED_LEADER_SCALE);
             if (d != null && d instanceof Number)
+            {
+                directionOnly = false;
                 length *= ((Number) d).doubleValue();
+            }
 
             if (this.useGroundHeadingIndicator)
             {
                 List<? extends Point2D> points = MilStd2525Util.computeGroundHeadingIndicatorPoints(dc, osym.placePoint,
-                    (Angle) o, length, this.iconRect.getHeight());
+                    (Angle) o, length, this.iconRect.getHeight(), directionOnly);
                 this.addLine(dc, Offset.BOTTOM_CENTER, points, LAYOUT_RELATIVE, points.size() - 1, osym);
             }
             else
             {
                 List<? extends Point2D> points = MilStd2525Util.computeCenterHeadingIndicatorPoints(dc,
-                    osym.placePoint, (Angle) o, length);
+                    osym.placePoint, (Angle) o, length, directionOnly);
                 this.addLine(dc, Offset.CENTER, points, null, 0, osym);
             }
         }

--- a/src/gov/nasa/worldwind/symbology/milstd2525/graphics/TacticalGraphicSymbol.java
+++ b/src/gov/nasa/worldwind/symbology/milstd2525/graphics/TacticalGraphicSymbol.java
@@ -350,7 +350,7 @@ public class TacticalGraphicSymbol extends AbstractTacticalSymbol
             double length = this.iconRect.getHeight();
 
             java.util.List<? extends Point2D> points = MilStd2525Util.computeGroundHeadingIndicatorPoints(dc,
-                osym.placePoint, (Angle) o, length, this.iconRect.getHeight());
+                osym.placePoint, (Angle) o, length, this.iconRect.getHeight(), true);
             this.addLine(dc, BELOW_BOTTOM_CENTER_OFFSET, points, LAYOUT_RELATIVE, points.size() - 1, osym);
         }
     }


### PR DESCRIPTION
Changes pulled in from upstream PR [#5](https://github.com/NASAWorldWind/WorldWindJava/pull/5).

### Description of the Change
MilStd 2525C states direction of movement is an arrow or staff, but having an arrow differentiates the direction of movement only from a speed leader line.

### Why Should This Be In Core?
Any fixes or improvements to the way in which the MilStd graphics are drawn should be added.

### Benefits
More accurate drawing of MilStd graphics.

### Potential Drawbacks
None

### Applicable Issues
None