### PR TITLE
Compare key not value in SurfaceImageLayer

### DIFF
--- a/src/gov/nasa/worldwind/layers/SurfaceImageLayer.java
+++ b/src/gov/nasa/worldwind/layers/SurfaceImageLayer.java
@@ -252,7 +252,7 @@ public class SurfaceImageLayer extends RenderableLayer
             throw new IllegalArgumentException(message);
         }
 
-        if (this.imageTable.contains(name))
+        if (this.imageTable.containsKey(name))
             this.removeImage(name);
 
         final ArrayList<SurfaceImage> surfaceImages = new ArrayList<SurfaceImage>();
@@ -359,7 +359,7 @@ public class SurfaceImageLayer extends RenderableLayer
             throw new IllegalArgumentException(message);
         }
 
-        if (this.imageTable.contains(name))
+        if (this.imageTable.containsKey(name))
             this.removeImage(name);
 
         final ArrayList<SurfaceImage> surfaceImages = new ArrayList<SurfaceImage>();


### PR DESCRIPTION
### Description of the Change

Change a check if an image path already exists to check against the key instead of the value in the map.  ConcurrentHashMap.contains() calls containsValue(), which will never return true when passed a String.

### Why Should This Be In Core?

It's a bug.

### Benefits

If an image is added twice to a SurfaceImageLayer, the first one's tiles will be removed.

### Potential Drawbacks

None that I can think of.

### Applicable Issues

None created.