### PR TITLE
Fixed wrong count of geo keys in GeotiffWriter

### DIFF
--- a/src/gov/nasa/worldwind/formats/tiff/GeotiffWriter.java
+++ b/src/gov/nasa/worldwind/formats/tiff/GeotiffWriter.java
@@ -925,7 +925,7 @@ public class GeotiffWriter
                 };
 
             // IMPORTANT!! update count - number of geokeys
-            values[3] = (short) (values.length / 4);
+            values[3] = (short) ((values.length - 4) / 4);
 
             byte[] bytes = this.getBytes(values);
             this.theChannel.write(ByteBuffer.wrap(bytes));
@@ -983,7 +983,7 @@ public class GeotiffWriter
                 };
 
             // IMPORTANT!! update count - number of geokeys
-            values[3] = (short) (values.length / 4);
+            values[3] = (short) ((values.length - 4) / 4);
 
             byte[] bytes = this.getBytes(values);
             this.theChannel.write(ByteBuffer.wrap(bytes));


### PR DESCRIPTION
### Description of the Change
Fixed incorrect count of geo keys in GeotiffWriter. It used to not subtract numbers of headers while counting geo keys.

### Why Should This Be In Core?
It makes correct Geotiff export and import

### Benefits
It makes correct Geotiff export and import
### Potential Drawbacks
None
### Applicable Issues
None