### PR TITLE
Make it possible to disable drag for AbstractAirspace

### DIFF
--- a/src/gov/nasa/worldwind/render/airspaces/AbstractAirspace.java
+++ b/src/gov/nasa/worldwind/render/airspaces/AbstractAirspace.java
@@ -989,7 +989,7 @@ public abstract class AbstractAirspace extends WWObjectImpl
     @Override
     public void setDragEnabled(boolean enabled)
     {
-        this.dragEnabled = true;
+        this.dragEnabled = enabled;
     }
 
     @Override


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Make setDragEnabled use the provided parameter instead of the hard coded 'true'.

### Why Should This Be In Core?
Looks like a bug to me

### Benefits
It would be working as intended.

### Potential Drawbacks
None that I know of, I have used a workaround for years.

### Applicable Issues
https://github.com/WorldWindEarth/WorldWindJava/issues/85